### PR TITLE
[feat] Split window vs full attention statistics via attn_type tag

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -131,28 +131,41 @@ class PaddleProbe(Probe):
     # Convenience: declare/record using class-level aggregation rules
     # ------------------------------------------------------------------
 
-    def _layer_key(self, layer_idx: int, metric_name: str) -> str:
+    def _layer_key(self, layer_idx: int, metric_name: str, attn_type: str | None = None) -> str:
+        # Attention-type prefix (``swa_`` / ``full_``) goes on the metric name,
+        # not the layer number, so the viewer's ``layer_(\d+)/(sub)`` regex
+        # still matches and its per-(monitor, sub) grouping naturally splits
+        # window vs full charts. ``attn_type=None`` keeps the legacy key.
+        if attn_type is not None:
+            return f"{self.METRIC_PREFIX}/layer_{layer_idx}/{attn_type}_{metric_name}"
         return f"{self.METRIC_PREFIX}/layer_{layer_idx}/{metric_name}"
 
-    def _global_key(self, metric_name: str) -> str:
+    def _global_key(self, metric_name: str, attn_type: str | None = None) -> str:
+        if attn_type is not None:
+            return f"{self.METRIC_PREFIX}/global_{attn_type}_{metric_name}"
         return f"{self.METRIC_PREFIX}/global_{metric_name}"
 
     def _should_disable_explicit_key(self, key: str) -> bool:
         return key.startswith(f"{self.METRIC_PREFIX}/global_") and not self.log_global
 
-    def declare_layer_metric(self, layer_idx: int, metric_name: str) -> None:
+    def declare_layer_metric(self, layer_idx: int, metric_name: str, attn_type: str | None = None) -> None:
         """声明一个 per-layer 指标。
 
         1. 根据 MAX_AGGREGATED/MIN_AGGREGATED 选择聚合方式，注册 layer key
         2. 建立 layer_key → global_key 的分组映射，flush 时自动推导 global
+
+        ``attn_type`` (optional): when set (``"swa"`` / ``"full"``), the tag is
+        prepended to ``metric_name`` in both layer and global keys so the
+        viewer renders window vs full statistics in separate charts. When
+        ``None``, legacy key layout is preserved.
         """
         if not (self.log_per_layer or self.log_global):
             return
-        layer_key = self._layer_key(layer_idx, metric_name)
-        global_key = self._global_key(metric_name)
+        layer_key = self._layer_key(layer_idx, metric_name, attn_type=attn_type)
+        global_key = self._global_key(metric_name, attn_type=attn_type)
         all_declared = self._mean_keys | self._max_keys | self._min_keys
         assert global_key not in all_declared
-        # 根据类级别聚合规则选择 declare 方式
+        # 根据类级别聚合规则选择 declare 方式 (基于原始 metric_name，attn_type 不改变聚合语义)
         if self._is_max_aggregated(metric_name):
             agg = "max"
             if layer_key not in all_declared:
@@ -176,11 +189,13 @@ class PaddleProbe(Probe):
             assert existing[0] == agg
             existing[1].append(layer_key)
 
-    def record_layer_metric(self, layer_idx: int, metric_name: str, val: paddle.Tensor) -> None:
+    def record_layer_metric(
+        self, layer_idx: int, metric_name: str, val: paddle.Tensor, attn_type: str | None = None
+    ) -> None:
         """热路径：只写 per-layer 累加器，global 在 flush 时从各层推导。"""
         if not (self.log_per_layer or self.log_global):
             return
-        layer_key = self._layer_key(layer_idx, metric_name)
+        layer_key = self._layer_key(layer_idx, metric_name, attn_type=attn_type)
         if self._is_max_aggregated(metric_name):
             self.record_max(layer_key, val)
         elif metric_name in self.MIN_AGGREGATED:

--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -8,11 +8,17 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class MonitorLayer:
-    """A transformer layer together with its metric layer id."""
+    """A transformer layer together with its metric layer id and attention type."""
 
     idx: int
     layer: object
     is_mtp: bool = False
+    # Attention type tag for models that mix window / full attention (e.g. ernie-lite).
+    # ``"swa"`` for sliding-window layers, ``"full"`` for full-attention layers,
+    # ``None`` when the layer does not expose an ``is_swa`` flag (backward compat
+    # for eb5_v2 / dsv4). Monitors use this to split metric keys so window vs
+    # full statistics never mix in the same chart.
+    attn_type: str | None = None
 
 
 def _flatten_model_chunks(model) -> list[object] | None:
@@ -71,6 +77,30 @@ def unwrap_mtp_layer(layer):
     return getattr(layer, "transformer_layer", None) if is_mtp_wrapper(layer) else layer
 
 
+def classify_attn_type(layer) -> str | None:
+    """Classify a transformer layer as sliding-window or full attention.
+
+    Reads ``layer.self_attn.is_swa`` (or ``layer.self_attention.is_swa``) — a
+    boolean set at model init by the attention module. Returns:
+
+    - ``"swa"`` if the layer uses sliding-window attention
+    - ``"full"`` if the layer uses full attention
+    - ``None`` if the attention module does not expose ``is_swa`` (e.g.
+      eb5_v2 / dsv4 where all layers are homogeneous). Callers should treat
+      ``None`` as "do not tag metrics with attention type" so those models
+      keep their existing metric key layout.
+    """
+    attn = getattr(layer, "self_attn", None)
+    if attn is None:
+        attn = getattr(layer, "self_attention", None)
+    if attn is None:
+        return None
+    is_swa = getattr(attn, "is_swa", None)
+    if is_swa is None:
+        return None
+    return "swa" if is_swa else "full"
+
+
 def resolve_layer_idx(layer, local_idx: int, num_local_layers: int, pp_rank: int = 0, layer_offset: int = 0) -> int:
     """Resolve a PaddleFleet metric layer id without converting 0-based ids."""
     for attr in ("layer_idx", "layer_index", "idx", "layer_number"):
@@ -93,6 +123,10 @@ def iter_monitor_layers(
     ``wrapper.transformer_layer``. Pipeline ``run_function`` also contains
     embedding, norm, empty, and LM head entries, so MTP metric ids must be
     assigned after matched main transformer layers rather than physical entries.
+
+    Each returned ``MonitorLayer`` also carries an ``attn_type`` tag (see
+    :func:`classify_attn_type`) so monitors that emit attention-related
+    metrics can split window vs full statistics.
     """
     layers = list(layers)
     main_layers = [layer for layer in layers if not is_mtp_wrapper(layer)]
@@ -103,7 +137,9 @@ def iter_monitor_layers(
 
     for local_idx, layer in enumerate(matched_main_layers):
         idx = resolve_layer_idx(layer, local_idx, num_main_layers, pp_rank=pp_rank, layer_offset=layer_offset)
-        monitor_layers.append(MonitorLayer(idx=idx, layer=layer, is_mtp=False))
+        monitor_layers.append(
+            MonitorLayer(idx=idx, layer=layer, is_mtp=False, attn_type=classify_attn_type(layer))
+        )
 
     next_mtp_idx = max((item.idx for item in monitor_layers), default=layer_offset - 1) + 1
     for mtp_idx, wrapper in enumerate(mtp_wrappers):
@@ -111,6 +147,8 @@ def iter_monitor_layers(
         if not matches(layer):
             continue
         idx = next_mtp_idx + mtp_idx
-        monitor_layers.append(MonitorLayer(idx=idx, layer=layer, is_mtp=True))
+        monitor_layers.append(
+            MonitorLayer(idx=idx, layer=layer, is_mtp=True, attn_type=classify_attn_type(layer))
+        )
 
     return monitor_layers

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -164,7 +164,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             if self.sample_layers and item.idx not in self.sample_layers:
                 continue
             for m in metric_names:
-                self.declare_layer_metric(item.idx, m)
+                self.declare_layer_metric(item.idx, m, attn_type=item.attn_type)
             registered += 1
 
         self.allocate_buffers()
@@ -172,12 +172,12 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         for item in monitor_layers:
             if self.sample_layers and item.idx not in self.sample_layers:
                 continue
-            hook = item.layer.register_forward_pre_hook(self._make_residual_hook(item.idx))
+            hook = item.layer.register_forward_pre_hook(self._make_residual_hook(item.idx, item.attn_type))
             self.hooks.append(hook)
 
         logger.info(f"[MassiveActMonitor] Registered {registered} hooks.")
 
-    def _make_residual_hook(self, layer_idx: int):
+    def _make_residual_hook(self, layer_idx: int, attn_type: str | None = None):
         def hook_fn(module, inputs):
             if not module.training:
                 return
@@ -189,7 +189,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     return
 
                 with paddle.no_grad():
-                    self._compute_and_log(layer_idx, hidden_states.detach(), module)
+                    self._compute_and_log(layer_idx, hidden_states.detach(), module, attn_type=attn_type)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[MassiveActMonitor] Error at layer {layer_idx}: {e}")
@@ -213,7 +213,9 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             return first
         return None
 
-    def _compute_and_log(self, layer_idx: int, hidden_states: paddle.Tensor, module: nn.Layer):
+    def _compute_and_log(
+        self, layer_idx: int, hidden_states: paddle.Tensor, module: nn.Layer, attn_type: str | None = None
+    ):
         # HyperConnection (e.g. DSv4): the residual stream is expanded to [..., n*h].
         hc = getattr(module, "self_attention_hyper_connection", None)
         analysis_input = hidden_states
@@ -241,9 +243,9 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         scale_stats = compute_activation_scale_stats(analysis_input)
 
         for name, val in stats.items():
-            self.record_layer_metric(layer_idx, name, val)
+            self.record_layer_metric(layer_idx, name, val, attn_type=attn_type)
         for name, val in scale_stats.items():
-            self.record_layer_metric(layer_idx, name, val)
+            self.record_layer_metric(layer_idx, name, val, attn_type=attn_type)
 
         norm_layer = getattr(module, "input_layernorm", None)
         if norm_layer is not None:
@@ -255,11 +257,13 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     layer_idx,
                     "post_norm_sparsity",
                     compute_post_norm_sparsity(normalized, epsilon=self.sparsity_epsilon),
+                    attn_type=attn_type,
                 )
                 self.record_layer_metric(
                     layer_idx,
                     "post_norm_cosine",
                     compute_post_norm_cosine_stability(normalized, num_sample_pairs=self.cosine_sample_pairs),
+                    attn_type=attn_type,
                 )
             except Exception as e:
                 if self.verbose and layer_idx not in self._post_norm_failed_layers:

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -298,7 +298,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 self.cp_size,
             )
 
-        for layer_idx, _ in attention_layers:
+        for layer_idx, _attn_module, attn_type in attention_layers:
             for m in (
                 "max",
                 "mean",
@@ -311,18 +311,20 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 "sink_head_max",
                 "sink_nonsink_gap",
             ):
-                self.declare_layer_metric(layer_idx, m)
+                self.declare_layer_metric(layer_idx, m, attn_type=attn_type)
 
         self.allocate_buffers()
 
-        for layer_idx, attn_module in attention_layers:
+        for layer_idx, attn_module, attn_type in attention_layers:
             if hasattr(attn_module, "core_attention"):
-                hook = attn_module.core_attention.register_forward_pre_hook(self._make_compute_hook(layer_idx))
+                hook = attn_module.core_attention.register_forward_pre_hook(
+                    self._make_compute_hook(layer_idx, attn_type)
+                )
                 self.hooks.append(hook)
 
         logger.info(f"[PaddleQKMonitor] Registered {len(self.hooks)} hooks.")
 
-    def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer]]:
+    def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer, str | None]]:
         def has_attention(layer):
             return hasattr(layer, "self_attn") or hasattr(layer, "self_attention")
 
@@ -338,7 +340,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
         for item in monitor_layers:
             attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
             if attn is not None:
-                attention_layers.append((item.idx, attn))
+                attention_layers.append((item.idx, attn, item.attn_type))
         return attention_layers
 
     def _cp_gather_seq(self, tensor: paddle.Tensor) -> paddle.Tensor | None:
@@ -404,19 +406,19 @@ class PaddleQKStatsMonitor(PaddleProbe):
                     stats = compute_qk_stats_paddle(query, key, causal=self.causal, row_stride=effective_stride)
 
                 all_heads = stats["entropy_per_head"]
-                self.record_layer_metric(layer_idx, "max", stats["max_global"])
-                self.record_layer_metric(layer_idx, "mean", stats["mean_global"])
-                self.record_layer_metric(layer_idx, "entropy_avg", stats["entropy_global"])
-                self.record_layer_metric(layer_idx, "sink", stats["sink_global"])
-                self.record_layer_metric(layer_idx, "entropy_min", all_heads.min())
-                self.record_layer_metric(layer_idx, "entropy_max", all_heads.max())
-                self.record_layer_metric(layer_idx, "entropy_std", all_heads.std())
+                self.record_layer_metric(layer_idx, "max", stats["max_global"], attn_type=attn_type)
+                self.record_layer_metric(layer_idx, "mean", stats["mean_global"], attn_type=attn_type)
+                self.record_layer_metric(layer_idx, "entropy_avg", stats["entropy_global"], attn_type=attn_type)
+                self.record_layer_metric(layer_idx, "sink", stats["sink_global"], attn_type=attn_type)
+                self.record_layer_metric(layer_idx, "entropy_min", all_heads.min(), attn_type=attn_type)
+                self.record_layer_metric(layer_idx, "entropy_max", all_heads.max(), attn_type=attn_type)
+                self.record_layer_metric(layer_idx, "entropy_std", all_heads.std(), attn_type=attn_type)
                 # sink_per_head: [B, H] — average across batch to get [H]
                 sink_per_head = stats["sink_per_head"]
                 sink_for_classify = sink_per_head.mean(axis=0) if sink_per_head.ndim > 1 else sink_per_head
                 sink_class = compute_sink_head_classification(sink_for_classify, threshold=self.sink_head_threshold)
                 for name, val in sink_class.items():
-                    self.record_layer_metric(layer_idx, name, val)
+                    self.record_layer_metric(layer_idx, name, val, attn_type=attn_type)
             except Exception as e:
                 logger.error(f"[PaddleQKMonitor] Error layer {layer_idx}: {e}")
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -124,6 +124,43 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
 
         self.assertEqual(layer_discovery.get_decoder_layers(model), [layer])
 
+    def test_classify_attn_type_reads_is_swa_flag(self):
+        """classify_attn_type returns swa/full based on self_attn.is_swa, None if absent."""
+        swa_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=True))
+        full_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
+        untagged_layer = SimpleNamespace(self_attn=SimpleNamespace())  # no is_swa
+        no_attn_layer = SimpleNamespace()  # no self_attn at all
+
+        self.assertEqual(layer_discovery.classify_attn_type(swa_layer), "swa")
+        self.assertEqual(layer_discovery.classify_attn_type(full_layer), "full")
+        self.assertIsNone(layer_discovery.classify_attn_type(untagged_layer))
+        self.assertIsNone(layer_discovery.classify_attn_type(no_attn_layer))
+
+    def test_classify_attn_type_falls_back_to_self_attention(self):
+        """Some models expose the module as ``self_attention`` instead of ``self_attn``."""
+        swa_layer = SimpleNamespace(self_attention=SimpleNamespace(is_swa=True))
+        self.assertEqual(layer_discovery.classify_attn_type(swa_layer), "swa")
+
+    def test_iter_monitor_layers_populates_attn_type_for_swa_and_full(self):
+        """MonitorLayer.attn_type is populated per layer for models that mix SWA and full."""
+        # Simulate ernie-lite: layer 0 full, layer 1 SWA, layer 2 full
+        full_layer_a = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
+        swa_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=True))
+        full_layer_b = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
+
+        result = layer_discovery.iter_monitor_layers(
+            [full_layer_a, swa_layer, full_layer_b], lambda layer: hasattr(layer, "self_attn")
+        )
+
+        self.assertEqual([item.attn_type for item in result], ["full", "swa", "full"])
+
+    def test_iter_monitor_layers_attn_type_is_none_for_backward_compat_models(self):
+        """Models without an is_swa flag (eb5_v2 / dsv4) must yield attn_type=None."""
+        layer = SimpleNamespace(self_attn=SimpleNamespace())  # no is_swa
+        result = layer_discovery.iter_monitor_layers([layer], lambda x: hasattr(x, "self_attn"))
+        self.assertEqual(len(result), 1)
+        self.assertIsNone(result[0].attn_type)
+
 
 class PaddleMoEMonitorTest(unittest.TestCase):
     def setUp(self):
@@ -165,6 +202,38 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         latest = training_logs.get_latest(prefix="moe_health")
         self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 3.0, places=4)
         self.assertAlmostEqual(latest["moe_health/global_score_sum_max"], 0.9, places=4)
+
+    def test_attn_type_tag_produces_typed_keys_and_split_global_aggregation(self):
+        """When declare/record_layer_metric receives attn_type, keys are
+        ``{prefix}/layer_N/{type}_{metric}`` and ``{prefix}/global_{type}_{metric}``.
+        SWA and full aggregate independently -- window vs full never mix.
+
+        MoE monitor is used here as a convenient concrete PaddleProbe subclass;
+        in production attn_type only flows through attention-family monitors.
+        """
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
+        # layer 0 is full, layer 1 is swa, layer 2 is full
+        monitor.declare_layer_metric(0, "router_entropy", attn_type="full")
+        monitor.declare_layer_metric(1, "router_entropy", attn_type="swa")
+        monitor.declare_layer_metric(2, "router_entropy", attn_type="full")
+        monitor.allocate_buffers()
+
+        monitor.record_layer_metric(0, "router_entropy", paddle.to_tensor(2.0), attn_type="full")
+        monitor.record_layer_metric(1, "router_entropy", paddle.to_tensor(10.0), attn_type="swa")
+        monitor.record_layer_metric(2, "router_entropy", paddle.to_tensor(4.0), attn_type="full")
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        # Per-layer keys carry the attn_type prefix on the metric name.
+        self.assertAlmostEqual(latest["moe_health/layer_0/full_router_entropy"], 2.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_1/swa_router_entropy"], 10.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_2/full_router_entropy"], 4.0, places=4)
+        # Global aggregations split by attn_type: SWA global uses only layer 1;
+        # full global averages layer 0 and layer 2. There is no untagged
+        # ``global_router_entropy`` when all layers are typed.
+        self.assertAlmostEqual(latest["moe_health/global_swa_router_entropy"], 10.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/global_full_router_entropy"], 3.0, places=4)
+        self.assertNotIn("moe_health/global_router_entropy", latest)
 
     def test_fused_expert_norm_matches_per_expert_concat_norm(self):
         """Vectorized per-expert norm equals the old concat([w1_i, w2_i]).norm()."""


### PR DESCRIPTION
Ernie-lite 通过 ``window_attn_skip_freq`` 混合了 sliding-window attention
(SWA) 层和 full-attention 层。SWA 层使用 128 token 的滑动窗口、不同的
num_key_value_heads 数量、以及不同的 sink-bias 行为，因此它们的 qk_stats
与 massive_activation 分布与 full-attention 层显著偏离。混在一起做聚合
会产生误导性的 global 曲线和层间混杂的 trace。

- ``layer_discovery.classify_attn_type`` 读取 ``layer.self_attn.is_swa``返回 ``"swa"`` / ``"full"`` / ``None``。向后兼容：eb5_v2 / dsv4 因缺失``is_swa`` 属性会拿到 ``None``，保留原有的 metric key 命名。
- ``MonitorLayer`` 新增 ``attn_type`` 字段，让 monitor 在 register 时把 tag 通过 hook closure 直接串下去，避免在 hot path 里重复分类。
- ``PaddleProbe._layer_key`` / ``_global_key`` / ``declare_layer_metric`` / ``record_layer_metric`` 接受 ``attn_type`` 参数。设置后 tag 会前缀到metric 名上（比如 ``qk_stats/layer_5/swa_entropy_avg`` ``qk_stats/global_swa_entropy_avg``）。这样 viewer 侧的 ``layer_(\d+)/(sub)`` 正则依然生效，per-(monitor, sub) 的分组会自动把两类 attention 拆到独立的图中，viewer 端零修改。
- ``PaddleQKStatsMonitor._find_attention_layers`` 返回三元组带上 attn_type；declare / record 调用把它一路串下去。
- ``PaddleMassiveActivationMonitor`` 的 register / hook / compute 流水线同样按此方式串 attn_type。