### PR TITLE
feat(massive_act): add per-layer Lipschitz constant via backward grad…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 包含四大监控模块：
 - **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (13 指标)
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标)
-- **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (15 指标)
+- **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (17 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 
 ---
@@ -68,6 +68,7 @@ internal_medicine_monitors:
 `true` 表示启用该 monitor 并使用默认参数；嵌套 dict 会作为该 monitor 的 kwargs 透传，例如上面的 `massive_act` 等价于
 `setup_internal_medicine(..., massive_act={"log_activation_rms": False, "log_post_norm_metrics": False})`。
 `log_activation_rms` 统一控制残差尺度/增益一组指标（`activation_rms` + `spectral_norm_max/min`）——`activation_rms` 由 spectral hook 的 per-token pre-RMS 免费导出，故合用一个开关。
+`log_lipschitz`（默认 `true`）控制每层 Lipschitz/梯度增益指标（`lipschitz_max/min`）——由 forward hook 在输入/输出 hidden 上注册 tensor grad hook，在反向传播采集 `‖∂L/∂x‖/‖∂L/∂y‖`。
 list 形式仍兼容，但需要按 monitor 传参时不要再额外加 `internal_medicine_monitor_kwargs` 字段。
 
 ### 读取指标
@@ -216,6 +217,8 @@ setup_internal_medicine()
 | 13 | `post_norm_cosine` | `massive_act/.../post_norm_cosine` | `cos_sim(tokens)` | 每层+全局 | 近常量向量检测 |
 | 14 | `spectral_norm_max` | `massive_act/.../spectral_norm_max` | `max(post_rms / pre_rms)` | 每层+全局 | 层增益比上界，谱范数(σ_max)下界 |
 | 15 | `spectral_norm_min` | `massive_act/.../spectral_norm_min` | `min(post_rms / pre_rms)` | 每层+全局 | 层增益比下界，最小奇异值(σ_min)上界 |
+| 16 | `lipschitz_max` | `massive_act/.../lipschitz_max` | `max(‖∂L/∂x‖ / ‖∂L/∂y‖)` | 每层+全局 | 反向梯度增益上界，σ_max(J)下界 = Lipschitz 常数 |
+| 17 | `lipschitz_min` | `massive_act/.../lipschitz_min` | `min(‖∂L/∂x‖ / ‖∂L/∂y‖)` | 每层+全局 | 反向梯度增益下界，σ_min(J)上界 |
 
 ### 核心洞察
 
@@ -297,7 +300,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 
 ## 附录: 完整指标速查表
 
-共 44 个指标键 (13 MoE + 9 QK + 15 MassiveAct + 7 PLE)。
+共 46 个指标键 (13 MoE + 9 QK + 17 MassiveAct + 7 PLE)。
 
 | Monitor | 指标 | 公式 | SmoothedValue 模式 | 健康信号 |
 |---------|------|------|--------------------|----------|
@@ -341,6 +344,8 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **MassiveAct** | `post_norm_cosine` | `cos_sim(tokens)` | mean | 近常量向量检测 |
 | **MassiveAct** | `spectral_norm_max` | `max(post_rms / pre_rms)` | max | 谱范数(σ_max)下界 |
 | **MassiveAct** | `spectral_norm_min` | `min(post_rms / pre_rms)` | min | 最小奇异值(σ_min)上界 |
+| **MassiveAct** | `lipschitz_max` | `max(‖∂L/∂x‖ / ‖∂L/∂y‖)` | max | σ_max(J)下界 = Lipschitz 常数 |
+| **MassiveAct** | `lipschitz_min` | `min(‖∂L/∂x‖ / ‖∂L/∂y‖)` | min | σ_min(J)上界 |
 | **PLE** | `token_ple_norm` | `mean(\|\|token_ple\|\|₂)` | mean | 量级稳定 |
 | **PLE** | `proj_ple_norm` | `mean(\|\|proj × H^{-0.5}\|\|₂)` | mean | 与 token 分支匹配 |
 | **PLE** | `per_layer_inputs_norm` | `mean(\|\|(t+p)×2^{-0.5}\|\|₂)` | mean | 量级稳定 |

--- a/docs/massive_activation.md
+++ b/docs/massive_activation.md
@@ -1,6 +1,6 @@
 # Massive Activation Monitor
 
-**Residual Stream Massive Activation 健康监控模块**，监控 15 个核心指标。
+**Residual Stream Massive Activation 健康监控模块**，监控 17 个核心指标。
 
 基于论文发现实现：
 
@@ -229,6 +229,49 @@ spectral_norm_min = min_t(ratio_t)     # 在一个 global batch 内对所有 tok
 
 ---
 
+### 11. Lipschitz / Gradient-Gain Bounds (每层 Lipschitz 常数)
+
+**数学公式：**
+```
+dx_t = ∂L/∂x_t   (loss 对该层输入 hidden 的梯度)
+dy_t = ∂L/∂y_t   (loss 对该层输出 hidden 的梯度)
+ratio_t = ||dx_t|| / ||dy_t|| = ||Jᵀ dy_t|| / ||dy_t||   (每 token, sqrt(H) 约掉)
+lipschitz_max = max_t(ratio_t)   # 一个 global batch 内对所有 token 取 max
+lipschitz_min = min_t(ratio_t)   # 一个 global batch 内对所有 token 取 min
+```
+
+反向传播给出 `∂L/∂x = Jᵀ·∂L/∂y`（`J = ∂y/∂x` 为该层前向映射的 Jacobian）。因为 `J` 与
+`Jᵀ` 奇异值相同，每 token 的梯度增益比 `||dx_t||/||dy_t||` 即 `Jᵀ` 作用在观测梯度上的增益。
+在一个 global batch 内对所有 token 归约：
+
+- `lipschitz_max`（ratio 的最大值）是该层 **σ_max(J) 的下界** —— 即该层前向映射
+  **Lipschitz 常数的下界**：任意观测增益 ≤ `sup_v ||Jᵀv||/||v||`。
+- `lipschitz_min`（ratio 的最小值）是该层 **σ_min(J) 的上界**：任意观测增益 ≥ `inf_v ||Jᵀv||/||v||`。
+
+它同时直接刻画反向传播中的**梯度放大系数**：`lipschitz_max > 1` 表示梯度反向穿过该层时被放大
+（爆炸风险），`<< 1` 表示被压缩（消失风险）。
+
+**实现要点：**
+- 该指标是**反向**量，但由 forward hook 在层的输入/输出 hidden 张量上注册 tensor grad hook
+  （`.register_hook`）来采集 —— 因为 Megatron 以全 keyword 参数调用 layer，module 级
+  `register_full_backward_hook` 的 `grad_input` 为空，拿不到输入梯度。
+- forward hook 的 grad guard（`torch.is_grad_enabled()`）会跳过 activation recompute 的初始
+  no-grad 前向，只在 grad-enabled 的重算前向上注册，故 grad hook **恰好触发一次**（已在
+  reentrant / non-reentrant checkpoint 下验证）。
+- 输入/输出梯度均为完整 H 向量，每 token RMS 是真实全向量 RMS，**无需 TP 通道归约**；
+  max/min 跨 token-partition rank 由 `gather_and_aggregate()` 在 flush 时 `all_gather` +
+  max/min 合成，**hook 内无 collective**。
+- 每 token 分解忽略了 attention 的 token 耦合（真实 Jacobian 会混合 token），与前向
+  `spectral_norm` 指标做同样的简化近似。
+- 仅在训练反向传播的 monitored step 记录（eval/inference 下 `requires_grad=False` 会跳过）；
+  被 CUDA graph 捕获的层不触发 eager hook，因而不产出该指标。
+
+**诊断意义：**
+- `lipschitz_max` 持续 > 1 且上升 → 该层反向放大梯度，谱范数/Lipschitz 增大，关注梯度爆炸与训练稳定性
+- `lipschitz_min` 远小于 1 → 该层对部分方向强烈压缩梯度，关注梯度消失
+
+---
+
 ## 健康阈值参考
 
 | 指标 | 值 | 状态 | 说明 |
@@ -255,6 +298,10 @@ spectral_norm_min = min_t(ratio_t)     # 在一个 global batch 内对所有 tok
 | | 持续 > 1 且上升 | WARNING | 层放大残差流，关注 spike/训练稳定性 |
 | `spectral_norm_min` | ~1.0 | NORMAL | 层增益接近恒等 |
 | | << 1.0 | WARNING | 对部分 token 强烈压缩 |
+| `lipschitz_max` | ~1.0 | NORMAL | 层 Jacobian 增益接近恒等 |
+| | 持续 > 1 且上升 | WARNING | 反向梯度放大，Lipschitz 增大，关注梯度爆炸 |
+| `lipschitz_min` | ~1.0 | NORMAL | 层 Jacobian 增益接近恒等 |
+| | << 1.0 | WARNING | 对部分方向强烈压缩梯度，关注梯度消失 |
 
 ---
 

--- a/src/internal_medicine/backends/megatron/massive_activation_metrics.py
+++ b/src/internal_medicine/backends/megatron/massive_activation_metrics.py
@@ -20,6 +20,11 @@ Core metrics:
     pre_layer_rms). The max ratio over the global batch lower-bounds the layer's
     spectral norm (largest singular value); the min ratio upper-bounds its
     smallest singular value.
+11. Lipschitz / Gradient-Gain Bounds — per-token backward gradient-gain ratio
+    (‖∂L/∂x‖ / ‖∂L/∂y‖). Since backprop gives ∂L/∂x = Jᵀ·∂L/∂y, this is the gain
+    of the layer Jacobian's transpose on the observed gradient; the max over the
+    global batch lower-bounds σ_max(J) (the layer's Lipschitz constant) and the
+    min upper-bounds σ_min(J). Captured in the backward pass (see the monitor).
 
 All metrics compute local values only; cross-rank aggregation is handled
 by training_logs.gather_and_aggregate().
@@ -94,6 +99,54 @@ def compute_spectral_norm_bounds(
     if include_activation_rms:
         metrics["activation_rms"] = pre_rms.square().mean().sqrt()
     return metrics
+
+
+def compute_grad_gain_bounds(
+    grad_in: torch.Tensor,
+    grad_out: torch.Tensor,
+    eps: float = 1e-8,
+) -> dict[str, torch.Tensor]:
+    """Per-token backward gradient-gain ratio (‖∂L/∂x‖ / ‖∂L/∂y‖) reduced to
+    max/min bounds on the layer's Jacobian singular values (its Lipschitz constant).
+
+    ``grad_in`` is the gradient of the loss w.r.t. the layer INPUT hidden states
+    (∂L/∂x); ``grad_out`` is the gradient w.r.t. the layer OUTPUT hidden states
+    (∂L/∂y). Backprop through the layer map ``f: x -> y`` gives ``∂L/∂x = Jᵀ·∂L/∂y``
+    with ``J = ∂y/∂x``, so per token
+
+        ``rms(grad_in_t) / rms(grad_out_t) == ‖∂L/∂x_t‖ / ‖∂L/∂y_t‖ == ‖Jᵀ dy_t‖ / ‖dy_t‖``
+
+    (the ``sqrt(H)`` cancels), the gain of ``Jᵀ`` on the observed gradient. Over all
+    tokens, and since ``J`` and ``Jᵀ`` share singular values:
+
+    - ``lipschitz_max`` (max ratio) lower-bounds ``σ_max(J)`` — the layer's spectral
+      norm, i.e. its Lipschitz constant: every observed gain is <= sup_v ‖Jᵀv‖/‖v‖.
+    - ``lipschitz_min`` (min ratio) upper-bounds ``σ_min(J)``: every observed gain is
+      >= inf_v ‖Jᵀv‖/‖v‖.
+
+    It also reads directly as the layer's gradient amplification in backprop:
+    ``lipschitz_max > 1`` => gradients grow passing backward through the layer
+    (explosion risk); ``<< 1`` => they shrink (vanishing risk).
+
+    Both inputs are the full-H hidden-state gradient ([S, B, H] or [B, S, H]); the RMS
+    is a true full-vector RMS, so no TP channel reduction is needed. The max/min compose
+    across token-partitioned ranks via ``training_logs.gather_and_aggregate``.
+
+    The per-token decomposition ignores the sequence coupling introduced by attention
+    (the true Jacobian mixes tokens); it is the same simplification the forward
+    ``compute_spectral_norm_bounds`` metric makes.
+
+    Returns 0-dim GPU tensors (no host sync).
+    """
+    gin = grad_in.reshape(-1, grad_in.shape[-1]).float()
+    gout = grad_out.reshape(-1, grad_out.shape[-1]).float()
+    in_rms = gin.square().mean(dim=-1).sqrt()
+    out_rms = gout.square().mean(dim=-1).sqrt()
+    ratio = in_rms / out_rms.clamp(min=eps)
+    return {
+        "lipschitz_max": ratio.max(),
+        "lipschitz_min": ratio.min(),
+    }
 
 
 def _nearest_quantile_from_sorted(sorted_values: torch.Tensor, q: float) -> torch.Tensor:

--- a/src/internal_medicine/backends/megatron/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/megatron/massive_activation_monitor.py
@@ -15,6 +15,7 @@ from .base import TorchProbe
 from .massive_activation_metrics import (
     DEFAULT_ABSOLUTE_THRESHOLDS,
     _threshold_key,
+    compute_grad_gain_bounds,
     compute_per_channel_max,
     compute_post_norm_cosine_stability,
     compute_post_norm_sparsity,
@@ -39,9 +40,11 @@ class MassiveActivationMonitor(TorchProbe):
         "activation_rms",
         "massive_act_channel_count",
         "spectral_norm_max",
+        "lipschitz_max",
     }
     MIN_AGGREGATED = {
         "spectral_norm_min",
+        "lipschitz_min",
     }
 
     def __init__(
@@ -58,6 +61,7 @@ class MassiveActivationMonitor(TorchProbe):
         absolute_thresholds: tuple[float, ...] = DEFAULT_ABSOLUTE_THRESHOLDS,
         log_post_norm_metrics: bool = True,
         log_activation_rms: bool = True,
+        log_lipschitz: bool = True,
         hook_timing_enabled: bool = False,
     ):
         super().__init__(
@@ -78,6 +82,13 @@ class MassiveActivationMonitor(TorchProbe):
         # per-token spectral-norm bounds. activation_rms is derived from the same
         # per-token pre-RMS the spectral hook computes, so they share one flag.
         self.log_activation_rms = log_activation_rms
+        # Per-layer Lipschitz constant estimate, captured in the backward pass: the
+        # per-token gradient-gain ratio ‖∂L/∂x‖/‖∂L/∂y‖ bounds the layer Jacobian's
+        # singular values (max -> σ_max lower bound = Lipschitz const; min -> σ_min
+        # upper bound). Rides a forward hook that registers tensor grad hooks on the
+        # input/output hidden states — module full_backward_hook cannot see the input
+        # grad because Megatron calls layers with all-keyword args.
+        self.log_lipschitz = log_lipschitz
         self.MAX_AGGREGATED = self.MAX_AGGREGATED | {
             f"channel_count_gt_{_threshold_key(t)}" for t in self.absolute_thresholds
         }
@@ -100,6 +111,8 @@ class MassiveActivationMonitor(TorchProbe):
             names.extend(["post_norm_sparsity", "post_norm_cosine"])
         if self.log_activation_rms:
             names.extend(["activation_rms", "spectral_norm_max", "spectral_norm_min"])
+        if self.log_lipschitz:
+            names.extend(["lipschitz_max", "lipschitz_min"])
         for t in self.absolute_thresholds:
             names.append(f"channel_count_gt_{_threshold_key(t)}")
         return tuple(names)
@@ -168,6 +181,17 @@ class MassiveActivationMonitor(TorchProbe):
                     self.timed_hook("spectral_norm", self._make_spectral_norm_hook(global_idx)), with_kwargs=True
                 )
                 self.hooks.append(spec_hook)
+            # Lipschitz / gradient-gain bounds are a backward-pass quantity, but we
+            # attach from a forward hook that registers tensor grad hooks on the input
+            # and output hidden states. A module full_backward_hook cannot recover the
+            # input gradient here (Megatron calls layers all-keyword, so grad_input is
+            # empty). The forward-hook grad guard also selects the recompute pass under
+            # activation checkpointing, so the grad hooks fire exactly once.
+            if self.log_lipschitz:
+                grad_hook = layer.register_forward_hook(
+                    self.timed_hook("grad_gain", self._make_grad_gain_hook(global_idx)), with_kwargs=True
+                )
+                self.hooks.append(grad_hook)
             registered += 1
         logger.info(f"[MassiveActMonitor] Registered {registered} hooks.")
 
@@ -276,6 +300,50 @@ class MassiveActivationMonitor(TorchProbe):
         for name, val in tensor_metrics.items():
             self.record_layer_metric(layer_idx, name, val)
 
+    def _make_grad_gain_hook(self, layer_idx: int):
+        """Forward hook that captures the layer's backward gradient-gain (Lipschitz).
+
+        It registers tensor grad hooks on the input (``pre``) and output (``post``)
+        hidden states. In the backward pass ``post``'s hook fires first (output->input)
+        and stashes ∂L/∂y; ``pre``'s hook then reads it and records the per-token ratio
+        ‖∂L/∂x‖/‖∂L/∂y‖ bounds. The per-invocation ``state`` dict isolates concurrent
+        microbatch/pipeline backwards.
+        """
+
+        def hook_fn(module, args, kwargs, output):
+            # _should_monitor() requires grad enabled, so the initial no-grad forward
+            # under activation recompute is skipped and only the recompute (grad-enabled)
+            # forward registers the grad hooks — they fire exactly once.
+            if not self._should_monitor():
+                return
+            try:
+                pre = self._extract_hidden_states(args, kwargs)
+                post = self._first_tensor(output)
+                if pre is None or post is None or not pre.requires_grad or not post.requires_grad:
+                    return
+
+                state: dict[str, torch.Tensor] = {}
+
+                def save_grad_out(grad):
+                    state["dy"] = grad.detach()
+
+                def record_grad_gain(grad):
+                    grad_out = state.pop("dy", None)
+                    if grad_out is None:
+                        return
+                    with torch.no_grad():
+                        tensor_metrics = compute_grad_gain_bounds(grad_in=grad.detach(), grad_out=grad_out)
+                    for name, val in tensor_metrics.items():
+                        self.record_layer_metric(layer_idx, name, val)
+
+                post.register_hook(save_grad_out)
+                pre.register_hook(record_grad_gain)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MassiveActMonitor] Grad-gain error at layer {layer_idx}: {e}")
+
+        return hook_fn
+
     def _compute_residual_metrics(self, layer_idx: int, hidden_states: torch.Tensor):
         per_channel_max = compute_per_channel_max(hidden_states)
         per_channel_max = self._aggregate_per_channel_max(per_channel_max)
@@ -336,6 +404,7 @@ def setup_massive_activation_monitor(
     absolute_thresholds: tuple[float, ...] = DEFAULT_ABSOLUTE_THRESHOLDS,
     log_post_norm_metrics: bool = True,
     log_activation_rms: bool = True,
+    log_lipschitz: bool = True,
     hook_timing_enabled: bool = False,
     monitor_dict: dict | None = None,
 ):
@@ -352,6 +421,7 @@ def setup_massive_activation_monitor(
         absolute_thresholds=absolute_thresholds,
         log_post_norm_metrics=log_post_norm_metrics,
         log_activation_rms=log_activation_rms,
+        log_lipschitz=log_lipschitz,
         hook_timing_enabled=hook_timing_enabled,
     )
 

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -83,6 +83,8 @@ class CoreMonitoringTest(unittest.TestCase):
             "massive_act/layer_0/activation_rms",
             "massive_act/layer_0/spectral_norm_max",
             "massive_act/global_spectral_norm_max",
+            "massive_act/layer_0/lipschitz_max",
+            "massive_act/global_lipschitz_max",
         ):
             self.assertTrue(training_logs._is_max_metric(key), key)
 
@@ -90,6 +92,8 @@ class CoreMonitoringTest(unittest.TestCase):
         for key in (
             "massive_act/layer_0/spectral_norm_min",
             "massive_act/global_spectral_norm_min",
+            "massive_act/layer_0/lipschitz_min",
+            "massive_act/global_lipschitz_min",
         ):
             self.assertTrue(training_logs._is_min_metric(key), key)
             self.assertFalse(training_logs._is_max_metric(key), key)

--- a/tests/test_megatron_monitors.py
+++ b/tests/test_megatron_monitors.py
@@ -304,6 +304,56 @@ class MegatronMassiveActivationMonitorTest(unittest.TestCase):
 
         self.assertTrue(torch.allclose(original, derived, rtol=0, atol=1e-6), f"{original} != {derived}")
 
+    def test_grad_gain_bounds_equal_scaled_gradients(self):
+        # grad_in = 2 * grad_out per token => the per-token ratio ‖dx‖/‖dy‖ is exactly
+        # 2.0 for every token, so both the Lipschitz max and min bound collapse to 2.0.
+        torch.manual_seed(0)
+        grad_out = torch.randn(5, 3, 4)  # [S, B, H]
+        grad_in = grad_out * 2.0
+
+        bounds = massive_activation_metrics.compute_grad_gain_bounds(grad_in, grad_out)
+
+        self.assertAlmostEqual(bounds["lipschitz_max"].item(), 2.0, places=5)
+        self.assertAlmostEqual(bounds["lipschitz_min"].item(), 2.0, places=5)
+
+    def test_grad_gain_hook_records_lipschitz_from_backward(self):
+        # End-to-end: a scalar-mul layer y = 2*x has ∂L/∂x = 2·∂L/∂y for any loss, so
+        # the backward-captured gradient-gain ratio is exactly 2.0 regardless of the
+        # gradient direction. This also proves the tensor grad-hook path fires and
+        # records (a module full_backward_hook would see an empty grad_input here,
+        # since the layer is called all-keyword like Megatron does).
+        monitor = MassiveActivationMonitor(
+            log_per_layer=True,
+            log_global=True,
+            log_post_norm_metrics=False,
+            log_activation_rms=False,
+            log_lipschitz=True,
+        )
+        for name in monitor._layer_metric_names():
+            monitor.declare_layer_metric(0, name)
+        monitor.allocate_buffers(torch.device("cpu"))
+
+        class ScalarMul(nn.Module):
+            def forward(self, hidden_states):
+                return hidden_states * 2.0, None  # (output, context) like a Megatron layer
+
+        layer = ScalarMul()
+        hook = layer.register_forward_hook(monitor._make_grad_gain_hook(0), with_kwargs=True)
+
+        x = torch.randn(3, 2, 4, requires_grad=True)  # [S, B, H]
+        out, _ = layer(hidden_states=x)  # all-keyword call, as the Megatron block does
+        out.sum().backward()
+        hook.remove()
+
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="massive_act")
+        for key in ("lipschitz_max", "lipschitz_min"):
+            self.assertIn(f"massive_act/layer_0/{key}", latest)
+            self.assertIn(f"massive_act/global_{key}", latest)
+        self.assertAlmostEqual(latest["massive_act/layer_0/lipschitz_max"], 2.0, places=5)
+        self.assertAlmostEqual(latest["massive_act/layer_0/lipschitz_min"], 2.0, places=5)
+
 
 class SinkHeadClassificationTest(unittest.TestCase):
     """The gap computation is branchless to avoid a GPU->CPU sync on the hot


### PR DESCRIPTION
1. 理论动机 (Motivation)
Muon 中的观察，引出了一个问题：如何更准确地刻画模型对输入信号的放大倍数？如果能监控到这个性质，就能想办法降低放大倍数从而改善每一层的信号传递。
为了监控和保证深层 Transformer 架构的训练稳定性，我们需要界定网络层的利普希茨常数 (Lipschitz Constant) ‭$K$‬。对于非线性算子，它等价于其雅可比矩阵谱范数在全局空间的上确界：
‭$K = \sup_{x} \|J(x)\|_2$‬‭‬‭‬‭‬‭‬‭‬‭‬
由于计算超高维非线性系统的完整雅可比矩阵 ‭$J(x)$‬‭‬‭‬‭‬ 在数学与物理上均不可行，我们需要寻找一种绕过显式矩阵实例化的理论逼近方法。

2. 核心数学转化 (Mathematical Transformation)

本方案的核心思想是将“前向扰动”转化为“反向梯度”的观测。
根据反向传播的链式法则，损失函数对输入的梯度 ‭$dx$‬ 与对输出的梯度 ‭$dy$‬ 满足以下线性映射关系：
‭$dx = J(x)^T dy$‬‭‬‭‬‭‬‭‬
基于线性代数中奇异值分解的性质，矩阵及其转置的谱范数（最大奇异值）严格相等：
‭$\|J(x)\|_2 \equiv \|J(x)^T\|_2$‬‭‬‭‬‭‬‭‬‭‬‭‬‭‬‭‬‭‬
利用算子范数的定义，对于空间中的任意非零梯度向量 ‭$dy$‬，其拉伸比值必然小于或等于最大拉伸率（即谱范数）：
‭$\|J(x)^T\|_2 = \max_{v \neq 0} \frac{\|J(x)^T v\|_2}{\|v\|_2} \ge \frac{\|J(x)^T dy\|_2}{\|dy\|_2} = \frac{\|dx\|_2}{\|dy\|_2}$‬‭‬‭‬‭‬‭‬‭‬‭‬‭‬‭‬
这证明了：单次反向传播中输入与输出梯度的 L2 范数之比 ‭$\frac{\|dx\|_2}{\|dy\|_2}$‬，构成了该特定输入点局部雅可比谱范数的严格数学下界。

3. 数据流形上的统计逼近 (Statistical Approximation)

为了从局部谱范数推广到逼近全局利普希茨常数 ‭$K$‬，我们采用基于数据流形的蒙特卡洛统计估计。
通过在足够大的全局批次 (Global Batch Size, GBS) 中遍历真实数据样本，我们定义经验利普希茨常数：
‭$K_{\text{empirical}} = \max_{x \in \text{GBS}} \frac{\|dx\|_2}{\|dy\|_2}$‬‭‬‭‬
思想总结：
虽然统计推断无法穷尽整个 ‭$\mathbb{R}^d$‬ 空间得出绝对的理论上界（‭$K_{\text{empirical}} \le K_{\text{global}}$‬‭‬），但它利用了真实损失地形（Loss Landscape）指引的梯度方向作为“试探向量”。这种方法在纯粹的数学意义上，精准提取了网络在当前真实数据流形上所经历的最大相对形变率，成为零算力成本下刻画非线性动力学稳定性的最紧致经验下界。

3. 代码实现