### PR TITLE
[moe_monitor] feat: add expert load-balance metrics (max/min, max/med…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ setup_internal_medicine()
 | 11 | `expert_norm_max` | `moe_health/.../expert_norm_max` | `max(expert_L2_norms)` | 每层+全局 | 最大专家范数 |
 | 12 | `shared_expert_norm` | `moe_health/.../shared_expert_norm` | `\|\|shared_params\|\|₂` | 每层+全局 | 共享专家权重范数 |
 | 13 | `shared_routed_ratio` | `moe_health/.../shared_routed_ratio` | `shared_norm / routed_mean` | 每层+全局 | 共享/路由专家比例 |
+| 14 | `load_max_min_ratio` | `moe_health/.../load_max_min_ratio` | `max(tokens) / min(tokens)` | 每层+全局 | 最忙/最闲专家 token 数比值 |
+| 15 | `load_max_median_ratio` | `moe_health/.../load_max_median_ratio` | `max(tokens) / median(tokens)` | 每层+全局 | 最忙/中位专家 token 数比值 |
+| 16 | `load_cv` | `moe_health/.../load_cv` | `std(tokens) / mean(tokens)` | 每层+全局 | 专家负载变异系数 (均衡=0) |
+
+> **注**: 指标 14-16 (`load_*`) 仅在 `moe_router_enable_expert_bias=true` 时输出。
+> 它们复用 mcore 在 `get_updated_expert_bias` 中已做的 TPxCPxDP all-reduce
+> (每个 global batch 一次, 不在 forward hook 热路径上), 因此无需 monitor 侧
+> collective, 统计值已是全局正确值。
 
 ### 健康阈值
 
@@ -303,6 +311,9 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **MoE** | `expert_norm_max` | `max(L2)` | max | 不应过载 |
 | **MoE** | `shared_expert_norm` | `\|\|shared\|\|₂` | mean | 稳定 |
 | **MoE** | `shared_routed_ratio` | `shared/routed` | mean | 0.3 ~ 3.0 OK |
+| **MoE** | `load_max_min_ratio` | `max/min(tokens)` | mean | 越接近 1 越均衡 (仅 expert_bias) |
+| **MoE** | `load_max_median_ratio` | `max/median(tokens)` | mean | 越接近 1 越均衡 (仅 expert_bias) |
+| **MoE** | `load_cv` | `std/mean(tokens)` | mean | 越接近 0 越均衡 (仅 expert_bias) |
 | **QK** | `max` | `max(QK^T/√d)` | max | 不应暴增 |
 | **QK** | `mean` | `mean(logits)` | mean | 稳定 |
 | **QK** | `entropy_avg` | `-Σ(p log p)` avg | mean | 适中 |

--- a/src/internal_medicine/backends/megatron/base.py
+++ b/src/internal_medicine/backends/megatron/base.py
@@ -57,8 +57,11 @@ class TorchProbe(Probe):
         self.hook_timing_enabled = hook_timing_enabled
         self._hook_timing: dict[str, tuple[int, float]] = {}
 
-    def _should_monitor(self) -> bool:
-        if not torch.is_grad_enabled():
+    def _should_monitor(self, in_forward: bool = True) -> bool:
+        # in_forward=False lets off-forward callers (e.g. the expert-bias update
+        # at finalize_model_grads time) keep the interval gate without the
+        # recompute-pass grad guard, which only makes sense inside a forward.
+        if in_forward and not torch.is_grad_enabled():
             return False
         return super()._should_monitor()
 

--- a/src/internal_medicine/backends/megatron/moe_metrics.py
+++ b/src/internal_medicine/backends/megatron/moe_metrics.py
@@ -100,6 +100,52 @@ def compute_bias_affinity_jaccard(
     return intersection / union.clamp(min=1e-8)
 
 
+def compute_load_balance_ratios(tokens_per_expert: torch.Tensor) -> dict[str, torch.Tensor] | None:
+    """专家负载极值比值, 基于已 all-reduce 的 tokens-per-expert.
+
+    输入是 mcore 在 get_updated_expert_bias 里跨 TPxCPxDP all-reduce 之后的
+    全局 per-expert token 计数 (每张卡上都相同), 因此这里算出的比值本身就是全局
+    正确值, 无需 monitor 侧 collective, 也无需 training_logs 跨 rank 聚合.
+
+    对每一层 (行) 计算:
+      - load_max_min_ratio    = #tokens(most-routed) / #tokens(least-routed)
+      - load_max_median_ratio = #tokens(most-routed) / #tokens(median expert)
+      - load_cv               = std(counts) / mean(counts)  (变异系数, 完全均衡=0)
+
+    median 用 torch.median (偶数个专家时取下中位, 即某个真实专家的计数, 不做插值).
+    极值比值分母 clamp(min=1.0) 防止死专家 (count=0) 产生 inf/NaN. CV 用 population
+    std (unbiased=False) 除以 mean, mean clamp(min=1.0) 防止空批次除零. 全程 GPU
+    tensor, 不在 hot path 上运行 (调用点在 finalize_model_grads, forward hook 之外).
+
+    Args:
+        tokens_per_expert: reduced counts. [num_layers, num_experts] (stacked)
+            or [num_experts] (single layer). Last dim is the expert axis.
+
+    Returns:
+        Dict of per-layer 0-dim/1-dim tensors keyed by metric name (shape matches
+        the leading layer dim), or None if the expert axis has < 2 experts.
+    """
+    counts = tokens_per_expert.to(torch.float32)
+    if counts.dim() == 1:
+        counts = counts.unsqueeze(0)
+    if counts.dim() != 2 or counts.shape[-1] < 2:
+        return None
+
+    max_count = counts.max(dim=-1).values
+    min_count = counts.min(dim=-1).values
+    median_count = counts.median(dim=-1).values
+    # Population std (unbiased=False): with the global per-expert totals this is
+    # the exact CV, not a sample estimate. Balanced load -> std=0 -> CV=0.
+    mean_count = counts.mean(dim=-1)
+    std_count = counts.std(dim=-1, unbiased=False)
+
+    return {
+        "load_max_min_ratio": max_count / min_count.clamp(min=1.0),
+        "load_max_median_ratio": max_count / median_count.clamp(min=1.0),
+        "load_cv": std_count / mean_count.clamp(min=1.0),
+    }
+
+
 def compute_expert_norms(expert_weights: list[torch.Tensor]) -> dict[str, torch.Tensor]:
     """
     计算 Expert Norms (专家权重L2范数).

--- a/src/internal_medicine/backends/megatron/moe_monitor.py
+++ b/src/internal_medicine/backends/megatron/moe_monitor.py
@@ -5,6 +5,7 @@ Migrated from src/internal_medicine/moe_specialist/.
 
 import logging
 import weakref
+from importlib import import_module
 from typing import Any
 
 import torch
@@ -15,6 +16,7 @@ from .base import TorchProbe
 from .moe_metrics import (
     compute_bias_affinity_jaccard,
     compute_expert_norms,
+    compute_load_balance_ratios,
     compute_router_entropy,
     compute_shared_expert_norm,
     compute_shared_routed_ratio,
@@ -22,6 +24,11 @@ from .moe_metrics import (
 )
 
 logger = logging.getLogger(__name__)
+
+# `megatron.core.distributed` exposes a *function* named `finalize_model_grads`
+# that shadows the submodule of the same name, so `from ... import
+# finalize_model_grads` binds the function. Fetch the module object explicitly.
+_finalize_model_grads = import_module("megatron.core.distributed.finalize_model_grads")
 
 
 _ROUTER_METRICS = (
@@ -32,6 +39,17 @@ _ROUTER_METRICS = (
     "expert_bias_mean",
     "expert_bias_std",
     "bias_affinity_jaccard",
+)
+
+# Emitted only when moe_router_enable_expert_bias is on. mcore already
+# all-reduces tokens-per-expert across TPxCPxDP inside get_updated_expert_bias
+# (once per global batch, off the hot path); we piggyback on that reduced
+# tensor rather than adding any monitor-side collective. See
+# _patch_expert_bias_update / _record_load_balance_metrics.
+_LOAD_BALANCE_METRICS = (
+    "load_max_min_ratio",
+    "load_max_median_ratio",
+    "load_cv",
 )
 
 _EXPERT_METRICS = (
@@ -61,6 +79,12 @@ class MoESpecialistMonitor(TorchProbe):
         )
         self._monitored_moe_layers: list[tuple[int, weakref.ref]] = []
         self._patched_routers: list[weakref.ref] = []
+        # Populated in _prepare_layers when moe_router_enable_expert_bias is on.
+        # Maps the layer position within the stacked tokens_per_expert tensor
+        # (the order finalize_model_grads visits routers) to our layer_idx.
+        self._expert_bias_enabled = False
+        self._load_balance_layer_order: list[int] = []
+        self._orig_get_updated_expert_bias = None
 
     def register_hooks(self, model: nn.Module):
         self._init_parallel_state()
@@ -69,6 +93,7 @@ class MoESpecialistMonitor(TorchProbe):
             return
         self.allocate_buffers(next(model.parameters()).device)
         self._attach_hooks(targets)
+        self._patch_expert_bias_update()
 
     def _init_parallel_state(self):
         try:
@@ -87,9 +112,18 @@ class MoESpecialistMonitor(TorchProbe):
         if self.verbose:
             logger.info(f"[MoEMonitor] Found {len(moe_layers)} MoE layers.")
 
-        for layer_idx, _ in moe_layers:
+        for layer_idx, moe_layer in moe_layers:
             for name in (*_ROUTER_METRICS, *_EXPERT_METRICS):
                 self.declare_layer_metric(layer_idx, name)
+            # Load-balance ratios are only observable when expert-bias is on
+            # (mcore all-reduces tokens-per-expert only in that path). Declare
+            # them here so the schema is locked before allocate_buffers.
+            router = getattr(moe_layer, "router", None)
+            if router is not None and getattr(router, "enable_expert_bias", False):
+                self._expert_bias_enabled = True
+                self._load_balance_layer_order.append(layer_idx)
+                for name in _LOAD_BALANCE_METRICS:
+                    self.declare_layer_metric(layer_idx, name)
         return moe_layers
 
     def _attach_hooks(self, targets: list[tuple[int, nn.Module]]):
@@ -103,6 +137,71 @@ class MoESpecialistMonitor(TorchProbe):
                 self.hooks.append(hook)
 
         logger.info(f"[MoEMonitor] Registered {len(self.hooks)} hooks on {len(targets)} layers.")
+
+    def _patch_expert_bias_update(self):
+        """Piggyback on mcore's per-global-batch expert-bias update to emit
+        load-balance ratios, without adding any monitor-side collective.
+
+        mcore's ``get_updated_expert_bias`` all-reduces the stacked
+        ``tokens_per_expert`` (``[num_bias_layers, num_experts]``) across
+        TPxCPxDP in-place, then throws it away. We wrap it: after the original
+        runs, the passed tensor holds the *global* counts, identical on every
+        rank, so ratios computed here need no cross-rank aggregation.
+
+        The stacking order in ``_update_router_expert_bias`` is the order
+        routers appear in ``model.modules()`` — the same order we recorded in
+        ``self._load_balance_layer_order`` while walking the layers.
+
+        NOTE: ``finalize_model_grads`` binds the function via
+        ``from ..moe_utils import get_updated_expert_bias`` at import time, so it
+        holds its own module-level reference. We must rebind the name in the
+        *caller's* namespace, not in ``moe_utils``, or the wrapper never fires.
+        """
+        if not self._expert_bias_enabled:
+            return
+        fmg = _finalize_model_grads
+        if getattr(fmg.get_updated_expert_bias, "_im_patched", False):
+            return
+
+        original = fmg.get_updated_expert_bias
+        monitor = self
+
+        def patched(tokens_per_expert, expert_bias, expert_bias_update_rate, *args, **kwargs):
+            updated = original(tokens_per_expert, expert_bias, expert_bias_update_rate, *args, **kwargs)
+            # `tokens_per_expert` has been all-reduced in-place by `original`.
+            # in_forward=False: the update runs at finalize_model_grads time,
+            # outside any forward, so skip the recompute grad guard but keep the
+            # monitor-interval gate.
+            try:
+                if monitor._should_monitor(in_forward=False):
+                    monitor._record_load_balance_metrics(tokens_per_expert.detach())
+            except Exception as e:
+                if monitor.verbose:
+                    logger.error(f"[MoEMonitor] load-balance metric error: {e}")
+            return updated
+
+        patched._im_patched = True
+        patched._im_original = original
+        fmg.get_updated_expert_bias = patched
+        self._orig_get_updated_expert_bias = (fmg, original)
+        if self.verbose:
+            logger.info(
+                f"[MoEMonitor] Patched get_updated_expert_bias for "
+                f"{len(self._load_balance_layer_order)} bias-enabled layers."
+            )
+
+    def _record_load_balance_metrics(self, tokens_per_expert: torch.Tensor):
+        ratios = compute_load_balance_ratios(tokens_per_expert)
+        if ratios is None:
+            return
+        max_min = ratios["load_max_min_ratio"]
+        max_median = ratios["load_max_median_ratio"]
+        load_cv = ratios["load_cv"]
+        n = min(max_min.shape[0], len(self._load_balance_layer_order))
+        for row, layer_idx in zip(range(n), self._load_balance_layer_order[:n], strict=False):
+            self.record_layer_metric(layer_idx, "load_max_min_ratio", max_min[row])
+            self.record_layer_metric(layer_idx, "load_max_median_ratio", max_median[row])
+            self.record_layer_metric(layer_idx, "load_cv", load_cv[row])
 
     def _patch_router_cache(self, router):
         if not hasattr(router, "_apply_aux_loss"):
@@ -204,11 +303,11 @@ class MoESpecialistMonitor(TorchProbe):
                     logger.error(f"[MoEMonitor] Step expert-metric error layer {layer_idx}: {e}")
 
     def step(self):
-        # Bypass TorchProbe._should_monitor's torch.is_grad_enabled() guard:
-        # that guard exists to skip recompute-pass forward hooks, but step()
-        # runs outside any forward and a caller-side no_grad wrapper must not
-        # silently disable expert-weight metrics.
-        if self.step_count % self.monitor_interval == 0:
+        # in_forward=False: step() runs outside any forward, so we want the
+        # monitor-interval gate without _should_monitor's recompute grad guard
+        # (a caller-side no_grad wrapper must not silently disable expert-weight
+        # metrics). Same reason the expert-bias update uses in_forward=False.
+        if self._should_monitor(in_forward=False):
             self._compute_expert_metrics_for_all_layers()
         super().step()
 
@@ -285,6 +384,11 @@ class MoESpecialistMonitor(TorchProbe):
 
     def remove_hooks(self):
         super().remove_hooks()
+        if self._orig_get_updated_expert_bias is not None:
+            fmg, original = self._orig_get_updated_expert_bias
+            if getattr(fmg.get_updated_expert_bias, "_im_patched", False):
+                fmg.get_updated_expert_bias = original
+            self._orig_get_updated_expert_bias = None
         for router_ref in self._patched_routers:
             router = router_ref()
             if router is None:
@@ -341,6 +445,8 @@ def setup_moe_monitor(
         monitor.allocate_buffers(device)
         for _, targets in chunk_targets:
             monitor._attach_hooks(targets)
+        # Idempotent global patch; call once after all chunks' schemas are locked.
+        monitor._patch_expert_bias_update()
     logger.info(f"[MoEMonitor] Setup complete. Monitoring {len(monitor.hooks)} hooks.")
     if monitor_dict is not None:
         monitor_dict["moe_health"] = monitor

--- a/tests/test_megatron_monitors.py
+++ b/tests/test_megatron_monitors.py
@@ -97,6 +97,77 @@ class MegatronMoEMonitorTest(unittest.TestCase):
         self.assertIn("moe_health/layer_0/expert_norm_mean", latest)
         self.assertIn("moe_health/global_expert_norm_mean", latest)
 
+    def test_load_balance_metrics_from_reduced_tokens_per_expert(self):
+        # Two bias-enabled layers, recorded in the order finalize_model_grads
+        # stacks them. tokens_per_expert is the ALREADY-reduced global count.
+        monitor = MoESpecialistMonitor(log_per_layer=True, log_global=True)
+        monitor._expert_bias_enabled = True
+        monitor._load_balance_layer_order = [0, 1]
+        for layer_idx in (0, 1):
+            for name in moe_monitor_module._LOAD_BALANCE_METRICS:
+                monitor.declare_layer_metric(layer_idx, name)
+        monitor.allocate_buffers(torch.device("cpu"))
+
+        # layer 0: [5,3,2,2] -> max/min=5/2=2.5, max/median=5/2=2.5
+        # layer 1: [10,0,4,6] -> max/min=10/1(clamp)=10, max/median=10/4=2.5
+        reduced = torch.tensor([[5.0, 3.0, 2.0, 2.0], [10.0, 0.0, 4.0, 6.0]])
+        monitor._record_load_balance_metrics(reduced)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/load_max_min_ratio"], 2.5, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_1/load_max_min_ratio"], 10.0, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_0/load_max_median_ratio"], 2.5, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_1/load_max_median_ratio"], 2.5, places=5)
+        # CV = population std / mean. layer 0 mean=3, std=sqrt(((2)+(0)+(1)+(1))/4)=sqrt(1.5)
+        self.assertAlmostEqual(latest["moe_health/layer_0/load_cv"], (1.5**0.5) / 3.0, places=5)
+        self.assertIn("moe_health/global_load_max_min_ratio", latest)
+        self.assertIn("moe_health/global_load_cv", latest)
+
+    def test_load_balance_metrics_absent_without_expert_bias(self):
+        # When no router has expert-bias enabled, the metric must not be
+        # declared (schema stays clean) — nothing to record or patch.
+        monitor = MoESpecialistMonitor(log_per_layer=True, log_global=True)
+        self.assertFalse(monitor._expert_bias_enabled)
+        self.assertEqual(monitor._load_balance_layer_order, [])
+        # Idempotent no-op when expert-bias is off.
+        monitor._patch_expert_bias_update()
+        self.assertIsNone(monitor._orig_get_updated_expert_bias)
+
+    def test_expert_bias_patch_rebinds_caller_and_fires(self):
+        # The wrapper must rebind the name in finalize_model_grads (the caller),
+        # observe the reduced tokens_per_expert, and unpatch cleanly.
+        fmg = moe_monitor_module._finalize_model_grads
+        original = fmg.get_updated_expert_bias
+        # Stub the underlying update so the test needs no distributed group:
+        # the real fn all-reduces tokens_per_expert, which requires dist init.
+        # Our wrapper only cares that the tensor it receives is the reduced one.
+        fmg.get_updated_expert_bias = lambda tpe, bias, rate, *a, **k: bias
+
+        monitor = MoESpecialistMonitor(log_per_layer=True, log_global=True)
+        monitor._expert_bias_enabled = True
+        monitor._load_balance_layer_order = [0]
+        for name in moe_monitor_module._LOAD_BALANCE_METRICS:
+            monitor.declare_layer_metric(0, name)
+        monitor.allocate_buffers(torch.device("cpu"))
+
+        try:
+            monitor._patch_expert_bias_update()
+            self.assertTrue(getattr(fmg.get_updated_expert_bias, "_im_patched", False))
+
+            # Caller hands the wrapper an ALREADY-reduced count row.
+            tokens = torch.tensor([[6.0, 2.0, 3.0, 3.0]])  # max/min=6/2=3, max/median=6/3=2
+            bias = torch.zeros_like(tokens)
+            fmg.get_updated_expert_bias(tokens, bias, 0.0)
+            monitor.step()
+
+            latest = training_logs.get_latest(prefix="moe_health")
+            self.assertAlmostEqual(latest["moe_health/layer_0/load_max_min_ratio"], 3.0, places=5)
+            self.assertAlmostEqual(latest["moe_health/layer_0/load_max_median_ratio"], 2.0, places=5)
+        finally:
+            monitor.remove_hooks()
+            fmg.get_updated_expert_bias = original
+
 
 class MegatronPLEMonitorTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
加 moe 均衡性统计。
开启`moe_routing_bias`  时候才有用。实在不想开可以给一个 0 的 update 系数