### PR TITLE
fix: improve PaddleFleet monitor discovery and aggregation

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -15,20 +15,48 @@ class MonitorLayer:
     is_mtp: bool = False
 
 
+def _flatten_model_chunks(model) -> list[object] | None:
+    """Return flattened run_function entries from PaddleFleet VPP chunks."""
+    chunks = getattr(model, "_model_chunks", None)
+    if not chunks:
+        return None
+
+    layers = []
+    for chunk in chunks:
+        chunk_layers = get_decoder_layers(chunk)
+        if chunk_layers is not None:
+            layers.extend(chunk_layers)
+    return layers if layers else None
+
+
 def get_decoder_layers(model) -> list[object] | None:
-    """Find PaddleFleet decoder layers, including MTP wrapper layers."""
-    if hasattr(model, "_layers") and hasattr(model._layers, "run_function"):
-        model = model._layers
+    """Find PaddleFleet decoder layers, including VPP chunks and MTP wrappers."""
+    candidates = [model]
+    if hasattr(model, "_layers"):
+        candidates.append(model._layers)
     if hasattr(model, "module"):
-        model = model.module
-    if hasattr(model, "run_function"):
-        return list(model.run_function)
-    if hasattr(model, "decoder") and hasattr(model.decoder, "layers"):
-        return list(model.decoder.layers)
-    if hasattr(model, "encoder") and hasattr(model.encoder, "layers"):
-        return list(model.encoder.layers)
-    if hasattr(model, "layers"):
-        return list(model.layers)
+        candidates.append(model.module)
+
+    seen = set()
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        candidate_id = id(candidate)
+        if candidate_id in seen:
+            continue
+        seen.add(candidate_id)
+
+        chunk_layers = _flatten_model_chunks(candidate)
+        if chunk_layers is not None:
+            return chunk_layers
+        if hasattr(candidate, "run_function"):
+            return list(candidate.run_function)
+        if hasattr(candidate, "decoder") and hasattr(candidate.decoder, "layers"):
+            return list(candidate.decoder.layers)
+        if hasattr(candidate, "encoder") and hasattr(candidate.encoder, "layers"):
+            return list(candidate.encoder.layers)
+        if hasattr(candidate, "layers"):
+            return list(candidate.layers)
     return None
 
 

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -216,6 +216,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 gate._cached_gates = scores.detach()
                 return result
 
+            gate._im_original_hash_routing = original_hash_routing
             gate._hash_routing = cached_hash_routing
 
         gate._im_patched = True
@@ -380,7 +381,10 @@ class PaddleMoEMonitor(PaddleProbe):
             original_fn = getattr(gate, "_im_original_gate_score_func", None)
             if original_fn is not None:
                 gate.gate_score_func = original_fn
-            for attr in ("_im_original_gate_score_func", "_im_patched", "_cached_gates"):
+            original_hash_routing = getattr(gate, "_im_original_hash_routing", None)
+            if original_hash_routing is not None:
+                gate._hash_routing = original_hash_routing
+            for attr in ("_im_original_gate_score_func", "_im_original_hash_routing", "_im_patched", "_cached_gates"):
                 if hasattr(gate, attr):
                     delattr(gate, attr)
         self._patched_gates = []

--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -38,6 +38,7 @@ class Probe(ABC):
         self.step_count = 0
         self.pp_rank = 0
         self._global_accum: dict[str, float] = {}
+        self._global_metric_counts: dict[str, int] = {}
         self._global_count: int = 0
 
     @abstractmethod
@@ -104,24 +105,32 @@ class Probe(ABC):
     def _is_max_aggregated(self, name: str) -> bool:
         return name in self.MAX_AGGREGATED
 
-    def _count_global_observation(self):
+    def _count_global_observation(self, metric_names: set[str] | None = None):
         """Count one complete layer observation for global averages."""
         if self.log_global:
             self._global_count += 1
+            if metric_names is None:
+                metric_names = set(self._global_accum)
+            for name in metric_names:
+                self._global_metric_counts[name] = self._global_metric_counts.get(name, 0) + 1
 
     def _flush_global_metrics(self):
         """Aggregate accumulated metrics into global keys and write to training_logs."""
         if self._global_count == 0:
             self._global_accum.clear()
+            self._global_metric_counts.clear()
             return
         log_dict = {}
         for name, val in self._global_accum.items():
             if self._is_max_aggregated(name) or name in self.MIN_AGGREGATED:
                 log_dict[f"{self.METRIC_PREFIX}/global_{name}"] = val
             else:
-                log_dict[f"{self.METRIC_PREFIX}/global_{name}"] = val / self._global_count
+                count = self._global_metric_counts.get(name, self._global_count)
+                if count > 0:
+                    log_dict[f"{self.METRIC_PREFIX}/global_{name}"] = val / count
         training_logs.update(**log_dict)
         self._global_accum = {}
+        self._global_metric_counts = {}
         self._global_count = 0
 
     def _resolve_layer_idx(self, layer, local_idx: int, num_local_layers: int, layer_offset: int = 0) -> int:

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -44,6 +44,20 @@ class CoreMonitoringTest(unittest.TestCase):
         self.assertEqual(latest["dummy/global_floor"], 1.0)
         self.assertEqual(probe._global_count, 0)
         self.assertEqual(probe._global_accum, {})
+        self.assertEqual(probe._global_metric_counts, {})
+
+    def test_sparse_global_metrics_use_per_metric_counts(self):
+        probe = DummyProbe(log_per_layer=False, log_global=True)
+
+        probe._accumulate_global({"common": 2.0, "sparse": 4.0})
+        probe._count_global_observation({"common", "sparse"})
+        probe._accumulate_global({"common": 6.0})
+        probe._count_global_observation({"common"})
+        probe.step()
+
+        latest = training_logs.get_latest(prefix="dummy")
+        self.assertEqual(latest["dummy/global_common"], 4.0)
+        self.assertEqual(latest["dummy/global_sparse"], 4.0)
 
     def test_log_flags_are_respected(self):
         probe = DummyProbe(log_per_layer=False, log_global=True)

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -20,6 +20,7 @@ PaddleMassiveActivationMonitor = importlib.import_module(
 ).PaddleMassiveActivationMonitor
 PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor").PaddleMoEMonitor
 PaddleQKStatsMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor").PaddleQKStatsMonitor
+layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
 training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
 
 
@@ -29,6 +30,27 @@ class BrokenPaddleMoELayer:
     @property
     def grouped_gemm_experts(self):
         raise RuntimeError("grouped expert read failed")
+
+
+class PaddleLayerDiscoveryTest(unittest.TestCase):
+    def test_get_decoder_layers_flattens_virtual_pipeline_chunks(self):
+        layer0 = SimpleNamespace(layer_idx=0)
+        layer1 = SimpleNamespace(layer_idx=1)
+        layer2 = SimpleNamespace(layer_idx=2)
+        model = SimpleNamespace(
+            _model_chunks=[
+                SimpleNamespace(run_function=[layer0, layer1]),
+                SimpleNamespace(run_function=[layer2]),
+            ]
+        )
+
+        self.assertEqual(layer_discovery.get_decoder_layers(model), [layer0, layer1, layer2])
+
+    def test_get_decoder_layers_checks_wrapped_module_after_empty_layers_wrapper(self):
+        layer = SimpleNamespace(layer_idx=0)
+        model = SimpleNamespace(_layers=SimpleNamespace(), module=SimpleNamespace(run_function=[layer]))
+
+        self.assertEqual(layer_discovery.get_decoder_layers(model), [layer])
 
 
 class PaddleMoEMonitorTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR fixes several PaddleFleet monitor edge cases around layer discovery, sparse metric aggregation, and hook cleanup.

## Changes

- Support virtual pipeline `_model_chunks` when discovering PaddleFleet decoder layers.
- Fall back to wrapped `model.module` when `model._layers` does not expose decoder layers.
- Track per-metric observation counts for legacy global aggregation, so sparse metrics are averaged only over layers that actually emitted them.
- Restore the original `_hash_routing` function in `remove_hooks()` after MoE monitor monkey-patching.