### PR TITLE
[feat] add mHC health monitor in paddlefleet

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -5,6 +5,7 @@ import logging
 from .base import PaddleProbe
 from .gather import install_gather_fn
 from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_massive_activation_monitor
+from .mhc_monitor import PaddleMHCHealthMonitor, setup_mhc_monitor
 from .moe_monitor import PaddleMoEMonitor, setup_moe_monitor
 from .qk_monitor import PaddleQKStatsMonitor, setup_qk_monitor
 
@@ -14,6 +15,7 @@ _MONITOR_MAP = {
     "qk_stats": setup_qk_monitor,
     "moe_health": setup_moe_monitor,
     "massive_act": setup_massive_activation_monitor,
+    "mhc_health": setup_mhc_monitor,
 }
 
 _MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
@@ -30,7 +32,12 @@ def _monitor_config(monitor_interval, verbose, options):
 
 def _monitor_has_active_hooks(monitor):
     hooks = getattr(monitor, "hooks", None)
-    return bool(hooks)
+    if hooks:
+        return True
+    # mhc_health does not register forward hooks; it wraps ``compute_mappings``.
+    # Fall back to its wrapped-method registry to detect an active setup.
+    wrapped = getattr(monitor, "_wrapped", None)
+    return bool(wrapped)
 
 
 def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, verbose=False, **kwargs):
@@ -60,9 +67,7 @@ def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, 
             existing_config = getattr(existing_monitor, _MONITOR_CONFIG_ATTR, None)
             if _monitor_has_active_hooks(existing_monitor) and existing_config == expected_config:
                 monitor_dict[name] = existing_monitor
-                logger.info(
-                    f"[InternalMedicine/paddlefleet] Monitor already enabled: {name}, skipping duplicate setup"
-                )
+                logger.info(f"[InternalMedicine/paddlefleet] Monitor already enabled: {name}, skipping duplicate setup")
                 continue
             existing_monitor.remove_hooks()
             model_monitor_dict.pop(name, None)
@@ -95,4 +100,6 @@ __all__ = [
     "setup_moe_monitor",
     "PaddleMassiveActivationMonitor",
     "setup_massive_activation_monitor",
+    "PaddleMHCHealthMonitor",
+    "setup_mhc_monitor",
 ]

--- a/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
@@ -1,0 +1,48 @@
+"""mHC (Manifold-Constrained Hyper-Connections) metric compute functions.
+
+Paddle port of ``backends/megatron/mhc_metrics.py``. Pure, stateless tensor
+helpers for the ``mhc_health`` monitor. They operate on the three mappings a
+``HyperConnectionModule`` produces per token:
+
+- ``h_pre``  [..., n]     — stream aggregation gate (sigmoid)
+- ``h_post`` [..., n]     — stream expansion gate (2 * sigmoid)
+- ``h_res``  [..., n, n]  — Sinkhorn doubly-stochastic residual-mixing matrix
+
+``n = num_residual_streams``.
+
+The ``amax_gain`` diagnostic follows the mHC paper: the max-abs **row** sum of a
+mixing matrix bounds the worst-case forward-pass expansion, and the max-abs
+**column** sum bounds the backward-pass expansion. For a single doubly-stochastic
+``h_res`` both sit at ~1.0; on the *composite* mapping (cumulative product of
+``h_res`` across layers) they drift away from 1.0 with depth, flagging
+residual-stream amplification.
+
+All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
+``.cpu()``), so they are safe to call from a forward hot path. See
+``.claude/skills/monitor-hook-perf-rules``.
+"""
+
+import paddle
+
+
+def amax_gain(mat: paddle.Tensor, axis: int) -> paddle.Tensor:
+    """Per-token max-abs {row|col} sum of a batched ``[..., n, n]`` matrix, meaned over tokens.
+
+    ``axis=-1`` sums over columns -> per-row sums (forward gain); ``axis=-2``
+    sums over rows -> per-column sums (backward gain). ``sum(axis)`` collapses
+    one ``n``-axis to ``[..., n]``; ``abs().max(axis=-1)`` takes the worst
+    stream per token; ``mean()`` averages over all tokens.
+
+    Returns a 0-dim tensor on ``mat``'s device/dtype (fp32 from
+    ``compute_mappings``).
+    """
+    sums = mat.sum(axis=axis)  # [..., n]
+    return sums.abs().max(axis=-1).mean()  # 0-dim
+
+
+def gate_stats(h: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Mean and (unbiased) std of a gate tensor ``h`` over all elements.
+
+    Returns two 0-dim tensors ``(mean, std)``; no host sync.
+    """
+    return h.mean(), h.std()

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -1,0 +1,341 @@
+"""mHC Health Monitor for PaddleFleet.
+
+Paddle port of ``backends/megatron/mhc_monitor.py``. Monitors the three
+per-token mappings of every ``HyperConnectionModule`` in an mHC
+(Manifold-Constrained Hyper-Connections) model:
+
+- ``h_pre`` / ``h_post`` — the aggregation / expansion gates: mean and std.
+- ``h_res``              — the doubly-stochastic residual-mixing matrix: the
+  paper's ``amax_gain`` forward (max-abs row sum) and backward (max-abs column
+  sum), computed both on this layer's ``h_res`` and on the running **composite
+  mapping** (cumulative product of ``h_res`` across the layers local to this
+  pipeline stage / VPP chunk).
+
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 8
+mean-aggregated series, name-prefixed by component:
+
+    {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
+    {attn,mlp}_h_post_mean  {attn,mlp}_h_post_std
+    {attn,mlp}_amax_gain_fwd            {attn,mlp}_amax_gain_bwd
+    {attn,mlp}_composite_amax_gain_fwd  {attn,mlp}_composite_amax_gain_bwd
+
+``h_pre`` is not part of ``HyperConnectionModule.forward``'s return, so we
+cannot use a forward hook. Instead we wrap the module's ``compute_mappings``
+bound method to capture its real ``(h_pre, h_post, h_res)`` — no recompute.
+Everything is detached and computed under ``no_grad`` (see the VRAM-safety
+notes on the hook).
+
+The monitor is a hard no-op unless the model actually uses the mHC layer: if
+the mHC classes cannot be imported, or no ``HyperConnectionTransformerLayer``
+is found, ``setup_mhc_monitor`` attaches nothing and registers no metrics.
+
+Hot-path discipline (no D2H sync, no hook-time collectives, schema fixed at
+registration): see ``.claude/skills/monitor-hook-perf-rules``.
+"""
+
+import logging
+
+import paddle
+import paddle.nn as nn
+
+from .base import PaddleProbe
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
+from .mhc_metrics import amax_gain, gate_stats
+
+logger = logging.getLogger(__name__)
+
+
+# mHC classes are optional: this monitor must be a no-op when they are absent
+# (non-mHC model, or a PaddleFleet build without hyper-connections). Bind to
+# None on import failure and gate every code path on that.
+try:
+    from paddlefleet.transformer.hyper_connection import HyperConnectionModule
+    from paddlefleet.transformer.transformer_layer import HyperConnectionTransformerLayer
+except Exception:  # pragma: no cover - environment dependent
+    HyperConnectionModule = None
+    HyperConnectionTransformerLayer = None
+
+
+_METRIC_NAMES = (
+    "h_pre_mean",
+    "h_pre_std",
+    "h_post_mean",
+    "h_post_std",
+    "amax_gain_fwd",
+    "amax_gain_bwd",
+    "composite_amax_gain_fwd",
+    "composite_amax_gain_bwd",
+)
+
+# (component_name, layer attribute) — attn runs before mlp in the layer forward.
+_COMPONENTS = (
+    ("attn", "self_attention_hyper_connection"),
+    ("mlp", "mlp_hyper_connection"),
+)
+
+
+def _iter_chunks(model):
+    """Yield ``(chunk_id, chunk)`` pairs for VPP-aware discovery.
+
+    PaddleFleet exposes VPP model chunks via ``_model_chunks`` on the pipeline
+    layer. When present, each chunk owns its own ``run_function`` and executes
+    in its own forward pass — so the running composite mapping must reset at
+    each chunk's first hc module, and never carry over.
+
+    Falls back to a single chunk ``(0, model)`` when no VPP chunking is present.
+    """
+    candidates = [model]
+    if hasattr(model, "_layers"):
+        candidates.append(model._layers)
+    if hasattr(model, "module"):
+        candidates.append(model.module)
+    for cand in candidates:
+        if cand is None:
+            continue
+        chunks = getattr(cand, "_model_chunks", None)
+        if chunks:
+            yield from enumerate(chunks)
+            return
+    yield 0, model
+
+
+class PaddleMHCHealthMonitor(PaddleProbe):
+    """Monitor the h_pre / h_post / h_res mappings of mHC hyper-connection layers."""
+
+    METRIC_PREFIX = "mhc_health"
+    # Every metric is a mean over tokens/batch (and over microbatches/ranks at
+    # flush). No max/min series, so both classification sets stay empty. The
+    # metric names end in _mean/_std/_fwd/_bwd — never a `_max`/`_min` boundary —
+    # so training_logs' suffix classifier also keeps them as "mean".
+    MAX_AGGREGATED: set[str] = set()
+    MIN_AGGREGATED: set[str] = set()
+
+    def __init__(
+        self,
+        log_per_layer: bool = True,
+        log_global: bool = True,
+        monitor_interval: int = 1,
+        verbose: bool = False,
+    ):
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=monitor_interval,
+            verbose=verbose,
+        )
+        # chunk_id -> running composite mapping [s*b, n, n], detached (no graph).
+        self._composite: dict[int, paddle.Tensor] = {}
+        # (module, original_compute_mappings) pairs, for remove_hooks() restoration.
+        self._wrapped: list[tuple[nn.Layer, object]] = []
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def _find_hc_modules(self, chunk, chunk_id: int):
+        """Return ``[(global_idx, comp, hc_module, chunk_id, is_root)]`` for one chunk.
+
+        Empty (auto-skip) when the mHC classes are unavailable or the chunk has
+        no ``HyperConnectionTransformerLayer``. Uses ``isinstance`` against the
+        real classes rather than duck-typing, so a plain ``TransformerLayer``
+        (or an ``IdentityOp`` placeholder) is never matched.
+        """
+        if HyperConnectionTransformerLayer is None or HyperConnectionModule is None:
+            return []
+        layers = get_decoder_layers(chunk)
+        if not layers:
+            return []
+
+        def matches(layer):
+            return isinstance(layer, HyperConnectionTransformerLayer)
+
+        monitor_layers = iter_monitor_layers(layers, matches, pp_rank=self.pp_rank)
+        entries: list[tuple[int, str, nn.Layer, int, bool]] = []
+        # is_mtp so we can mark them for `_mtp` suffix in metric keys.
+        mtp_layer_ids = [item.idx for item in monitor_layers if item.is_mtp]
+        if mtp_layer_ids:
+            self.mark_mtp_layers(mtp_layer_ids)
+        first_attn_seen = False
+        for item in monitor_layers:
+            for comp, attr in _COMPONENTS:
+                mod = getattr(item.layer, attr, None)
+                if not isinstance(mod, HyperConnectionModule):
+                    continue
+                # Chunk root = the attn hc of the first monitored layer in this
+                # chunk's execution order; it resets the composite each forward.
+                is_root = comp == "attn" and not first_attn_seen
+                if is_root:
+                    first_attn_seen = True
+                entries.append((item.idx, comp, mod, chunk_id, is_root))
+        return entries
+
+    # ------------------------------------------------------------------
+    # Setup: prepare (declare) -> allocate -> attach
+    # ------------------------------------------------------------------
+
+    def _init_parallel_state(self):
+        try:
+            from paddlefleet.parallel_state import get_pipeline_model_parallel_rank
+
+            self.pp_rank = get_pipeline_model_parallel_rank()
+        except Exception:
+            pass
+
+    def _prepare(self, model):
+        """Discover all hc modules across chunks and declare metric schema.
+
+        Returns a list of chunks' entries; buffers are still unallocated so
+        every ``declare_layer_metric`` call remains legal.
+        """
+        self._init_parallel_state()
+        all_targets: list[list[tuple[int, str, nn.Layer, int, bool]]] = []
+        for chunk_id, chunk in _iter_chunks(model):
+            entries = self._find_hc_modules(chunk, chunk_id=chunk_id)
+            if not entries:
+                continue
+            for global_idx, comp, _, _, _ in entries:
+                for name in _METRIC_NAMES:
+                    self.declare_layer_metric(global_idx, f"{comp}_{name}")
+            all_targets.append(entries)
+        return all_targets
+
+    def _attach(self, all_targets):
+        for entries in all_targets:
+            for layer_idx, comp, mod, chunk_id, is_root in entries:
+                orig = mod.compute_mappings
+                mod.compute_mappings = self._make_capture(orig, layer_idx, comp, chunk_id, is_root)
+                self._wrapped.append((mod, orig))
+        logger.info(f"[PaddleMHCMonitor] Wrapped {len(self._wrapped)} hyper-connection modules.")
+
+    def register_hooks(self, model):
+        """Discover, declare, allocate, and attach — the whole three-phase setup."""
+        all_targets = self._prepare(model)
+        if not any(all_targets):
+            logger.info("[PaddleMHCMonitor] No hyper-connection layers found; skipping.")
+            return
+        self.allocate_buffers()
+        self._attach(all_targets)
+
+    def remove_hooks(self):
+        # Restore the original bound methods and drop all cross-call state so
+        # the monitor holds no module references or composite tensors after
+        # teardown. ``del mod.compute_mappings`` removes the instance attribute
+        # and falls back to the class method; if that fails (e.g. slots), we
+        # re-bind the captured original.
+        for mod, orig in self._wrapped:
+            try:
+                del mod.compute_mappings
+            except AttributeError:
+                mod.compute_mappings = orig
+        self._wrapped = []
+        self._composite.clear()
+        super().remove_hooks()
+
+    def step(self):
+        super().step()
+        # Release the running composite between train steps so a [s*b, n, n]
+        # buffer never sits idle in VRAM; the root reseeds it next forward, so
+        # clearing is correctness-neutral.
+        self._composite.clear()
+
+    # ------------------------------------------------------------------
+    # Capture wrapper (the hot path)
+    # ------------------------------------------------------------------
+
+    def _make_capture(self, orig, layer_idx: int, component: str, chunk_id: int, is_root: bool):
+        """Wrap ``compute_mappings`` to record metrics from its real return value.
+
+        VRAM safety: the mappings arrive attached to the training autograd
+        graph; we ``.detach()`` them and do all metric/composite math under
+        ``no_grad`` so no stored tensor pins the graph through backward. The
+        composite slot holds one detached ``[s*b, n, n]`` tensor per chunk
+        (cloned on seed so it never aliases the model's ``h_res`` storage);
+        ``step()`` clears it.
+        """
+
+        def wrapped(x):
+            out = orig(x)  # the real mappings the model consumes — returned unchanged
+            # Gate the whole capture: metrics are only recorded on monitored
+            # steps, and the composite is reset at the chunk root on each such
+            # step, so gating here keeps the composite self-consistent (root
+            # reset -> ordered bmm builds within one monitored forward).
+            # _should_monitor() also requires grad enabled, selecting the
+            # training (not a no-grad / recompute) forward.
+            if not self._should_monitor():
+                return out
+            try:
+                h_pre, h_post, h_res = out
+                with paddle.no_grad():
+                    h_pre = h_pre.detach()
+                    h_post = h_post.detach()
+                    h_res = h_res.detach()
+
+                    pre_mean, pre_std = gate_stats(h_pre)
+                    post_mean, post_std = gate_stats(h_post)
+                    self.record_layer_metric(layer_idx, f"{component}_h_pre_mean", pre_mean)
+                    self.record_layer_metric(layer_idx, f"{component}_h_pre_std", pre_std)
+                    self.record_layer_metric(layer_idx, f"{component}_h_post_mean", post_mean)
+                    self.record_layer_metric(layer_idx, f"{component}_h_post_std", post_std)
+
+                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-1))
+                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, axis=-2))
+
+                    # Composite mapping M_k = h_res_k @ M_{k-1} (per token).
+                    # h_res arrives as [..., n, n]; flatten leading dims to a
+                    # single batch axis for bmm.
+                    shape = h_res.shape
+                    n = shape[-1]
+                    hb = h_res.reshape([-1, n, n])
+                    prev = self._composite.get(chunk_id)
+                    # Reset at the chunk root each forward; also self-heal on
+                    # first fire / shape drift (variable s*b across
+                    # microbatches). identity @ h_res == h_res, so seed with
+                    # h_res; clone() so the slot owns a fresh buffer and never
+                    # pins the model's h_res storage.
+                    if is_root or prev is None or prev.shape != hb.shape:  # noqa: SIM108
+                        M = hb.clone()
+                    else:
+                        M = paddle.bmm(hb, prev)  # fresh tensor, no graph
+                    self._composite[chunk_id] = M
+
+                    self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_fwd", amax_gain(M, axis=-1))
+                    self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_bwd", amax_gain(M, axis=-2))
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[PaddleMHCMonitor] Error layer {layer_idx}/{component}: {e}")
+            return out
+
+        return wrapped
+
+
+def setup_mhc_monitor(
+    model,
+    log_per_layer: bool = True,
+    log_global: bool = True,
+    monitor_interval: int = 1,
+    verbose: bool = False,
+    monitor_dict: dict | None = None,
+):
+    """Enable the mHC health monitor. No-op on any non-mHC model.
+
+    Multi-chunk (VPP / interleaved 1F1B) safe: declares the schema across all
+    chunks before ``allocate_buffers`` locks it, then attaches. Each model
+    chunk gets its own composite slot so a later chunk's layers never
+    contaminate an earlier chunk's running product.
+    """
+    # No-op guarantee #1: mHC classes unavailable -> touch nothing.
+    if HyperConnectionTransformerLayer is None or HyperConnectionModule is None:
+        logger.info("[PaddleMHCMonitor] Hyper-connection classes unavailable; skipping.")
+        return model
+
+    monitor = PaddleMHCHealthMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+    )
+    monitor.register_hooks(model)
+    if monitor._wrapped and monitor_dict is not None:
+        monitor_dict["mhc_health"] = monitor
+    logger.info(f"[PaddleMHCMonitor] Setup complete. Monitoring {len(monitor._wrapped)} hc modules.")
+    return model

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 AVAILABLE_MONITORS = {
     "megatron": ["qk_stats", "moe_health", "ple_health", "massive_act", "mhc_health"],
-    "paddlefleet": ["qk_stats", "moe_health", "massive_act"],
+    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health"],
 }
 
 

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -1,0 +1,223 @@
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+importlib.import_module("_backend_env").skip_unless_backend("paddlefleet")
+
+try:
+    paddle = importlib.import_module("paddle")
+    nn = importlib.import_module("paddle.nn")
+except Exception as exc:  # pragma: no cover - depends on optional backend install
+    raise unittest.SkipTest(f"paddle backend unavailable: {exc}") from exc
+
+mhc_metrics = importlib.import_module("internal_medicine.backends.paddlefleet.mhc_metrics")
+mhc_monitor = importlib.import_module("internal_medicine.backends.paddlefleet.mhc_monitor")
+training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
+
+PaddleMHCHealthMonitor = mhc_monitor.PaddleMHCHealthMonitor
+
+
+class FakeHC(nn.Layer):
+    """Stand-in for HyperConnectionModule exposing compute_mappings."""
+
+    def __init__(self, n, h_pre, h_post, h_res):
+        super().__init__()
+        self.n = n
+        self._h_pre = h_pre
+        self._h_post = h_post
+        self._h_res = h_res
+
+    def compute_mappings(self, x):
+        return self._h_pre, self._h_post, self._h_res
+
+    def forward(self, hidden_states):  # pragma: no cover - unused
+        return hidden_states, self._h_res, self._h_post
+
+
+class FakeLayer(nn.Layer):
+    """Stand-in for HyperConnectionTransformerLayer with the two hc modules."""
+
+    def __init__(self, attn, mlp):
+        super().__init__()
+        self.self_attention_hyper_connection = attn
+        self.mlp_hyper_connection = mlp
+
+
+def _mhc_model(layers):
+    return SimpleNamespace(decoder=SimpleNamespace(layers=nn.LayerList(layers)))
+
+
+class MHCMetricsTest(unittest.TestCase):
+    def test_amax_gain_row_vs_col(self):
+        # [[1,2],[3,4]] -> row sums [3,7] -> max abs 7 (fwd); col sums [4,6] -> 6 (bwd).
+        m = paddle.to_tensor([[[[1.0, 2.0], [3.0, 4.0]]]], dtype="float32")
+        self.assertAlmostEqual(float(mhc_metrics.amax_gain(m, axis=-1)), 7.0, places=5)
+        self.assertAlmostEqual(float(mhc_metrics.amax_gain(m, axis=-2)), 6.0, places=5)
+
+    def test_doubly_stochastic_gain_is_one(self):
+        n = 4
+        ident = paddle.eye(n).reshape([1, 1, n, n])
+        self.assertAlmostEqual(float(mhc_metrics.amax_gain(ident, axis=-1)), 1.0, places=5)
+        self.assertAlmostEqual(float(mhc_metrics.amax_gain(ident, axis=-2)), 1.0, places=5)
+
+    def test_gate_stats(self):
+        h = paddle.to_tensor([[[0.0, 1.0, 2.0, 3.0]]], dtype="float32")
+        mean, std = mhc_metrics.gate_stats(h)
+        self.assertAlmostEqual(float(mean), 1.5, places=5)
+        self.assertAlmostEqual(float(std), float(h.std()), places=5)
+
+
+class MHCMonitorTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+        # Discovery uses isinstance against the real classes; point them at the fakes.
+        self._orig_layer_cls = mhc_monitor.HyperConnectionTransformerLayer
+        self._orig_mod_cls = mhc_monitor.HyperConnectionModule
+        mhc_monitor.HyperConnectionTransformerLayer = FakeLayer
+        mhc_monitor.HyperConnectionModule = FakeHC
+
+    def tearDown(self):
+        mhc_monitor.HyperConnectionTransformerLayer = self._orig_layer_cls
+        mhc_monitor.HyperConnectionModule = self._orig_mod_cls
+        training_logs.reset()
+
+    def _identity_layer(self, n, s, b):
+        ident = paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n])
+
+        def make_hc():
+            return FakeHC(
+                n=n,
+                h_pre=paddle.full([s, b, n], 0.5),
+                h_post=paddle.ones([s, b, n]),
+                h_res=paddle.assign(ident),  # own storage so composite.clone can't alias
+            )
+
+        return FakeLayer(attn=make_hc(), mlp=make_hc())
+
+    def _drive(self, targets, x_dim):
+        # Fire each wrapped compute_mappings; grad is enabled by default in dygraph.
+        for _, _, mod, _, _ in targets:
+            mod.compute_mappings(paddle.randn([4, 2, x_dim]))
+
+    def _prepare_and_attach(self, monitor, model):
+        all_targets = monitor._prepare(model)
+        monitor.allocate_buffers()
+        monitor._attach(all_targets)
+        # Return a single flat list of entries for convenience.
+        return [entry for chunk_entries in all_targets for entry in chunk_entries]
+
+    def test_identity_composite_stays_unit_gain(self):
+        n, s, b = 4, 2, 3
+        layer = self._identity_layer(n, s, b)
+        model = _mhc_model([layer])
+
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self.assertTrue(targets)
+
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for key in (
+                "h_pre_mean",
+                "h_pre_std",
+                "h_post_mean",
+                "h_post_std",
+                "amax_gain_fwd",
+                "amax_gain_bwd",
+                "composite_amax_gain_fwd",
+                "composite_amax_gain_bwd",
+            ):
+                self.assertIn(f"mhc_health/layer_0/{comp}_{key}", latest)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_amax_gain_fwd"], 1.0, places=4)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_fwd"], 1.0, places=4)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_bwd"], 1.0, places=4)
+            # h_pre == 0.5 everywhere, h_post == 1.0 everywhere.
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_mean"], 0.5, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_mean"], 1.0, places=5)
+        # global aggregate is derived too.
+        self.assertIn("mhc_health/global_attn_amax_gain_fwd", latest)
+
+    def test_remove_hooks_restores_compute_mappings(self):
+        n, s, b = 4, 2, 3
+        layer = self._identity_layer(n, s, b)
+        model = _mhc_model([layer])
+        monitor = PaddleMHCHealthMonitor()
+        original = layer.self_attention_hyper_connection.compute_mappings
+        self._prepare_and_attach(monitor, model)
+        self.assertIsNot(layer.self_attention_hyper_connection.compute_mappings, original)
+        monitor.remove_hooks()
+        # falls back to the (bound) class method after deleting the instance attr
+        self.assertEqual(
+            layer.self_attention_hyper_connection.compute_mappings.__func__,
+            FakeHC.compute_mappings,
+        )
+        self.assertEqual(monitor._wrapped, [])
+        self.assertEqual(monitor._composite, {})
+
+    def test_no_graph_retention(self):
+        n, s, b = 4, 2, 3
+        ident = paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n])
+        # Outputs attached to a graph (require grad) — the wrapper must detach.
+        leaf = paddle.zeros([s, b, n])
+        leaf.stop_gradient = False
+        h_pre = leaf + 0.5
+        h_post = leaf + 1.0
+        h_res = paddle.assign(ident) * (leaf.sum() + 1.0)  # grad-tracked
+        hc = FakeHC(n=n, h_pre=h_pre, h_post=h_post, h_res=h_res)
+        layer = FakeLayer(attn=hc, mlp=hc)
+        model = _mhc_model([layer])
+
+        monitor = PaddleMHCHealthMonitor()
+        targets = self._prepare_and_attach(monitor, model)
+        for _, _, mod, _, _ in targets:
+            mod.compute_mappings(paddle.randn([4, 2, n * 8]))
+
+        stored = monitor._composite[0]
+        # detach() sets stop_gradient=True; the composite must not be graph-tracked.
+        self.assertTrue(stored.stop_gradient)
+        monitor.step()
+        self.assertEqual(monitor._composite, {})  # cleared between steps
+
+
+class MHCMonitorNoOpTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def test_auto_skip_no_hc(self):
+        # A plain model (no HyperConnectionTransformerLayer) -> wraps nothing.
+        plain_layer = nn.Linear(4, 4)
+        model = _mhc_model([plain_layer])
+        monitor_dict = {}
+        mhc_monitor.setup_mhc_monitor(model, monitor_dict=monitor_dict)
+        self.assertEqual(monitor_dict, {})
+
+    def test_no_op_when_unimportable(self):
+        # Simulate mHC classes not importable -> setup is a total no-op, no raise.
+        orig_layer = mhc_monitor.HyperConnectionTransformerLayer
+        orig_mod = mhc_monitor.HyperConnectionModule
+        mhc_monitor.HyperConnectionTransformerLayer = None
+        mhc_monitor.HyperConnectionModule = None
+        try:
+            model = _mhc_model([nn.Linear(4, 4)])
+            monitor_dict = {}
+            returned = mhc_monitor.setup_mhc_monitor(model, monitor_dict=monitor_dict)
+            self.assertIs(returned, model)
+            self.assertEqual(monitor_dict, {})
+        finally:
+            mhc_monitor.HyperConnectionTransformerLayer = orig_layer
+            mhc_monitor.HyperConnectionModule = orig_mod
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

为 paddlefleet 后端新增 `mhc_health` monitor，用于监控使用`HyperConnectionTransformerLayer`（mHC）的模型内部健康度：α_pre / α_post 门控分布与 Sinkhorn 双随机残差混合矩阵 `h_res` 的最坏放大情况。

## 动机

paddlefleet 后端此前只覆盖 `qk_stats / moe_health / massive_act`，对启用了 mHC 的训练而言，多流残差混合矩阵与门控分布完全没有可视性，是一段实际的观测盲区。此 PR 补齐这一维度。

## 新增文件

- `backends/paddlefleet/mhc_metrics.py` — 纯 paddle 计算辅助函数`amax_gain(mat, axis)` / `gate_stats(h)`
- `backends/paddlefleet/mhc_monitor.py` — `PaddleMHCHealthMonitor` 类及`setup_mhc_monitor` 入口
- `tests/test_mhc_paddlefleet_monitor.py` — 8 项测试（metrics 3 + monitor 3 + no-op 2）

## 已修改文件

- `backends/paddlefleet/__init__.py`
  - `_MONITOR_MAP` 增加 `"mhc_health": setup_mhc_monitor`
  - `_monitor_has_active_hooks` 兜底检查 `_wrapped`（mhc 用方法 wrap 而非 forward hook）
  - `__all__` 导出 `PaddleMHCHealthMonitor / setup_mhc_monitor`
- `core/registry.py` — `AVAILABLE_MONITORS["paddlefleet"]` 增加 `"mhc_health"`

## 指标集

每个 hyper-connection 模块产出 8 个指标（按 `attn_` / `mlp_` 前缀区分主副组件），全部按 token/batch 求均值，flush 时对 microbatch / rank 求均值：

| 类别 | 指标 |
|---|---|
| 门控统计 | `{c}_h_pre_mean`、`{c}_h_pre_std`、`{c}_h_post_mean`、`{c}_h_post_std` |
| 单层 h_res 放大 | `{c}_amax_gain_fwd`、`{c}_amax_gain_bwd` |
| 跨层复合放大 | `{c}_composite_amax_gain_fwd`、`{c}_composite_amax_gain_bwd` |

日志键：`mhc_health/layer_{i}/{c}_{name}` 与自动派生的 `mhc_health/global_{c}_{name}`。

## 采集实现要点

- `h_pre` 不在 `HyperConnectionModule.forward` 返回中，无法用 forward hook 抓取，因此**包裹 `compute_mappings` 绑定方法**直接捕获真实返回值，无重算
- 捕获后立即 `.detach()`，全部指标计算在 `paddle.no_grad()` 下完成，避免梯度图被跨调用的复合状态钉住（VRAM 泄漏防护）
- 复合映射 seed 用 `hb.clone()` 而非 `h_res` 视图，避免 alias 模型存储
- `step()` 每步清空 `self._composite`，`remove_hooks()` 恢复原始 `compute_mappings`并清空所有状态

## 验证

- **单元测试**：`pytest tests/test_mhc_paddlefleet_monitor.py` 8/8 通过
- **paddlefleet 全套测试**：30 + 新增 8 = 38/38 通过
- **ruff / ruff format**：所有新增/修改文件均通过