### PR TITLE
[fix] guard _should_monitor against None/0 monitor_interval。

### DIFF
--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -63,6 +63,8 @@ class Probe(ABC):
         return None
 
     def _should_monitor(self) -> bool:
+        if not self.monitor_interval:
+            return False
         return self.step_count % self.monitor_interval == 0
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fix `TypeError: unsupported operand type(s) for %: 'int' and 'NoneType'` in `_should_monitor` when `monitor_interval` is None/0. Treat falsy interval as "monitoring disabled".