### PR TITLE
feat(paddlefleet): mark MTP layers in metric keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,14 @@ setup_internal_medicine()
 所有指标遵循统一的命名格式：
 
 ```
-{monitor_name}/layer_{global_idx}/{metric_name}    # 逐层指标
-{monitor_name}/global_{metric_name}                 # 全局聚合指标
+{monitor_name}/layer_{global_idx}/{metric_name}        # 普通层逐层指标
+{monitor_name}/layer_{global_idx}_mtp/{metric_name}    # MTP 层逐层指标
+{monitor_name}/global_{metric_name}                     # 全局聚合指标
 ```
 
 - `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health`
 - `global_idx`: 考虑 PP (Pipeline Parallelism) 的全局层索引 = `pp_rank × local_layers + local_idx`
+- `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路
 
 ---
 

--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -36,6 +36,7 @@ class PaddleProbe(Probe):
         self._layer_metric_groups: dict[str, tuple[str, list[str]]] = {}
         self._layer_metric_keys: set[str] = set()  # 所有 per-layer key，用于 flush 时判断是否输出
         self._disabled_keys: set[str] = set()  # log_global=False 时被禁用的 global keys
+        self._mtp_layer_ids: set[int] = set()
         self._buffers_allocated = False
 
     def _should_monitor(self) -> bool:
@@ -131,14 +132,21 @@ class PaddleProbe(Probe):
     # Convenience: declare/record using class-level aggregation rules
     # ------------------------------------------------------------------
 
+    def mark_mtp_layers(self, layer_ids) -> None:
+        """Mark MTP layers before declaring the metric schema."""
+        assert not self._buffers_allocated, "mark_mtp_layers after allocate_buffers"
+        self._mtp_layer_ids.update(int(layer_idx) for layer_idx in layer_ids)
+
     def _layer_key(self, layer_idx: int, metric_name: str, attn_type: str | None = None) -> str:
-        # Attention-type prefix (``swa_`` / ``full_``) goes on the metric name,
-        # not the layer number, so the viewer's ``layer_(\d+)/(sub)`` regex
-        # still matches and its per-(monitor, sub) grouping naturally splits
-        # window vs full charts. ``attn_type=None`` keeps the legacy key.
+        # Attention type stays on the metric name so window/full charts split
+        # naturally. MTP identity stays on the layer token and follows the
+        # existing metric gather/JSONL path without separate metadata.
+        layer_token = f"layer_{layer_idx}"
+        if layer_idx in self._mtp_layer_ids:
+            layer_token += "_mtp"
         if attn_type is not None:
-            return f"{self.METRIC_PREFIX}/layer_{layer_idx}/{attn_type}_{metric_name}"
-        return f"{self.METRIC_PREFIX}/layer_{layer_idx}/{metric_name}"
+            return f"{self.METRIC_PREFIX}/{layer_token}/{attn_type}_{metric_name}"
+        return f"{self.METRIC_PREFIX}/{layer_token}/{metric_name}"
 
     def _global_key(self, metric_name: str, attn_type: str | None = None) -> str:
         if attn_type is not None:

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -144,6 +144,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             return
 
         monitor_layers = iter_monitor_layers(layers, is_transformer_layer, pp_rank=self.pp_rank)
+        self.mark_mtp_layers(item.idx for item in monitor_layers if item.is_mtp)
 
         # Declare metric schema
         metric_names = [

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -250,6 +250,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 return []
 
         monitor_layers = iter_monitor_layers(layers, has_moe, pp_rank=self.pp_rank)
+        self.mark_mtp_layers(item.idx for item in monitor_layers if item.is_mtp)
         moe_layers = []
         for item in monitor_layers:
             layer = item.layer

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -364,6 +364,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
             return []
 
         monitor_layers = iter_monitor_layers(layers, has_attention, pp_rank=self.pp_rank)
+        self.mark_mtp_layers(item.idx for item in monitor_layers if item.is_mtp)
         attention_layers = []
         for item in monitor_layers:
             attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -161,6 +161,19 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIsNone(result[0].attn_type)
 
+    def test_iter_monitor_layers_marks_unwrapped_mtp_layer(self):
+        main_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
+        mtp_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
+        mtp_wrapper = SimpleNamespace(transformer_layer=mtp_layer)
+
+        result = layer_discovery.iter_monitor_layers(
+            [main_layer, mtp_wrapper],
+            lambda layer: hasattr(layer, "self_attn"),
+        )
+
+        self.assertEqual([item.idx for item in result], [0, 1])
+        self.assertEqual([item.is_mtp for item in result], [False, True])
+
 
 class PaddleMoEMonitorTest(unittest.TestCase):
     def setUp(self):
@@ -184,6 +197,22 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         latest = training_logs.get_latest(prefix="moe_health")
         self.assertAlmostEqual(latest["moe_health/layer_0/router_entropy"], 2.0, places=4)
         self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 2.0, places=4)
+
+    def test_mtp_layer_marker_is_encoded_in_metric_key(self):
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
+        monitor.mark_mtp_layers([1])
+        monitor.declare_layer_metric(0, "router_entropy")
+        monitor.declare_layer_metric(1, "router_entropy")
+        monitor.allocate_buffers()
+
+        monitor.record_layer_metric(0, "router_entropy", paddle.to_tensor(2.0))
+        monitor.record_layer_metric(1, "router_entropy", paddle.to_tensor(4.0))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/router_entropy"], 2.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_1_mtp/router_entropy"], 4.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 3.0, places=4)
 
     def test_gpu_buffer_multi_layer_global_aggregation(self):
         """Global metrics are derived from layer accumulators at flush time."""


### PR DESCRIPTION
## 背景

PaddleFleet 的 layer discovery 已经能够识别 MTP layer，但 monitor 在生成逐层指标时丢失了 `is_mtp` 信息，导致下游可视化无法区分普通层和 MTP 层。

## 改动内容

- 在 `PaddleProbe` 中记录 monitor 注册阶段发现的 MTP layer id。
- QK Stats、MoE Health、Massive Activation 三个 monitor 注册时保留 `MonitorLayer.is_mtp` 信息。
- MTP 层的逐层指标 key 增加 `_mtp` 标记：
  - 普通层：`qk_stats/layer_49/full_max`
  - MTP 层：`qk_stats/layer_50_mtp/full_max`
- 全局指标 key 和聚合行为保持不变。
- 更新指标命名规范文档。
- 增加 MTP wrapper discovery 和指标 key 生成测试。

## 设计说明

MTP 标记直接跟随现有指标 key 进入 TrainingLogs、分布式聚合和 JSONL，不新增 metadata 协议，也不增加额外 collective。

本次改动只发生在 monitor 注册和指标 key 生成阶段，不修改 hook 的数值计算、Tensor 操作或通信逻辑。

## 兼容性

- 普通层的指标 key 保持不变。
- 全局指标 key 保持不变。
- 下游可通过 `layer_<id>_mtp` 识别 MTP 层。
- 旧日志仍可按原格式解析，但不会包含 MTP 标记。

## 测试

```text
python -m pytest -q tests/test_paddlefleet_monitors.py
30 passed