### PR TITLE
feat: support PaddleFleet MTP layers in monitors

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -1,0 +1,88 @@
+"""Layer discovery helpers for PaddleFleet monitors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MonitorLayer:
+    """A transformer layer together with its metric layer id."""
+
+    idx: int
+    layer: object
+    is_mtp: bool = False
+
+
+def get_decoder_layers(model) -> list[object] | None:
+    """Find PaddleFleet decoder layers, including MTP wrapper layers."""
+    if hasattr(model, "_layers") and hasattr(model._layers, "run_function"):
+        model = model._layers
+    if hasattr(model, "module"):
+        model = model.module
+    if hasattr(model, "run_function"):
+        return list(model.run_function)
+    if hasattr(model, "decoder") and hasattr(model.decoder, "layers"):
+        return list(model.decoder.layers)
+    if hasattr(model, "encoder") and hasattr(model.encoder, "layers"):
+        return list(model.encoder.layers)
+    if hasattr(model, "layers"):
+        return list(model.layers)
+    return None
+
+
+def is_mtp_wrapper(layer) -> bool:
+    """Return True for wrapper layers that contain a real MTP transformer layer."""
+    inner = getattr(layer, "transformer_layer", None)
+    return inner is not None and inner is not layer
+
+
+def unwrap_mtp_layer(layer):
+    """Return the transformer layer to hook for a possible MTP wrapper."""
+    return getattr(layer, "transformer_layer", None) if is_mtp_wrapper(layer) else layer
+
+
+def resolve_layer_idx(layer, local_idx: int, num_local_layers: int, pp_rank: int = 0, layer_offset: int = 0) -> int:
+    """Resolve a PaddleFleet metric layer id without converting 0-based ids."""
+    for attr in ("layer_idx", "layer_index", "idx", "layer_number"):
+        value = getattr(layer, attr, None)
+        if isinstance(value, int):
+            return value
+    return pp_rank * num_local_layers + layer_offset + local_idx
+
+
+def iter_monitor_layers(
+    layers: Iterable[object],
+    matches: Callable[[object], bool],
+    *,
+    pp_rank: int = 0,
+    layer_offset: int = 0,
+) -> list[MonitorLayer]:
+    """Return main + MTP layers that satisfy ``matches``.
+
+    PaddleFleet MTP layers are wrappers whose real transformer layer lives at
+    ``wrapper.transformer_layer``. Pipeline ``run_function`` also contains
+    embedding, norm, empty, and LM head entries, so MTP metric ids must be
+    assigned after matched main transformer layers rather than physical entries.
+    """
+    layers = list(layers)
+    main_layers = [layer for layer in layers if not is_mtp_wrapper(layer)]
+    mtp_wrappers = [layer for layer in layers if is_mtp_wrapper(layer)]
+    matched_main_layers = [layer for layer in main_layers if matches(layer)]
+    num_main_layers = len(matched_main_layers)
+    monitor_layers: list[MonitorLayer] = []
+
+    for local_idx, layer in enumerate(matched_main_layers):
+        idx = resolve_layer_idx(layer, local_idx, num_main_layers, pp_rank=pp_rank, layer_offset=layer_offset)
+        monitor_layers.append(MonitorLayer(idx=idx, layer=layer, is_mtp=False))
+
+    next_mtp_idx = max((item.idx for item in monitor_layers), default=layer_offset - 1) + 1
+    for mtp_idx, wrapper in enumerate(mtp_wrappers):
+        layer = unwrap_mtp_layer(wrapper)
+        if not matches(layer):
+            continue
+        idx = next_mtp_idx + mtp_idx
+        monitor_layers.append(MonitorLayer(idx=idx, layer=layer, is_mtp=True))
+
+    return monitor_layers

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -35,6 +35,7 @@ import paddle
 import paddle.nn as nn
 
 from .base import PaddleProbe
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
 from .massive_activation_metrics import (
     DEFAULT_ABSOLUTE_THRESHOLDS,
     _threshold_key,
@@ -118,11 +119,20 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         except Exception:
             pass
 
-        layers = self._get_decoder_layers(model)
+        def is_transformer_layer(layer):
+            return hasattr(layer, "self_attn") or hasattr(layer, "self_attention") or hasattr(layer, "input_layernorm")
+
+        layers = get_decoder_layers(model)
+        if layers is None:
+            transformer_layers = [
+                sublayer for _name, sublayer in model.named_sublayers() if is_transformer_layer(sublayer)
+            ]
+            layers = transformer_layers if transformer_layers else None
         if not layers:
             logger.warning("[MassiveActMonitor] No transformer layers found!")
             return
-        layers = list(layers)
+
+        monitor_layers = iter_monitor_layers(layers, is_transformer_layer, pp_rank=self.pp_rank)
 
         # Declare metric schema
         metric_names = [
@@ -139,50 +149,22 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         ] + [f"channel_count_gt_{_threshold_key(t)}" for t in self.absolute_thresholds]
 
         registered = 0
-        for local_idx, layer in enumerate(layers):
-            global_idx = self._resolve_layer_idx(layer, local_idx, len(layers))
-            if self.sample_layers and global_idx not in self.sample_layers:
+        for item in monitor_layers:
+            if self.sample_layers and item.idx not in self.sample_layers:
                 continue
             for m in metric_names:
-                self.declare_layer_metric(global_idx, m)
+                self.declare_layer_metric(item.idx, m)
             registered += 1
 
         self.allocate_buffers()
 
-        idx = 0
-        for local_idx, layer in enumerate(layers):
-            global_idx = self._resolve_layer_idx(layer, local_idx, len(layers))
-            if self.sample_layers and global_idx not in self.sample_layers:
+        for item in monitor_layers:
+            if self.sample_layers and item.idx not in self.sample_layers:
                 continue
-            hook = layer.register_forward_pre_hook(self._make_residual_hook(global_idx))
+            hook = item.layer.register_forward_pre_hook(self._make_residual_hook(item.idx))
             self.hooks.append(hook)
-            idx += 1
 
         logger.info(f"[MassiveActMonitor] Registered {registered} hooks.")
-
-    def _get_decoder_layers(self, model):
-        """Find transformer decoder layers in PaddleFleet model hierarchy."""
-        if hasattr(model, "_layers") and hasattr(model._layers, "run_function"):
-            model = model._layers
-        if hasattr(model, "module"):
-            model = model.module
-        if hasattr(model, "run_function"):
-            return [
-                layer
-                for layer in model.run_function
-                if hasattr(layer, "self_attn") or hasattr(layer, "self_attention") or hasattr(layer, "input_layernorm")
-            ]
-        if hasattr(model, "decoder") and hasattr(model.decoder, "layers"):
-            return model.decoder.layers
-        if hasattr(model, "encoder") and hasattr(model.encoder, "layers"):
-            return model.encoder.layers
-        if hasattr(model, "layers"):
-            return model.layers
-        transformer_layers = []
-        for _name, sublayer in model.named_sublayers():
-            if hasattr(sublayer, "self_attn") or hasattr(sublayer, "self_attention"):
-                transformer_layers.append(sublayer)
-        return transformer_layers if transformer_layers else None
 
     def _make_residual_hook(self, layer_idx: int):
         def hook_fn(module, inputs):

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -21,6 +21,7 @@ import paddle
 import paddle.nn as nn
 
 from .base import PaddleProbe
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
 
 logger = logging.getLogger(__name__)
 
@@ -221,16 +222,26 @@ class PaddleMoEMonitor(PaddleProbe):
         self._patched_gates.append(gate)
 
     def _find_moe_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer]]:
-        moe_layers = []
-        layers = self._get_decoder_layers(model)
+        def has_moe(layer):
+            return (
+                (hasattr(layer, "mlp") and hasattr(layer.mlp, "gate"))
+                or hasattr(layer, "moe")
+                or hasattr(layer, "gate")
+            )
+
+        layers = get_decoder_layers(model)
         if layers is None:
             for _name, sublayer in model.named_sublayers():
                 if sublayer.__class__.__name__ == "MoELayer":
-                    moe_layers.append((len(moe_layers), sublayer))
-            return moe_layers
+                    layers = [] if layers is None else layers
+                    layers.append(sublayer)
+            if layers is None:
+                return []
 
-        for local_idx, layer in enumerate(layers):
-            global_idx = self._resolve_layer_idx(layer, local_idx, len(layers))
+        monitor_layers = iter_monitor_layers(layers, has_moe, pp_rank=self.pp_rank)
+        moe_layers = []
+        for item in monitor_layers:
+            layer = item.layer
             moe_module = None
             if hasattr(layer, "mlp") and hasattr(layer.mlp, "gate"):
                 moe_module = layer.mlp
@@ -239,39 +250,8 @@ class PaddleMoEMonitor(PaddleProbe):
             elif hasattr(layer, "gate"):
                 moe_module = layer
             if moe_module is not None:
-                moe_layers.append((global_idx, moe_module))
+                moe_layers.append((item.idx, moe_module))
         return moe_layers
-
-    def _get_decoder_layers(self, model):
-        if hasattr(model, "_layers") and hasattr(model._layers, "run_function"):
-            model = model._layers
-        if hasattr(model, "module"):
-            model = model.module
-        if hasattr(model, "run_function"):
-            return [
-                layer
-                for layer in model.run_function
-                if hasattr(layer, "self_attn")
-                or hasattr(layer, "self_attention")
-                or (hasattr(layer, "mlp") and hasattr(layer.mlp, "gate"))
-                or hasattr(layer, "moe")
-            ]
-        if hasattr(model, "decoder") and hasattr(model.decoder, "layers"):
-            return model.decoder.layers
-        if hasattr(model, "encoder") and hasattr(model.encoder, "layers"):
-            return model.encoder.layers
-        if hasattr(model, "layers"):
-            return model.layers
-        transformer_layers = []
-        for _name, sublayer in model.named_sublayers():
-            if (
-                hasattr(sublayer, "self_attn")
-                or hasattr(sublayer, "self_attention")
-                or (hasattr(sublayer, "mlp") and hasattr(sublayer.mlp, "gate"))
-                or hasattr(sublayer, "moe")
-            ):
-                transformer_layers.append(sublayer)
-        return transformer_layers if transformer_layers else None
 
     def _make_gate_hook(self, layer_idx: int, moe_layer: nn.Layer):
         def hook_fn(layer, inputs, outputs):

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -11,6 +11,7 @@ import paddle
 import paddle.nn as nn
 
 from .base import PaddleProbe
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
 
 logger = logging.getLogger(__name__)
 
@@ -241,37 +242,25 @@ class PaddleQKStatsMonitor(PaddleProbe):
         logger.info(f"[PaddleQKMonitor] Registered {len(self.hooks)} hooks.")
 
     def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer]]:
-        attention_layers = []
-        layers = self._get_decoder_layers(model)
+        def has_attention(layer):
+            return hasattr(layer, "self_attn") or hasattr(layer, "self_attention")
+
+        layers = get_decoder_layers(model)
+        if layers is None:
+            transformer_layers = [
+                sublayer for _name, sublayer in model.named_sublayers() if has_attention(sublayer)
+            ]
+            layers = transformer_layers if transformer_layers else None
         if layers is None:
             return []
-        for local_idx, layer in enumerate(layers):
-            global_idx = self._resolve_layer_idx(layer, local_idx, len(layers))
-            attn = getattr(layer, "self_attn", None) or getattr(layer, "self_attention", None)
-            if attn is not None:
-                attention_layers.append((global_idx, attn))
-        return attention_layers
 
-    def _get_decoder_layers(self, model):
-        if hasattr(model, "_layers") and hasattr(model._layers, "run_function"):
-            model = model._layers
-        if hasattr(model, "module"):
-            model = model.module
-        if hasattr(model, "run_function"):
-            return [
-                layer for layer in model.run_function if hasattr(layer, "self_attn") or hasattr(layer, "self_attention")
-            ]
-        if hasattr(model, "decoder") and hasattr(model.decoder, "layers"):
-            return model.decoder.layers
-        if hasattr(model, "encoder") and hasattr(model.encoder, "layers"):
-            return model.encoder.layers
-        if hasattr(model, "layers"):
-            return model.layers
-        transformer_layers = []
-        for _name, sublayer in model.named_sublayers():
-            if hasattr(sublayer, "self_attn") or hasattr(sublayer, "self_attention"):
-                transformer_layers.append(sublayer)
-        return transformer_layers if transformer_layers else None
+        monitor_layers = iter_monitor_layers(layers, has_attention, pp_rank=self.pp_rank)
+        attention_layers = []
+        for item in monitor_layers:
+            attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
+            if attn is not None:
+                attention_layers.append((item.idx, attn))
+        return attention_layers
 
     def _make_compute_hook(self, layer_idx: int):
         def hook_fn(layer, inputs):


### PR DESCRIPTION
## Summary

This PR adds PaddleFleet MTP layer support to the internal medicine monitors.

The previous layer discovery logic only handled regular decoder layers and pipeline `run_function` entries as direct transformer layers. In PaddleFleet MTP models, the MTP layer is wrapped and the real transformer layer lives under `wrapper.transformer_layer`, so the monitor hooks could miss MTP layers or assign layer ids incorrectly.

## Changes

- Add shared PaddleFleet layer discovery helpers for monitor layer resolution.
- Detect MTP wrapper layers and unwrap them before registering monitor hooks.
- Assign MTP metric layer ids after the matched main transformer layers.
- Update massive activation, QK stats, and MoE monitors to use the shared MTP-aware discovery logic.
- Preserve existing fallback discovery through `named_sublayers()` when decoder layers cannot be found directly.
- Keep massive activation GPU-buffer metric declaration and allocation compatible with MTP-aware layer ids.