### PR TITLE
qk_stats_kernel: causal short-circuit + drop ieee precision

### DIFF
--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -91,7 +91,12 @@ def qk_stats_kernel(
         row_sum_logit_raw = tl.zeros([BLOCK_M], dtype=tl.float32)
         row_count_raw = tl.zeros([BLOCK_M], dtype=tl.float32)
 
-        for n_start in range(0, seq_len, BLOCK_N):
+        if apply_causal_mask:
+            n_stop = tl.minimum(m_start + (BLOCK_M - 1) * ROW_STRIDE + BLOCK_N, seq_len)
+        else:
+            n_stop = seq_len
+
+        for n_start in range(0, n_stop, BLOCK_N):
             n_offsets = n_start + tl.arange(0, BLOCK_N)
             n_mask = n_offsets < seq_len
 
@@ -107,7 +112,7 @@ def qk_stats_kernel(
                 k_ptr = k_base + n_offsets[:, None] * stride_k_seq + k_offsets[None, :] * stride_k_dim
                 k = tl.load(k_ptr, mask=n_mask[:, None] & k_mask[None, :], other=0.0)
 
-                acc += tl.dot(q, tl.trans(k), input_precision="ieee")
+                acc += tl.dot(q, tl.trans(k))
 
             logits = acc * scale
 


### PR DESCRIPTION
### What
Two independent micro-optimizations to `qk_stats_kernel`:

1. **Causal N-loop short-circuit.** Under `apply_causal_mask=True`, the inner N loop previously scanned the full `seq_len`, even though blocks with `n_start` past the current M-block's rightmost row are fully masked out and contribute nothing. Tighten the upper bound to `n_stop`. This roughly halves the matmul work at long seq_len for causal attention.

2. **Drop `input_precision="ieee"` on `tl.dot`.** The old kernel forced IEEE fp32 accumulation, disabling TF32 tensor cores. Since the resulting logits feed only into monitor statistics (max / mean / entropy / sink), IEEE precision was unnecessary. Removing it lets the compiler pick the default TF32 path (2–4x faster `tl.dot`).

### Correctness
- **Causal short-circuit**: skipped N-blocks would have every element masked to `-1e10` and contribute zero to all accumulators (max / online-softmax / sink) — skipping them is bit-exact.
- **TF32 dot**: introduces at most ~1e-3 relative error on the fp32 accumulator, well below the noise floor of monitor metrics.