### PR TITLE
PaddleFleet Monitors 迁移至 GPU-Buffer Recording API

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -1,19 +1,253 @@
-"""PaddleFleet-specific Probe base class."""
+"""PaddleFleet-specific Probe base class with GPU-buffer recording API.
+
+Hot-path discipline: see ``.claude/skills/monitor-hook-perf-rules``.
+``declare_*`` is the schema gate; ``record_*`` only has a disabled-key guard.
+"""
+
+import logging
 
 import paddle
 
 from ...core.base_monitor import Probe
+from ...core.training_logs import training_logs
+
+logger = logging.getLogger(__name__)
 
 
 class PaddleProbe(Probe):
-    """Probe subclass with recompute (gradient checkpointing) guard.
+    """Probe with paddle-backed GPU-buffer accumulator + recompute guard.
 
-    During recompute, forward hooks fire again in the backward pass with
-    grad disabled. Accessing parameters at that point can crash when ZeRO
-    has freed their storage (holder->size():0).
+    GPU-buffer API — ``declare_mean`` / ``declare_max`` / ``declare_min``
+    at hook-registration time, then ``record_mean`` / ``record_max`` /
+    ``record_min`` inside hooks with **GPU 0-dim tensors**. No D2H sync
+    fires until ``step()`` does a single batched flush.
     """
 
+    def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
+        super().__init__(
+            log_per_layer=log_per_layer, log_global=log_global, monitor_interval=monitor_interval, verbose=verbose
+        )
+        self._mean_keys: set[str] = set()  # 需要求平均的 metric keys
+        self._max_keys: set[str] = set()  # 需要取最大值的 metric keys
+        self._min_keys: set[str] = set()  # 需要取最小值的 metric keys
+        self._gpu_acc: dict[str, paddle.Tensor] = {}  # GPU 0-dim 累加器
+        self._gpu_cnt: dict[str, int] = {}  # 每个 key 被 record 的次数
+        # global_key → (聚合方式, [对应的 layer keys])，flush 时从 layer 推导 global
+        self._layer_metric_groups: dict[str, tuple[str, list[str]]] = {}
+        self._layer_metric_keys: set[str] = set()  # 所有 per-layer key，用于 flush 时判断是否输出
+        self._disabled_keys: set[str] = set()  # log_global=False 时被禁用的 global keys
+        self._buffers_allocated = False
+
     def _should_monitor(self) -> bool:
+        # recompute 阶段 grad 被禁用，跳过以避免重复计数和访问已释放的参数
         if not paddle.is_grad_enabled():
             return False
         return super()._should_monitor()
+
+    def _flush_buffers(self) -> None:
+        """由 step() 调用，执行唯一的 D2H 传输并写入 training_logs。"""
+        if not self._buffers_allocated:
+            return
+        flushed = self._flush_gpu_buffer()
+        if flushed:
+            training_logs.update(**flushed)
+
+    # ------------------------------------------------------------------
+    # GPU-buffer API: declare → allocate → record → flush
+    # ------------------------------------------------------------------
+
+    def declare_mean(self, key: str) -> None:
+        assert not self._buffers_allocated, f"declare_mean({key!r}) after allocate_buffers"
+        if self._should_disable_explicit_key(key):
+            self._disabled_keys.add(key)
+            return
+        assert key not in self._mean_keys and key not in self._max_keys and key not in self._min_keys
+        self._mean_keys.add(key)
+
+    def declare_max(self, key: str) -> None:
+        assert not self._buffers_allocated, f"declare_max({key!r}) after allocate_buffers"
+        if self._should_disable_explicit_key(key):
+            self._disabled_keys.add(key)
+            return
+        assert key not in self._mean_keys and key not in self._max_keys and key not in self._min_keys
+        self._max_keys.add(key)
+
+    def declare_min(self, key: str) -> None:
+        assert not self._buffers_allocated, f"declare_min({key!r}) after allocate_buffers"
+        if self._should_disable_explicit_key(key):
+            self._disabled_keys.add(key)
+            return
+        assert key not in self._mean_keys and key not in self._max_keys and key not in self._min_keys
+        self._min_keys.add(key)
+
+    def allocate_buffers(self, dtype=None) -> None:
+        """物化所有已声明的累加器为 GPU 0-dim tensor。幂等，调用后 schema 冻结。"""
+        if self._buffers_allocated:
+            return
+        if dtype is None:
+            dtype = "float32"
+        # mean: 初始化为 0，record 时累加，flush 时除以 count
+        for k in self._mean_keys:
+            self._gpu_acc[k] = paddle.zeros((), dtype=dtype)
+            self._gpu_cnt[k] = 0
+        # max: 初始化为 -inf，record 时取 maximum
+        for k in self._max_keys:
+            self._gpu_acc[k] = paddle.full((), float("-inf"), dtype=dtype)
+            self._gpu_cnt[k] = 0
+        # min: 初始化为 +inf，record 时取 minimum
+        for k in self._min_keys:
+            self._gpu_acc[k] = paddle.full((), float("inf"), dtype=dtype)
+            self._gpu_cnt[k] = 0
+        self._buffers_allocated = True
+        if self.verbose:
+            logger.info(
+                f"[{self.METRIC_PREFIX}] GPU buffer: "
+                f"mean={len(self._mean_keys)} max={len(self._max_keys)} min={len(self._min_keys)}"
+            )
+
+    def record_mean(self, key: str, val: paddle.Tensor) -> None:
+        """热路径：GPU 上就地累加，不触发 D2H 同步。"""
+        if key in self._disabled_keys:
+            return
+        self._gpu_acc[key].add_(val.detach())
+        self._gpu_cnt[key] += 1
+
+    def record_max(self, key: str, val: paddle.Tensor) -> None:
+        """热路径：GPU 上取 maximum，不触发 D2H 同步。"""
+        if key in self._disabled_keys:
+            return
+        # paddle 不支持 maximum 的 out= 参数，用 assign 实现就地写入
+        paddle.assign(paddle.maximum(self._gpu_acc[key], val.detach()), self._gpu_acc[key])
+        self._gpu_cnt[key] += 1
+
+    def record_min(self, key: str, val: paddle.Tensor) -> None:
+        """热路径：GPU 上取 minimum，不触发 D2H 同步。"""
+        if key in self._disabled_keys:
+            return
+        paddle.assign(paddle.minimum(self._gpu_acc[key], val.detach()), self._gpu_acc[key])
+        self._gpu_cnt[key] += 1
+
+    # ------------------------------------------------------------------
+    # Convenience: declare/record using class-level aggregation rules
+    # ------------------------------------------------------------------
+
+    def _layer_key(self, layer_idx: int, metric_name: str) -> str:
+        return f"{self.METRIC_PREFIX}/layer_{layer_idx}/{metric_name}"
+
+    def _global_key(self, metric_name: str) -> str:
+        return f"{self.METRIC_PREFIX}/global_{metric_name}"
+
+    def _should_disable_explicit_key(self, key: str) -> bool:
+        return key.startswith(f"{self.METRIC_PREFIX}/global_") and not self.log_global
+
+    def declare_layer_metric(self, layer_idx: int, metric_name: str) -> None:
+        """声明一个 per-layer 指标。
+
+        1. 根据 MAX_AGGREGATED/MIN_AGGREGATED 选择聚合方式，注册 layer key
+        2. 建立 layer_key → global_key 的分组映射，flush 时自动推导 global
+        """
+        if not (self.log_per_layer or self.log_global):
+            return
+        layer_key = self._layer_key(layer_idx, metric_name)
+        global_key = self._global_key(metric_name)
+        all_declared = self._mean_keys | self._max_keys | self._min_keys
+        assert global_key not in all_declared
+        # 根据类级别聚合规则选择 declare 方式
+        if self._is_max_aggregated(metric_name):
+            agg = "max"
+            if layer_key not in all_declared:
+                self.declare_max(layer_key)
+        elif metric_name in self.MIN_AGGREGATED:
+            agg = "min"
+            if layer_key not in all_declared:
+                self.declare_min(layer_key)
+        else:
+            agg = "mean"
+            if layer_key not in all_declared:
+                self.declare_mean(layer_key)
+        self._layer_metric_keys.add(layer_key)
+        if not self.log_global:
+            return
+        # 注册 global 分组: flush 时从这些 layer keys 聚合出 global 值
+        existing = self._layer_metric_groups.get(global_key)
+        if existing is None:
+            self._layer_metric_groups[global_key] = (agg, [layer_key])
+        else:
+            assert existing[0] == agg
+            existing[1].append(layer_key)
+
+    def record_layer_metric(self, layer_idx: int, metric_name: str, val: paddle.Tensor) -> None:
+        """热路径：只写 per-layer 累加器，global 在 flush 时从各层推导。"""
+        if not (self.log_per_layer or self.log_global):
+            return
+        layer_key = self._layer_key(layer_idx, metric_name)
+        if self._is_max_aggregated(metric_name):
+            self.record_max(layer_key, val)
+        elif metric_name in self.MIN_AGGREGATED:
+            self.record_min(layer_key, val)
+        else:
+            self.record_mean(layer_key, val)
+
+    def _flush_gpu_buffer(self) -> dict[str, float]:
+        """单次批量 D2H：收集所有累加器 → 推导 global → stack→cpu→tolist → 重置。"""
+        keys: list[str] = []
+        tensors: list[paddle.Tensor] = []
+
+        # 1) 收集 per-layer mean 指标: acc / count
+        for k in self._mean_keys:
+            cnt = self._gpu_cnt[k]
+            if cnt == 0:
+                continue
+            if self.log_per_layer or k not in self._layer_metric_keys:
+                keys.append(k)
+                tensors.append(self._gpu_acc[k] / cnt)
+
+        # 2) 收集 per-layer max 指标: 直接取累加器值
+        for k in self._max_keys:
+            if self._gpu_cnt[k] == 0:
+                continue
+            if self.log_per_layer or k not in self._layer_metric_keys:
+                keys.append(k)
+                tensors.append(self._gpu_acc[k].clone())
+
+        # 3) 收集 per-layer min 指标
+        for k in self._min_keys:
+            if self._gpu_cnt[k] == 0:
+                continue
+            if self.log_per_layer or k not in self._layer_metric_keys:
+                keys.append(k)
+                tensors.append(self._gpu_acc[k].clone())
+
+        # 4) 从各层累加器推导 global 值（不需要 hook 时双写）
+        if self.log_global:
+            for global_key, (agg, layer_keys) in self._layer_metric_groups.items():
+                active = [lk for lk in layer_keys if self._gpu_cnt.get(lk, 0) > 0]
+                if not active:
+                    continue
+                if agg == "mean":
+                    total_sum = paddle.stack([self._gpu_acc[lk] for lk in active]).sum()
+                    total_cnt = sum(self._gpu_cnt[lk] for lk in active)
+                    tensors.append(total_sum / total_cnt)
+                elif agg == "max":
+                    tensors.append(paddle.stack([self._gpu_acc[lk] for lk in active]).max())
+                else:
+                    tensors.append(paddle.stack([self._gpu_acc[lk] for lk in active]).min())
+                keys.append(global_key)
+
+        # 5) 唯一 D2H 同步点：一次 stack → cpu → tolist
+        out: dict[str, float] = {}
+        if tensors:
+            vals = paddle.stack(tensors).cpu().tolist()
+            out = dict(zip(keys, vals, strict=False))
+
+        # 6) 重置所有累加器，为下一个 step 准备
+        for k in self._mean_keys:
+            self._gpu_acc[k].zero_()
+            self._gpu_cnt[k] = 0
+        for k in self._max_keys:
+            paddle.assign(paddle.full((), float("-inf"), dtype=self._gpu_acc[k].dtype), self._gpu_acc[k])
+            self._gpu_cnt[k] = 0
+        for k in self._min_keys:
+            paddle.assign(paddle.full((), float("inf"), dtype=self._gpu_acc[k].dtype), self._gpu_acc[k])
+            self._gpu_cnt[k] = 0
+        return out

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_metrics.py
@@ -32,17 +32,17 @@ def compute_per_channel_max(hidden_states: paddle.Tensor) -> paddle.Tensor:
     return h.abs().max(axis=0)
 
 
-def compute_activation_scale_stats(hidden_states: paddle.Tensor) -> dict[str, float]:
-    """Absolute scale statistics over the full residual stream."""
+def compute_activation_scale_stats(hidden_states: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Absolute scale statistics over the full residual stream. Returns GPU tensors."""
     h = hidden_states.reshape([-1, hidden_states.shape[-1]]).astype("float32")
     return {
-        "activation_rms": float(paddle.sqrt(paddle.square(h).mean())),
+        "activation_rms": paddle.sqrt(paddle.square(h).mean()),
     }
 
 
-def _nearest_quantile_from_sorted(sorted_values: paddle.Tensor, q: float) -> float:
+def _nearest_quantile_from_sorted(sorted_values: paddle.Tensor, q: float) -> paddle.Tensor:
     idx = min(max(round((sorted_values.shape[0] - 1) * q), 0), sorted_values.shape[0] - 1)
-    return float(sorted_values[idx])
+    return sorted_values[idx]
 
 
 def summarize_per_channel_max(
@@ -50,20 +50,20 @@ def summarize_per_channel_max(
     threshold_multiplier: float = 100.0,
     k: int = 3,
     absolute_thresholds: tuple[float, ...] = DEFAULT_ABSOLUTE_THRESHOLDS,
-) -> dict[str, float]:
-    """Derive scalar massive-activation metrics from per-channel maxima."""
-    channel_max = float(per_channel_max.max())
-    channel_median = float(paddle.median(per_channel_max))
-    channel_max_ratio = channel_max / max(channel_median, 1e-8)
+) -> dict[str, paddle.Tensor]:
+    """Derive scalar massive-activation metrics from per-channel maxima. Returns GPU tensors."""
+    channel_max = per_channel_max.max()
+    channel_median = paddle.median(per_channel_max)
+    channel_max_ratio = channel_max / paddle.clip(channel_median, min=1e-8)
 
     threshold = channel_median * threshold_multiplier
-    massive_act_channel_count = float((per_channel_max > threshold).astype("float32").sum())
+    massive_act_channel_count = (per_channel_max > threshold).astype("float32").sum()
 
     topk_vals, _ = paddle.topk(per_channel_max, min(k, per_channel_max.shape[0]))
-    topk_channel_norm = float(topk_vals.norm())
+    topk_channel_norm = topk_vals.norm()
     sorted_channel_max = paddle.sort(per_channel_max)
 
-    return {
+    result = {
         "channel_max": channel_max,
         "channel_median": channel_median,
         "channel_p95": _nearest_quantile_from_sorted(sorted_channel_max, 0.95),
@@ -71,13 +71,11 @@ def summarize_per_channel_max(
         "channel_max_ratio": channel_max_ratio,
         "massive_act_channel_count": massive_act_channel_count,
         "topk_channel_norm": topk_channel_norm,
-        **{
-            f"channel_count_gt_{_threshold_key(absolute_threshold)}": float(
-                (per_channel_max > absolute_threshold).astype("float32").sum()
-            )
-            for absolute_threshold in absolute_thresholds
-        },
     }
+    for absolute_threshold in absolute_thresholds:
+        key = f"channel_count_gt_{_threshold_key(absolute_threshold)}"
+        result[key] = (per_channel_max > absolute_threshold).astype("float32").sum()
+    return result
 
 
 def compute_pre_norm_metrics(
@@ -85,7 +83,7 @@ def compute_pre_norm_metrics(
     threshold_multiplier: float = 100.0,
     k: int = 3,
     absolute_thresholds: tuple[float, ...] = DEFAULT_ABSOLUTE_THRESHOLDS,
-) -> dict[str, float]:
+) -> dict[str, paddle.Tensor]:
     """All pre-norm massive activation metrics in one pass.
 
     Computes per_channel_max once and derives all dependent metrics.
@@ -96,7 +94,7 @@ def compute_pre_norm_metrics(
         k: number of top channels for top-K norm.
 
     Returns:
-        Dict with per-channel peak, outlier, absolute-threshold, and top-K metrics.
+        Dict with per-channel peak, outlier, absolute-threshold, and top-K metrics (GPU tensors).
     """
     return summarize_per_channel_max(
         compute_per_channel_max(hidden_states),
@@ -109,38 +107,22 @@ def compute_pre_norm_metrics(
 def compute_post_norm_sparsity(
     normalized_states: paddle.Tensor,
     epsilon: float = 0.01,
-) -> float:
-    """Fraction of near-zero entries in post-RMSNorm hidden states.
-
-    Args:
-        normalized_states: [..., H] hidden states AFTER RMSNorm.
-        epsilon: threshold below which a value is considered "near-zero".
-
-    Returns:
-        Fraction of entries with |x| < epsilon.
-    """
+) -> paddle.Tensor:
+    """Fraction of near-zero entries in post-RMSNorm hidden states. Returns GPU 0-dim tensor."""
     h = normalized_states.reshape([-1]).astype("float32")
-    return float((h.abs() < epsilon).astype("float32").mean())
+    return (h.abs() < epsilon).astype("float32").mean()
 
 
 def compute_post_norm_cosine_stability(
     normalized_states: paddle.Tensor,
     num_sample_pairs: int = 256,
-) -> float:
-    """Cosine similarity among token representations after normalization.
-
-    Args:
-        normalized_states: [..., H] post-RMSNorm hidden states.
-        num_sample_pairs: number of random pairs to sample.
-
-    Returns:
-        Mean pairwise cosine similarity (sampled).
-    """
+) -> paddle.Tensor:
+    """Cosine similarity among token representations after normalization. Returns GPU 0-dim tensor."""
     h = normalized_states.reshape([-1, normalized_states.shape[-1]]).astype("float32")
     num_tokens = h.shape[0]
 
     if num_tokens < 2:
-        return 1.0
+        return paddle.ones(())
 
     n_pairs = min(num_sample_pairs, num_tokens * (num_tokens - 1) // 2)
     idx_a = paddle.randint(0, num_tokens, [n_pairs])
@@ -151,4 +133,4 @@ def compute_post_norm_cosine_stability(
     vec_b = h[idx_b]
 
     cosine = paddle.nn.functional.cosine_similarity(vec_a, vec_b, axis=-1)
-    return float(cosine.mean())
+    return cosine.mean()

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -123,16 +123,39 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             return
         layers = list(layers)
 
+        # Declare metric schema
+        metric_names = [
+            "channel_max",
+            "channel_median",
+            "channel_p95",
+            "channel_p99",
+            "channel_max_ratio",
+            "massive_act_channel_count",
+            "topk_channel_norm",
+            "activation_rms",
+            "post_norm_sparsity",
+            "post_norm_cosine",
+        ] + [f"channel_count_gt_{_threshold_key(t)}" for t in self.absolute_thresholds]
+
         registered = 0
         for local_idx, layer in enumerate(layers):
             global_idx = self._resolve_layer_idx(layer, local_idx, len(layers))
-
             if self.sample_layers and global_idx not in self.sample_layers:
                 continue
+            for m in metric_names:
+                self.declare_layer_metric(global_idx, m)
+            registered += 1
 
+        self.allocate_buffers()
+
+        idx = 0
+        for local_idx, layer in enumerate(layers):
+            global_idx = self._resolve_layer_idx(layer, local_idx, len(layers))
+            if self.sample_layers and global_idx not in self.sample_layers:
+                continue
             hook = layer.register_forward_pre_hook(self._make_residual_hook(global_idx))
             self.hooks.append(hook)
-            registered += 1
+            idx += 1
 
         logger.info(f"[MassiveActMonitor] Registered {registered} hooks.")
 
@@ -199,28 +222,37 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
     def _compute_and_log(self, layer_idx: int, hidden_states: paddle.Tensor, module: nn.Layer):
         per_channel_max = compute_per_channel_max(hidden_states)
         per_channel_max = self._aggregate_per_channel_max(per_channel_max)
-        metrics = summarize_per_channel_max(
+        stats = summarize_per_channel_max(
             per_channel_max,
             threshold_multiplier=self.spike_threshold_multiplier,
             k=self.topk_channels,
             absolute_thresholds=self.absolute_thresholds,
         )
-        metrics.update(compute_activation_scale_stats(hidden_states))
+        scale_stats = compute_activation_scale_stats(hidden_states)
+
+        for name, val in stats.items():
+            self.record_layer_metric(layer_idx, name, val)
+        for name, val in scale_stats.items():
+            self.record_layer_metric(layer_idx, name, val)
 
         norm_layer = getattr(module, "input_layernorm", None)
         if norm_layer is not None:
             try:
                 normalized = norm_layer(hidden_states)
-                metrics["post_norm_sparsity"] = compute_post_norm_sparsity(normalized, epsilon=self.sparsity_epsilon)
-                metrics["post_norm_cosine"] = compute_post_norm_cosine_stability(
-                    normalized, num_sample_pairs=self.cosine_sample_pairs
+                self.record_layer_metric(
+                    layer_idx,
+                    "post_norm_sparsity",
+                    compute_post_norm_sparsity(normalized, epsilon=self.sparsity_epsilon),
+                )
+                self.record_layer_metric(
+                    layer_idx,
+                    "post_norm_cosine",
+                    compute_post_norm_cosine_stability(normalized, num_sample_pairs=self.cosine_sample_pairs),
                 )
             except Exception as e:
                 if self.verbose and layer_idx not in self._post_norm_failed_layers:
                     logger.warning(f"[MassiveActMonitor] Post-norm metrics disabled at layer {layer_idx}: {e}")
                     self._post_norm_failed_layers.add(layer_idx)
-
-        self._record_metrics(layer_idx, metrics)
 
     def _aggregate_per_channel_max(self, per_channel_max: paddle.Tensor) -> paddle.Tensor:
         """Aggregate token-sharded per-channel maxima across the TP group when available."""

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -30,7 +30,7 @@ def _compute_router_entropy(probs):
     probs = probs.astype("float32").clip(min=1e-10)
     probs = probs / probs.sum(axis=-1, keepdim=True)
     entropy = -(probs * probs.log()).sum(axis=-1)
-    return float(entropy.mean())
+    return entropy.mean()
 
 
 def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=1, topk_group=1):
@@ -71,19 +71,19 @@ def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=
 
     intersection = (set_with & set_without).astype("float32").sum()
     union = (set_with | set_without).astype("float32").sum()
-    return float(intersection / union.clip(min=1.0))
+    return intersection / union.clip(min=1.0)
 
 
 def _compute_expert_norms_paddle(weight_list):
-    """Compute L2 norms for a list of paddle weight tensors."""
+    """Compute L2 norms for a list of paddle weight tensors. Returns GPU tensors."""
     if not weight_list:
-        return {"expert_norm_mean": 0.0, "expert_norm_std": 0.0, "expert_norm_min": 0.0, "expert_norm_max": 0.0}
+        return {}
     norms = paddle.stack([w.astype("float32").norm() for w in weight_list])
     return {
-        "expert_norm_mean": float(norms.mean()),
-        "expert_norm_std": float(norms.std()) if norms.numel() > 1 else 0.0,
-        "expert_norm_min": float(norms.min()),
-        "expert_norm_max": float(norms.max()),
+        "expert_norm_mean": norms.mean(),
+        "expert_norm_std": norms.std() if norms.numel() > 1 else paddle.zeros(()),
+        "expert_norm_min": norms.min(),
+        "expert_norm_max": norms.max(),
     }
 
 
@@ -97,7 +97,6 @@ class PaddleMoEMonitor(PaddleProbe):
             log_per_layer=log_per_layer, log_global=log_global, monitor_interval=monitor_interval, verbose=verbose
         )
         self._patched_gates = []
-        self._pending_router_global_layers: set[int] = set()
 
     def register_hooks(self, model: nn.Layer):
         try:
@@ -113,6 +112,30 @@ class PaddleMoEMonitor(PaddleProbe):
             return
         if self.verbose:
             logger.info(f"[PaddleMoEMonitor] Found {len(moe_layers)} MoE layers.")
+
+        # Declare metric schema
+        for layer_idx, moe_layer in moe_layers:
+            gate_metrics = ["router_entropy", "score_sum_mean", "score_sum_min", "score_sum_max"]
+            if hasattr(moe_layer, "gate") and hasattr(moe_layer.gate, "e_score_correction_bias"):
+                gate_metrics += [
+                    "bias_affinity_jaccard",
+                    "expert_bias_mean",
+                    "expert_bias_std",
+                    "expert_bias_max",
+                    "expert_bias_min",
+                ]
+            expert_metrics = [
+                "expert_norm_mean",
+                "expert_norm_std",
+                "expert_norm_min",
+                "expert_norm_max",
+                "shared_expert_norm",
+                "shared_routed_ratio",
+            ]
+            for m in gate_metrics + expert_metrics:
+                self.declare_layer_metric(layer_idx, m)
+
+        self.allocate_buffers()
 
         for layer_idx, moe_layer in moe_layers:
             if hasattr(moe_layer, "gate"):
@@ -261,7 +284,6 @@ class PaddleMoEMonitor(PaddleProbe):
                 with paddle.no_grad():
                     self._compute_expert_metrics(layer_idx, layer)
             except Exception as e:
-                self._finalize_layer_observation(layer_idx)
                 if self.verbose:
                     logger.error(f"[PaddleMoEMonitor] MoE layer hook error layer {layer_idx}: {e}")
 
@@ -269,9 +291,6 @@ class PaddleMoEMonitor(PaddleProbe):
 
     def _compute_gate_metrics(self, layer_idx, gate, outputs, moe_layer):
         """Compute router metrics from gate forward output."""
-        metrics = {}
-
-        # Use _cached_gates (patched softmax output, pre-bias) as the canonical probability distribution
         cached_gates = getattr(gate, "_cached_gates", None)
         k = getattr(gate, "num_experts_per_tok", None)
 
@@ -280,13 +299,13 @@ class PaddleMoEMonitor(PaddleProbe):
                 logger.warning(f"[PaddleMoEMonitor] layer {layer_idx}: _cached_gates is None, gate patch may not work")
             return
 
-        metrics["router_entropy"] = _compute_router_entropy(cached_gates)
+        self.record_layer_metric(layer_idx, "router_entropy", _compute_router_entropy(cached_gates))
         if k is not None:
             topk_vals, _ = paddle.topk(cached_gates, k, axis=-1)
             score_sum = topk_vals.sum(axis=-1)
-            metrics["score_sum_mean"] = float(score_sum.mean())
-            metrics["score_sum_min"] = float(score_sum.min())
-            metrics["score_sum_max"] = float(score_sum.max())
+            self.record_layer_metric(layer_idx, "score_sum_mean", score_sum.mean())
+            self.record_layer_metric(layer_idx, "score_sum_min", score_sum.min())
+            self.record_layer_metric(layer_idx, "score_sum_max", score_sum.max())
 
         if hasattr(gate, "e_score_correction_bias"):
             top_idx_with_bias = None
@@ -295,30 +314,18 @@ class PaddleMoEMonitor(PaddleProbe):
             if top_idx_with_bias is not None and k is not None:
                 n_group = getattr(gate, "n_group", 1)
                 topk_group = getattr(gate, "topk_group", 1)
-                metrics["bias_affinity_jaccard"] = _compute_bias_affinity_jaccard(
-                    top_idx_with_bias, cached_gates, k, n_group, topk_group
+                self.record_layer_metric(
+                    layer_idx,
+                    "bias_affinity_jaccard",
+                    _compute_bias_affinity_jaccard(top_idx_with_bias, cached_gates, k, n_group, topk_group),
                 )
             bias = gate.e_score_correction_bias
-            metrics["expert_bias_mean"] = float(bias.mean())
-            metrics["expert_bias_std"] = float(bias.std())
-            metrics["expert_bias_max"] = float(bias.max())
-            metrics["expert_bias_min"] = float(bias.min())
-
-        # Per-layer log + global accumulate (no count increment — expert hook does that)
-        self._log_per_layer_metrics(layer_idx, metrics)
-        if self.log_global and metrics:
-            self._accumulate_global(metrics)
-            self._pending_router_global_layers.add(layer_idx)
-
-    def _finalize_layer_observation(self, layer_idx: int, *, has_expert_metrics: bool = False):
-        """Finish one MoE layer observation and count global aggregation once."""
-        has_pending_router = layer_idx in self._pending_router_global_layers
-        if has_expert_metrics or has_pending_router:
-            self._count_global_observation()
-        self._pending_router_global_layers.discard(layer_idx)
+            self.record_layer_metric(layer_idx, "expert_bias_mean", bias.mean())
+            self.record_layer_metric(layer_idx, "expert_bias_std", bias.std())
+            self.record_layer_metric(layer_idx, "expert_bias_max", bias.max())
+            self.record_layer_metric(layer_idx, "expert_bias_min", bias.min())
 
     def _compute_expert_metrics(self, layer_idx, moe_layer):
-        metrics = {}
         routed_norm_mean = None
 
         if hasattr(moe_layer, "grouped_gemm_experts") and moe_layer.grouped_gemm_experts is not None:
@@ -333,8 +340,9 @@ class PaddleMoEMonitor(PaddleProbe):
                     expert_weights.append(combined)
             if expert_weights:
                 norm_stats = _compute_expert_norms_paddle(expert_weights)
-                metrics.update(norm_stats)
-                routed_norm_mean = norm_stats["expert_norm_mean"]
+                for name, val in norm_stats.items():
+                    self.record_layer_metric(layer_idx, name, val)
+                routed_norm_mean = norm_stats.get("expert_norm_mean")
 
         elif hasattr(moe_layer, "experts") and moe_layer.experts is not None:
             expert_weights = []
@@ -345,23 +353,21 @@ class PaddleMoEMonitor(PaddleProbe):
                         expert_weights.append(paddle.concat(weights))
             if expert_weights:
                 norm_stats = _compute_expert_norms_paddle(expert_weights)
-                metrics.update(norm_stats)
-                routed_norm_mean = norm_stats["expert_norm_mean"]
+                for name, val in norm_stats.items():
+                    self.record_layer_metric(layer_idx, name, val)
+                routed_norm_mean = norm_stats.get("expert_norm_mean")
 
         if hasattr(moe_layer, "shared_experts") and moe_layer.shared_experts is not None:
             shared_weights = [p.flatten() for p in moe_layer.shared_experts.parameters()]
             if shared_weights:
                 all_params = paddle.concat(shared_weights)
-                shared_norm = float(all_params.astype("float32").norm())
-                metrics["shared_expert_norm"] = shared_norm
-                if routed_norm_mean is not None and routed_norm_mean > 1e-8:
-                    metrics["shared_routed_ratio"] = shared_norm / routed_norm_mean
-
-        if metrics:
-            self._log_per_layer_metrics(layer_idx, metrics)
-            if self.log_global:
-                self._accumulate_global(metrics)
-        self._finalize_layer_observation(layer_idx, has_expert_metrics=bool(metrics))
+                shared_norm = all_params.astype("float32").norm()
+                self.record_layer_metric(layer_idx, "shared_expert_norm", shared_norm)
+                if routed_norm_mean is not None:
+                    # clip 防止除零（对齐 megatron compute_shared_routed_ratio），保持 GPU 张量无 D2H
+                    self.record_layer_metric(
+                        layer_idx, "shared_routed_ratio", shared_norm / routed_norm_mean.clip(min=1e-8)
+                    )
 
     def remove_hooks(self):
         super().remove_hooks()
@@ -373,13 +379,9 @@ class PaddleMoEMonitor(PaddleProbe):
                 if hasattr(gate, attr):
                     delattr(gate, attr)
         self._patched_gates = []
-        self._pending_router_global_layers.clear()
 
     def step(self):
-        for layer_idx in list(self._pending_router_global_layers):
-            self._finalize_layer_observation(layer_idx)
         super().step()
-        self._pending_router_global_layers.clear()
 
 
 def setup_moe_monitor(

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -35,7 +35,7 @@ def compute_sink_head_classification(sink_per_head: paddle.Tensor, threshold: fl
 
     is_sink = sink_per_head > threshold
     is_sink_f = is_sink.astype("float32")
-    is_nonsink_f = (~is_sink).astype("float32")
+    is_nonsink_f = paddle.logical_not(is_sink).astype("float32")
     sink_count = is_sink_f.sum()
     nonsink_count = is_nonsink_f.sum()
     sink_head_ratio = sink_count / float(num_heads)

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -101,10 +101,10 @@ def _compute_qk_stats_triton(q: paddle.Tensor, k: paddle.Tensor, causal: bool = 
         "mean_per_head": mean_logits,
         "entropy_per_head": entropy,
         "sink_per_head": sink,
-        "max_global": float(max_logits.max()),
-        "mean_global": float(mean_logits.mean()),
-        "entropy_global": float(entropy.mean()),
-        "sink_global": float(sink.mean()),
+        "max_global": max_logits.max(),
+        "mean_global": mean_logits.mean(),
+        "entropy_global": entropy.mean(),
+        "sink_global": sink.mean(),
     }
 
 
@@ -163,6 +163,12 @@ class PaddleQKStatsMonitor(PaddleProbe):
         if self.verbose:
             logger.info(f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. TP={self.tp_size}")
 
+        for layer_idx, _ in attention_layers:
+            for m in ("max", "mean", "entropy_avg", "sink", "entropy_min", "entropy_max", "entropy_std"):
+                self.declare_layer_metric(layer_idx, m)
+
+        self.allocate_buffers()
+
         for layer_idx, attn_module in attention_layers:
             if hasattr(attn_module, "core_attention"):
                 hook = attn_module.core_attention.register_forward_pre_hook(self._make_compute_hook(layer_idx))
@@ -212,24 +218,19 @@ class PaddleQKStatsMonitor(PaddleProbe):
             try:
                 query, key = inputs[0], inputs[1]
                 with paddle.no_grad():
-                    # Handle GQA
                     if query.shape[2] != key.shape[2]:
                         heads_per_group = query.shape[2] // key.shape[2]
                         key = key.repeat_interleave(heads_per_group, axis=2)
                     stats = compute_qk_stats_paddle(query, key, causal=self.causal)
 
                 all_heads = stats["entropy_per_head"]
-                metrics = {
-                    "max": stats["max_global"],
-                    "mean": stats["mean_global"],
-                    "entropy_avg": stats["entropy_global"],
-                    "sink": stats["sink_global"],
-                    "entropy_min": float(all_heads.min()),
-                    "entropy_max": float(all_heads.max()),
-                    "entropy_std": float(all_heads.std()),
-                }
-
-                self._record_metrics(layer_idx, metrics)
+                self.record_layer_metric(layer_idx, "max", stats["max_global"])
+                self.record_layer_metric(layer_idx, "mean", stats["mean_global"])
+                self.record_layer_metric(layer_idx, "entropy_avg", stats["entropy_global"])
+                self.record_layer_metric(layer_idx, "sink", stats["sink_global"])
+                self.record_layer_metric(layer_idx, "entropy_min", all_heads.min())
+                self.record_layer_metric(layer_idx, "entropy_max", all_heads.max())
+                self.record_layer_metric(layer_idx, "entropy_std", all_heads.std())
             except Exception as e:
                 logger.error(f"[PaddleQKMonitor] Error layer {layer_idx}: {e}")
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -38,46 +38,52 @@ class PaddleMoEMonitorTest(unittest.TestCase):
     def tearDown(self):
         training_logs.reset()
 
-    def test_router_only_global_observation_is_counted_once(self):
+    def test_gpu_buffer_gate_metrics_recorded(self):
+        """Gate hook records metrics via GPU-buffer API without D2H sync."""
         monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
-        monitor._log_per_layer_metrics(0, {"router_entropy": 2.0})
-        monitor._accumulate_global({"router_entropy": 2.0})
-        monitor._pending_router_global_layers.add(0)
+        # Manually declare and allocate for layer 0
+        for m in ["router_entropy", "score_sum_mean", "score_sum_min", "score_sum_max"]:
+            monitor.declare_layer_metric(0, m)
+        monitor.allocate_buffers()
 
-        monitor._finalize_layer_observation(0)
-        self.assertEqual(monitor._global_count, 1)
-        self.assertEqual(monitor._pending_router_global_layers, set())
-
+        # Simulate recording
+        monitor.record_layer_metric(0, "router_entropy", paddle.to_tensor(2.0))
         monitor.step()
-        latest = training_logs.get_latest(prefix="moe_health")
-        self.assertEqual(latest["moe_health/layer_0/router_entropy"], 2.0)
-        self.assertEqual(latest["moe_health/global_router_entropy"], 2.0)
 
-    def test_step_finalizes_pending_router_metrics_before_flush(self):
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/router_entropy"], 2.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 2.0, places=4)
+
+    def test_gpu_buffer_multi_layer_global_aggregation(self):
+        """Global metrics are derived from layer accumulators at flush time."""
         monitor = PaddleMoEMonitor(log_per_layer=False, log_global=True)
-        monitor._accumulate_global({"router_entropy": 4.0})
-        monitor._pending_router_global_layers.add(3)
+        for layer_idx in (0, 1):
+            for m in ["router_entropy", "score_sum_max"]:
+                monitor.declare_layer_metric(layer_idx, m)
+        monitor.allocate_buffers()
 
+        monitor.record_layer_metric(0, "router_entropy", paddle.to_tensor(2.0))
+        monitor.record_layer_metric(1, "router_entropy", paddle.to_tensor(4.0))
+        monitor.record_layer_metric(0, "score_sum_max", paddle.to_tensor(0.8))
+        monitor.record_layer_metric(1, "score_sum_max", paddle.to_tensor(0.9))
         monitor.step()
 
         latest = training_logs.get_latest(prefix="moe_health")
-        self.assertEqual(latest["moe_health/global_router_entropy"], 4.0)
-        self.assertEqual(monitor._global_count, 0)
-        self.assertEqual(monitor._pending_router_global_layers, set())
+        self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 3.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/global_score_sum_max"], 0.9, places=4)
 
-    def test_expert_hook_exception_finalizes_pending_router_metrics(self):
+    def test_expert_hook_exception_does_not_crash(self):
+        """Expert hook exceptions are caught without crashing the step."""
         monitor = PaddleMoEMonitor(log_per_layer=False, log_global=True, verbose=False)
-        monitor._accumulate_global({"router_entropy": 6.0})
-        monitor._pending_router_global_layers.add(2)
+        for m in ["expert_norm_mean", "expert_norm_std", "expert_norm_min", "expert_norm_max"]:
+            monitor.declare_layer_metric(2, m)
+        monitor.allocate_buffers()
 
         hook = monitor._make_moe_layer_hook(2, BrokenPaddleMoELayer())
         hook(BrokenPaddleMoELayer(), (), None)
 
-        self.assertEqual(monitor._global_count, 1)
-        self.assertEqual(monitor._pending_router_global_layers, set())
+        # Should not crash; step should still work
         monitor.step()
-        latest = training_logs.get_latest(prefix="moe_health")
-        self.assertEqual(latest["moe_health/global_router_entropy"], 6.0)
 
 
 class PaddleMassiveActivationMonitorTest(unittest.TestCase):
@@ -111,6 +117,25 @@ class PaddleMassiveActivationMonitorTest(unittest.TestCase):
             dtype="float32",
         )
 
+        # Must declare + allocate before _compute_and_log
+        metric_names = [
+            "channel_max",
+            "channel_median",
+            "channel_p95",
+            "channel_p99",
+            "channel_max_ratio",
+            "massive_act_channel_count",
+            "topk_channel_norm",
+            "activation_rms",
+            "post_norm_sparsity",
+            "post_norm_cosine",
+            "channel_count_gt_2",
+            "channel_count_gt_3",
+        ]
+        for m in metric_names:
+            monitor.declare_layer_metric(0, m)
+        monitor.allocate_buffers()
+
         monitor._compute_and_log(0, hidden_states, nn.Layer())
         monitor.step()
 
@@ -139,22 +164,18 @@ class PaddleMassiveActivationMonitorTest(unittest.TestCase):
             absolute_thresholds=(2.0, 3.0),
         )
 
-        monitor._record_metrics(
-            0,
-            {
-                "massive_act_channel_count": 0.0,
-                "channel_count_gt_2": 1.0,
-                "channel_count_gt_3": 0.0,
-            },
-        )
-        monitor._record_metrics(
-            1,
-            {
-                "massive_act_channel_count": 2.0,
-                "channel_count_gt_2": 3.0,
-                "channel_count_gt_3": 1.0,
-            },
-        )
+        # Declare and allocate for 2 layers
+        for layer_idx in (0, 1):
+            for m in ["massive_act_channel_count", "channel_count_gt_2", "channel_count_gt_3"]:
+                monitor.declare_layer_metric(layer_idx, m)
+        monitor.allocate_buffers()
+
+        monitor.record_layer_metric(0, "massive_act_channel_count", paddle.to_tensor(0.0))
+        monitor.record_layer_metric(0, "channel_count_gt_2", paddle.to_tensor(1.0))
+        monitor.record_layer_metric(0, "channel_count_gt_3", paddle.to_tensor(0.0))
+        monitor.record_layer_metric(1, "massive_act_channel_count", paddle.to_tensor(2.0))
+        monitor.record_layer_metric(1, "channel_count_gt_2", paddle.to_tensor(3.0))
+        monitor.record_layer_metric(1, "channel_count_gt_3", paddle.to_tensor(1.0))
         monitor.step()
 
         latest = training_logs.get_latest(prefix="massive_act")


### PR DESCRIPTION
# 问题
PaddleFleet 后端的三个 monitor（qk_monitor、moe_monitor、massive_activation_monitor）在 forward hook 内部调用 float(gpu_tensor) 将 GPU 张量同步转换为 Python 标量。每次 float() 都触发一次 cudaStreamSynchronize，阻塞 CPU 直到 GPU 队列清空，将本应重叠执行的 CPU launch / GPU compute / NCCL 通信打成串行。

# 解法
镜像 Megatron 后端已有的 GPU-buffer API（TorchProbe），在 PaddleProbe 中实现等价的 declare → allocate → record → flush 四阶段模式：
* Hook 内：只做纯 GPU 运算（0-dim tensor 的 add_ / maximum / minimum），零 D2H 同步
* Step 结束时：单次 paddle.stack(all_tensors).cpu().tolist() 完成所有指标的批量 D2H