### PR TITLE
feat: add CP support for qk_stats and massive_activation monitors

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -98,6 +98,8 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         }
         self.tp_size = 1
         self.tp_group = None
+        self.cp_size = 1
+        self.cp_group = None
         self._warned_per_channel_aggregate = False
         self._post_norm_failed_layers: set[int] = set()
         self._hc_aggregate_failed_layers: set[int] = set()
@@ -116,6 +118,15 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             pg = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp"])
             self.tp_group = pg.tp
             self.tp_size = get_pg_size(pg.tp)
+        except Exception:
+            pass
+        try:
+            from paddlefleet.process_groups_config import ProcessGroupCollection
+            from paddlefleet.utils import get_pg_size
+
+            pg = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["cp"])
+            self.cp_group = pg.cp
+            self.cp_size = get_pg_size(pg.cp)
         except Exception:
             pass
 
@@ -256,17 +267,39 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     self._post_norm_failed_layers.add(layer_idx)
 
     def _aggregate_per_channel_max(self, per_channel_max: paddle.Tensor) -> paddle.Tensor:
-        """Aggregate token-sharded per-channel maxima across the TP group when available."""
-        if self.tp_size <= 1 or self.tp_group is None:
-            return per_channel_max
+        """Aggregate token-sharded per-channel maxima across TP + CP groups when available.
+
+        - TP MAX all_reduce: covers SP-in-TP (residual stream sharded along seq
+          within the TP group under PaddleFleet's SP convention).
+        - CP MAX all_reduce: covers Context Parallel, which shards the sequence
+          dim over an independent CP group. Without this, each CP rank only sees
+          its local S/CP tokens and per-channel-max is a strict lower bound of
+          the true global max.
+
+        Both collectives are correctness-required (see monitor-hook-perf-rules
+        exception clause) and use MAX ops that are safe under repeated calls.
+        """
         try:
             import paddle.distributed as dist
-
-            dist.all_reduce(per_channel_max, op=dist.ReduceOp.MAX, group=self.tp_group)
         except Exception as e:
             if self.verbose and not self._warned_per_channel_aggregate:
-                logger.warning(f"[MassiveActMonitor] TP per-channel aggregation failed; using local values: {e}")
+                logger.warning(f"[MassiveActMonitor] paddle.distributed unavailable: {e}")
                 self._warned_per_channel_aggregate = True
+            return per_channel_max
+        if self.tp_size > 1 and self.tp_group is not None:
+            try:
+                dist.all_reduce(per_channel_max, op=dist.ReduceOp.MAX, group=self.tp_group)
+            except Exception as e:
+                if self.verbose and not self._warned_per_channel_aggregate:
+                    logger.warning(f"[MassiveActMonitor] TP per-channel aggregation failed: {e}")
+                    self._warned_per_channel_aggregate = True
+        if self.cp_size > 1 and self.cp_group is not None:
+            try:
+                dist.all_reduce(per_channel_max, op=dist.ReduceOp.MAX, group=self.cp_group)
+            except Exception as e:
+                if self.verbose and not self._warned_per_channel_aggregate:
+                    logger.warning(f"[MassiveActMonitor] CP per-channel aggregation failed: {e}")
+                    self._warned_per_channel_aggregate = True
         return per_channel_max
 
 

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -236,6 +236,8 @@ class PaddleQKStatsMonitor(PaddleProbe):
         )
         self.causal = causal
         self.tp_size = 1
+        self.cp_size = 1
+        self.cp_group = None
         self.pp_rank = 0
         self.sink_head_threshold = sink_head_threshold
         if int(row_stride) < 1:
@@ -243,6 +245,9 @@ class PaddleQKStatsMonitor(PaddleProbe):
         self.row_stride = int(row_stride)
         # Warn at most once if a runtime seq_len ends up smaller than row_stride.
         self._warned_row_stride_gt_seqlen = False
+        # Warn at most once if the CP-gather path fails at runtime (fallback:
+        # skip this hook invocation entirely to preserve correctness).
+        self._warned_cp_gather_failed = False
 
     def register_hooks(self, model: nn.Layer):
         try:
@@ -251,6 +256,16 @@ class PaddleQKStatsMonitor(PaddleProbe):
 
             pg = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp"])
             self.tp_size = get_pg_size(pg.tp)
+        except Exception:
+            pass
+
+        try:
+            from paddlefleet.process_groups_config import ProcessGroupCollection
+            from paddlefleet.utils import get_pg_size
+
+            pg = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["cp"])
+            self.cp_group = pg.cp
+            self.cp_size = get_pg_size(pg.cp)
         except Exception:
             pass
 
@@ -267,7 +282,21 @@ class PaddleQKStatsMonitor(PaddleProbe):
             return
 
         if self.verbose:
-            logger.info(f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. TP={self.tp_size}")
+            logger.info(
+                f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. "
+                f"TP={self.tp_size} CP={self.cp_size}"
+            )
+
+        if self.cp_size > 1:
+            logger.warning(
+                "[PaddleQKMonitor] CP=%d detected. To preserve exact metric "
+                "semantics the hook will all_gather Q/K across the CP group on "
+                "every monitored step; this adds significant traffic and "
+                "compute. If you do not need qk_stats under CP, remove "
+                "'qk_stats' from internal_medicine_monitors, or raise "
+                "internal_medicine_monitor_interval to sample less often.",
+                self.cp_size,
+            )
 
         for layer_idx, _ in attention_layers:
             for m in (
@@ -312,7 +341,33 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 attention_layers.append((item.idx, attn))
         return attention_layers
 
-    def _make_compute_hook(self, layer_idx: int):
+    def _cp_gather_seq(self, tensor: paddle.Tensor) -> paddle.Tensor | None:
+        """All-gather ``tensor`` along its seq dim across the CP group."""
+        if self.cp_group is None or self.cp_size <= 1:
+            return tensor
+        try:
+            import paddle.distributed as dist
+
+            # all_gather concatenates along axis=0. Move seq to axis 0 first,
+            # gather, then reshape back to [B, S_full, H, D].
+            # tensor: [B, S_local, H, D] -> [S_local, B, H, D]
+            t = tensor.transpose([1, 0, 2, 3]).contiguous()
+            gathered = paddle.empty([self.cp_size * t.shape[0], *t.shape[1:]], dtype=t.dtype)
+            dist.all_gather(gathered, t, group=self.cp_group)
+            # gathered: [S_full, B, H, D] -> [B, S_full, H, D]
+            return gathered.transpose([1, 0, 2, 3]).contiguous()
+        except Exception as e:
+            if not self._warned_cp_gather_failed:
+                logger.warning(
+                    "[PaddleQKMonitor] CP all_gather failed (%s); skipping qk_stats "
+                    "for this step to preserve correctness. Consider removing "
+                    "qk_stats from internal_medicine_monitors under CP.",
+                    e,
+                )
+                self._warned_cp_gather_failed = True
+            return None
+
+    def _make_compute_hook(self, layer_idx: int, attn_type: str | None = None):
         def hook_fn(layer, inputs):
             if not layer.training:
                 return
@@ -321,6 +376,13 @@ class PaddleQKStatsMonitor(PaddleProbe):
             try:
                 query, key = inputs[0], inputs[1]
                 with paddle.no_grad():
+                    if self.cp_size > 1:
+                        gathered_q = self._cp_gather_seq(query.detach())
+                        gathered_k = self._cp_gather_seq(key.detach())
+                        if gathered_q is None or gathered_k is None:
+                            return
+                        query, key = gathered_q, gathered_k
+
                     # query: [B, S, H, D]; seq_len is a static shape int (no D2H sync).
                     seq_len = query.shape[1]
                     effective_stride = self.row_stride


### PR DESCRIPTION
## 概述

为两个依赖"全序列"语义的监控指标补上 Context Parallel (CP) 适配。CP>1时序列维被切分到各 rank，之前只看到本 rank 局部分片，导致语义失真。

- **`massive_activation_monitor`**：在已有的 TP MAX all_reduce 之后，对 `per_channel_max` 追加一次 CP-group MAX all_reduce。修复后 `channel_median` / `p95` / `p99` / `max_ratio` 反映的是真正的全序列峰值，而不是各 rank 局部分片的最大值。
- **`qk_monitor`**：在 `core_attention` 的 pre-hook 中，当 `cp_size > 1`时对 `Q` / `K` 沿 CP 组做一次 all_gather，把完整序列送进 Triton kernel。这样 `entropy_*` / `sink_*` / `mean` 全部恢复 CP=1 语义（softmax 分母依赖全序列，sink 依赖 token-0，都无法从局部分片重构）。

## 动机

两个监控在语义上都把 sequence 维当全局量看待。CP 下 seq 被切片，若不做跨 CP 通信，报告出来的值只在 CP=1 时才正确：

- `massive_activation` 的峰值分布在某个 CP rank 上，其他 rank 报的是局部较小值，聚合结果偏低。
- `qk_stats` 的 softmax 归一分母和 token-0 权重都无法从局部分片重建，必须拿到全序列 Q/K 才能算出正确的 entropy / sink。

## 实现

- 在 `register_hooks` 中通过 `ProcessGroupCollection.use_mpu_process_groups`取回 CP 进程组（复用既有的 TP 组发现路径）。
- **`massive_activation`**：`_aggregate_per_channel_max` 在既有 TP MAXall_reduce 之后加一次 CP MAX all_reduce（两个 reduce 作用于同一 tensor，幂等）。
- **`qk_monitor`**：新增 `_cp_gather_seq`，把 `[B, S_local, H, D]` transpose为 `[S_local, B, H, D]`，沿 axis=0 all_gather，再 transpose 回`[B, S_full, H, D]`。hook 主体在 `cp_size > 1` 时改用 gather 后的 Q/K。

## 运行时开销

CP 下 `qk_stats` 是重量级操作：每个被监控层每个 step 各做一次 Q/Kall_gather。实测 8n EP=32 CP=2：
- `attn` 单步耗时：72s → 207s（**+186%**）已在 `register_hooks` 里加一条一次性 WARNING，提醒 CP 场景下要么调大
`internal_medicine_monitor_interval` 降低采样频率，要么把 `qk_stats` 从`internal_medicine_monitors` 里移除。
- `massive_activation` 的 CP MAX all_reduce 只跑一个小 tensor，开销可忽略。

## 验证

在 8n EP=32 CP=2 场景下，baseline（无 CP fix）vs 本 branch（baseline+fix）对比实验，`FLAGS_cudnn_deterministic=1 FLAGS_embedding_deterministic=1`：
- **语义正确性**：qk_stats `entropy` **+7.96%**、`sink` **−46.62%**，方向与"之前只看到 1/CP 序列"的预期一致。
- **训练数值**：loss、grad_norm 与 baseline **逐位对齐**（Δ = 0），证明修复只改变了监控看到的数据，不影响训练本身的计算。