### PR TITLE
fix: cache PaddleFleet MoE gates and avoid duplicate monitor setup

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -16,6 +16,22 @@ _MONITOR_MAP = {
     "massive_act": setup_massive_activation_monitor,
 }
 
+_MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
+_MONITOR_CONFIG_ATTR = "_internal_medicine_paddlefleet_config"
+
+
+def _monitor_config(monitor_interval, verbose, options):
+    return {
+        "monitor_interval": monitor_interval,
+        "verbose": verbose,
+        "options": repr(sorted(options.items())),
+    }
+
+
+def _monitor_has_active_hooks(monitor):
+    hooks = getattr(monitor, "hooks", None)
+    return bool(hooks)
+
 
 def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, verbose=False, **kwargs):
     """Setup all requested monitors on a PaddleFleet model."""
@@ -28,18 +44,41 @@ def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, 
     if monitor_dict is None:
         monitor_dict = {}
 
+    model_monitor_dict = getattr(model, _MODEL_MONITOR_ATTR, None)
+    if model_monitor_dict is None:
+        model_monitor_dict = {}
+        setattr(model, _MODEL_MONITOR_ATTR, model_monitor_dict)
+
     for name in monitors:
         if name not in _MONITOR_MAP:
             logger.warning(f"[InternalMedicine/paddlefleet] Unknown monitor: {name}, skipping")
             continue
+        options = kwargs.get(name, {})
+        expected_config = _monitor_config(monitor_interval, verbose, options)
+        existing_monitor = model_monitor_dict.get(name)
+        if existing_monitor is not None:
+            existing_config = getattr(existing_monitor, _MONITOR_CONFIG_ATTR, None)
+            if _monitor_has_active_hooks(existing_monitor) and existing_config == expected_config:
+                monitor_dict[name] = existing_monitor
+                logger.info(
+                    f"[InternalMedicine/paddlefleet] Monitor already enabled: {name}, skipping duplicate setup"
+                )
+                continue
+            existing_monitor.remove_hooks()
+            model_monitor_dict.pop(name, None)
+
         try:
             _MONITOR_MAP[name](
                 model,
                 monitor_dict=monitor_dict,
                 monitor_interval=monitor_interval,
                 verbose=verbose,
-                **kwargs.get(name, {}),
+                **options,
             )
+            monitor = monitor_dict.get(name)
+            if monitor is not None:
+                setattr(monitor, _MONITOR_CONFIG_ATTR, expected_config)
+                model_monitor_dict[name] = monitor
             logger.info(f"[InternalMedicine/paddlefleet] Enabled monitor: {name}")
         except Exception as e:
             logger.error(f"[InternalMedicine/paddlefleet] Failed to setup {name}: {e}")

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -201,8 +201,12 @@ class PaddleMoEMonitor(PaddleProbe):
 
             def cached_hash_routing(logits, flat_ids):
                 result = original_hash_routing(logits, flat_ids)
-                # _hash_routing computes scores internally (softmax/sigmoid on logits).
-                # Recompute here to cache the full [N, num_experts] score distribution.
+                if not monitor._should_monitor():
+                    gate._cached_gates = None
+                    return result
+
+                # _hash_routing computes scores internally. Recompute the full
+                # [N, num_experts] distribution so router metrics can use it.
                 import paddle.nn.functional as F
 
                 logits_fp32 = logits.cast("float32")
@@ -211,8 +215,11 @@ class PaddleMoEMonitor(PaddleProbe):
                     scores = F.softmax(logits_fp32, axis=-1)
                 elif scoring_func == "sigmoid":
                     scores = F.sigmoid(logits_fp32)
+                elif scoring_func == "sqrtsoftplus":
+                    scores = paddle.sqrt(F.softplus(logits_fp32) + 1e-20)
                 else:
-                    scores = F.softmax(logits_fp32, axis=-1)
+                    gate._cached_gates = None
+                    return result
                 gate._cached_gates = scores.detach()
                 return result
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -20,6 +20,7 @@ PaddleMassiveActivationMonitor = importlib.import_module(
 ).PaddleMassiveActivationMonitor
 PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor").PaddleMoEMonitor
 PaddleQKStatsMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor").PaddleQKStatsMonitor
+paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
 layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
 training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
 
@@ -30,6 +31,77 @@ class BrokenPaddleMoELayer:
     @property
     def grouped_gemm_experts(self):
         raise RuntimeError("grouped expert read failed")
+
+
+class DummyHook:
+    def __init__(self):
+        self.removed = False
+
+    def remove(self):
+        self.removed = True
+
+
+class DummyMonitor:
+    def __init__(self):
+        self.hooks = [DummyHook()]
+        self.removed = False
+
+    def remove_hooks(self):
+        self.removed = True
+        for hook in self.hooks:
+            hook.remove()
+        self.hooks = []
+
+
+class PaddleFleetSetupTest(unittest.TestCase):
+    def setUp(self):
+        self.original_monitor_map = dict(paddlefleet_backend._MONITOR_MAP)
+
+    def tearDown(self):
+        paddlefleet_backend._MONITOR_MAP.clear()
+        paddlefleet_backend._MONITOR_MAP.update(self.original_monitor_map)
+
+    def test_setup_monitors_reuses_existing_monitor_for_same_config(self):
+        created = []
+
+        def setup_dummy(_model, monitor_dict=None, **_kwargs):
+            monitor = DummyMonitor()
+            created.append(monitor)
+            monitor_dict["dummy"] = monitor
+
+        paddlefleet_backend._MONITOR_MAP.clear()
+        paddlefleet_backend._MONITOR_MAP["dummy"] = setup_dummy
+        model = SimpleNamespace()
+        first = {}
+        second = {}
+
+        paddlefleet_backend.setup_monitors(model, monitors=["dummy"], monitor_dict=first, monitor_interval=2)
+        paddlefleet_backend.setup_monitors(model, monitors=["dummy"], monitor_dict=second, monitor_interval=2)
+
+        self.assertEqual(len(created), 1)
+        self.assertIs(second["dummy"], first["dummy"])
+        self.assertFalse(first["dummy"].removed)
+
+    def test_setup_monitors_replaces_existing_monitor_when_config_changes(self):
+        created = []
+
+        def setup_dummy(_model, monitor_dict=None, **_kwargs):
+            monitor = DummyMonitor()
+            created.append(monitor)
+            monitor_dict["dummy"] = monitor
+
+        paddlefleet_backend._MONITOR_MAP.clear()
+        paddlefleet_backend._MONITOR_MAP["dummy"] = setup_dummy
+        model = SimpleNamespace()
+        first = {}
+        second = {}
+
+        paddlefleet_backend.setup_monitors(model, monitors=["dummy"], monitor_dict=first, monitor_interval=1)
+        paddlefleet_backend.setup_monitors(model, monitors=["dummy"], monitor_dict=second, monitor_interval=2)
+
+        self.assertEqual(len(created), 2)
+        self.assertTrue(first["dummy"].removed)
+        self.assertIs(second["dummy"], created[1])
 
 
 class PaddleLayerDiscoveryTest(unittest.TestCase):
@@ -106,6 +178,41 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
         # Should not crash; step should still work
         monitor.step()
+
+    def test_hash_routing_cache_supports_sqrtsoftplus(self):
+        monitor = PaddleMoEMonitor(log_per_layer=False, log_global=True, verbose=False)
+        logits = paddle.to_tensor([[0.0, 1.0]], dtype="float32")
+
+        def original_hash_routing(logits, flat_ids):
+            return "ok"
+
+        gate = SimpleNamespace(
+            gate_score_func=lambda logits: logits,
+            _hash_routing=original_hash_routing,
+            scoring_func="sqrtsoftplus",
+        )
+        monitor._patch_gate_cache(gate)
+
+        self.assertEqual(gate._hash_routing(logits, paddle.to_tensor([0], dtype="int64")), "ok")
+        expected = paddle.sqrt(paddle.nn.functional.softplus(logits) + 1e-20)
+        self.assertTrue(bool(paddle.allclose(gate._cached_gates, expected)))
+
+        monitor.remove_hooks()
+        self.assertIs(gate._hash_routing, original_hash_routing)
+
+    def test_hash_routing_cache_respects_monitor_interval(self):
+        monitor = PaddleMoEMonitor(log_per_layer=False, log_global=True, monitor_interval=2, verbose=False)
+        logits = paddle.to_tensor([[0.0, 1.0]], dtype="float32")
+        gate = SimpleNamespace(
+            gate_score_func=lambda logits: logits,
+            _hash_routing=lambda logits, flat_ids: "ok",
+            scoring_func="sigmoid",
+        )
+        monitor._patch_gate_cache(gate)
+        monitor.step_count = 1
+
+        self.assertEqual(gate._hash_routing(logits, paddle.to_tensor([0], dtype="int64")), "ok")
+        self.assertIsNone(gate._cached_gates)
 
 
 class PaddleMassiveActivationMonitorTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR fixes PaddleFleet MoE gate cache reliability by handling hash-routing gate scores correctly and avoiding duplicate monitor setup on the same model.

## Changes

- Cache `_hash_routing` gate scores only on active monitor steps.
- Support `sqrtsoftplus` scoring when recomputing cached hash-routing scores.
- Avoid falling back to an incorrect softmax cache for unsupported hash-routing scoring functions.
- Reuse already-enabled PaddleFleet monitors when the same monitor is set up again with the same config.
- Remove and recreate an existing monitor when its setup config changes.
- Restore patched gate functions and clear cached gate state during `remove_hooks()`.