### PR TITLE
feat(paddlefleet): expand QK, MoE, massive activation, and mHC training diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 训练时模型健康的实时监控框架，通过 forward hook 零侵入式采集指标，不影响训练梯度。
 
-包含五大监控模块：
-- **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (13 指标)
-- **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标)
-- **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (21 指标)
+包含五类监控能力，完整指标、公式和后端差异见 **[能力参考](./docs/capability_reference.md)**：
+- **[MoE Health](./docs/moe_specialist.md)** — Router、hard assignment、gate mass 与专家健康
+- **[QK Stats](./docs/qk_logits.md)** — Q/K/V 尺度、attention logits、熵与 sink
+- **[Massive Activation Health](./docs/massive_activation.md)** — Residual stream、模块输出与 massive activation
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 8 指标；仅在开启 mHC 层时生效)
 
@@ -24,7 +24,7 @@ monitor_dict = {}
 # 启用全部监控 (默认)
 model = setup_internal_medicine(
     model,
-    monitors=['all'],              # 或指定 ['moe_health', 'qk_stats', 'massive_act', 'ple_health']
+    monitors=['all'],
     monitor_dict=monitor_dict,
     monitor_interval=1,
     verbose=False,
@@ -107,7 +107,8 @@ setup_internal_medicine()
     ├── setup_moe_monitor()   → MoESpecialistMonitor → forward hooks on MoE layers
     ├── setup_qk_monitor()    → QKStatsMonitor     → forward pre-hooks on core_attention
     ├── setup_massive_activation_monitor() → MassiveActivationMonitor → forward pre-hooks on transformer layers
-    └── setup_ple_monitor()   → PLEHealthMonitor   → forward hooks on PLE modules
+    ├── setup_ple_monitor()   → PLEHealthMonitor   → forward hooks on PLE modules
+    └── setup_mhc_monitor()   → MHCHealthMonitor   → wraps mHC mapping computation
                                         │
                                         ▼
                               GPU 0-dim accumulators

--- a/docs/capability_reference.md
+++ b/docs/capability_reference.md
@@ -1,0 +1,141 @@
+# Internal Medicine 能力参考
+
+本文档描述当前代码能够采集的指标、计算口径、启用条件和训练生命周期。指标用于定位训练内部机制变化，不应脱离 loss、稳定性和最终质量单独解释。
+
+## 后端支持
+
+| Monitor | Megatron | PaddleFleet | 适用结构 |
+| --- | :---: | :---: | --- |
+| `qk_stats` | Yes | Yes | Attention |
+| `moe_health` | Yes | Yes | MoE |
+| `massive_act` | Yes | Yes | Transformer |
+| `ple_health` | Yes | No | Per-Layer Embedding |
+| `mhc_health` | Yes | Yes | mHC；无 mHC 时自动 no-op |
+
+## 通用键与状态
+
+| 指标模板 | 计算 | 含义 |
+| --- | --- | --- |
+| `{monitor}/layer_{i}/{metric}` | 第 `i` 层指标 | 逐层定位 |
+| `{monitor}/layer_{i}_mtp/{metric}` | MTP 层指标 | 区分主干与 MTP |
+| `{monitor}/global_{metric}` | 按指标语义做 mean/max/min | 跨层摘要 |
+| `monitor_status/{monitor}/compatible_sources_{min,max}` | 各 rank 发现的兼容源数量 | 安装覆盖 |
+| `monitor_status/{monitor}/observations_{min,max}` | 采样 step 成功记录次数 | 实际运行覆盖 |
+| `monitor_status/{monitor}/observed_layers_{min,max}` | 采样 step 覆盖层数 | 层覆盖 |
+| `monitor_status/{monitor}/runtime_errors_max` | monitor 捕获的异常数 | 静默退化检测 |
+
+PaddleFleet hot hook 只写 GPU 0 维累加器，`monitor.step()` 批量回传 CPU。QK 支持 PP/VPP、MTP、GQA、CP K-only gather、full/SWA 标签与 query-row subsampling。
+
+## QK Stats
+
+设单个 token/head 的向量为 $q,k,v$，attention logit 为
+
+$$
+l_{ij} = s q_i^\top k_j,\qquad p_{ij}=\operatorname{softmax}_j(l_{ij}).
+$$
+
+| 指标模板 | 计算 | 诊断含义 |
+| --- | --- | --- |
+| `{q,k,v}_norm_mean` | $\operatorname{mean}\lVert q/k/v\rVert_2$ | Q/K/V 平均尺度 |
+| `{q,k,v}_norm_max` | $\max\lVert q/k/v\rVert_2$ | 局部尺度峰值 |
+| `max`, `mean` | 有效 attention 区域内 logit 最大值、逐 query 均值 | logit 尺度 |
+| `entropy_avg/min/max/std` | $-\sum_jp_{ij}\log p_{ij}$ 的均值、head 极值与离散度 | attention sharpness |
+| `sink` | $\operatorname{mean}(p_{i0})$ | token-0 sink 强度 |
+| `sink_head_ratio` | sink weight 超阈值的 head 比例 | sink 是否普遍 |
+| `sink_head_max` | 最大 head sink weight | 最严重 sink |
+| `sink_nonsink_gap` | sink-head 与其他 head 的均值差 | head 分化 |
+
+SWA 指标只在真实窗口
+
+$$
+i-w_{\mathrm{left}}\le j\le i+w_{\mathrm{right}}
+$$
+
+内统计，并与 causal mask 共同生效。`softmax_scale` 使用模型实际值。
+
+## Massive Activation
+
+| 指标模板 | 计算 | 诊断含义 |
+| --- | --- | --- |
+| `channel_max/median/p95/p99` | 各 hidden channel 跨 token 绝对峰值的分布 | outlier 尺度与背景 |
+| `channel_max_ratio` | 最大 channel peak / 中位数 | 少数通道异常程度 |
+| `massive_act_channel_count` | channel peak 超相对阈值的数量 | massive channel 数 |
+| `channel_count_gt_{threshold}` | channel peak 超绝对阈值的数量 | 固定尺度告警 |
+| `topk_channel_norm` | 最大 K 个 channel peak 的 L2 norm | outlier 总强度 |
+| `activation_rms` | $\sqrt{\operatorname{mean}(h^2)}$ | residual 整体尺度 |
+| `post_norm_sparsity` | $\operatorname{mean}(|\hat h|<\epsilon)$ | norm 后稀疏性 |
+| `post_norm_cosine` | 确定性 token pair cosine 均值 | 表示同质化 |
+
+PaddleFleet 额外在五个机制位置输出 `{position}_{rms,abs_max,abs_p99,outlier_ratio}`：
+
+`layer_input`, `attn_out`, `post_attn_residual`, `ffn_or_moe_out`, `post_ffn_residual`。
+
+其中
+
+$$
+\text{outlier ratio}=\operatorname{mean}(|x|>10\operatorname{RMS}(x)).
+$$
+
+`attn_update_rms_ratio` 和 `ffn_update_rms_ratio` 分别衡量 attention、FFN/MoE 输出相对其 residual 输入的注入尺度。
+
+Megatron 后端另提供 spectral gain、Lipschitz、logit-lens 和 hidden spectral entropy 等可选指标，详见 [Massive Activation](./massive_activation.md)。
+
+## MoE Health
+
+令 router probability 为 $p_{te}$，实际 top-k assignment 为 $a_{te}\in\{0,1\}$。
+
+| 指标模板 | 计算 | 诊断含义 |
+| --- | --- | --- |
+| `router_input_rms/abs_max/abs_p99` | router 输入尺度与 tail | 区分输入异常与 router 放大 |
+| `router_logit_mean/std/abs_max` | raw router logits 分布 | router 决策尺度 |
+| `router_entropy` | token-wise $-\sum_ep_{te}\log p_{te}$ 的均值 | 单 token 路由不确定性 |
+| `prob_entropy_norm` | `router_entropy / log(E)` | 跨 expert 数可比熵 |
+| `score_sum_mean/min/max` | 每 token top-k probability 之和 | 选中质量 |
+| `router_margin_mean/min/p10/p01` | 第 k 与第 k+1 分数之差 | 路由边界脆弱性 |
+| `bias_affinity_jaccard` | bias 前后 expert 集合 Jaccard | correction bias 改写程度 |
+| `expert_bias_mean/std/min/max` | correction bias 分布 | balance 控制状态 |
+
+Hard assignment 与 gate mass 分开统计：
+
+$$
+c_e=\sum_t a_{te},\qquad m_e=\sum_ta_{te}p_{te}.
+$$
+
+`assignment_load_{cv,entropy_norm,kl_uniform,max_frac,min_frac,max_min_ratio}` 描述 $c_e$；`gate_mass_{...}` 描述 $m_e$。二者分别回答“专家接收多少 token”和“专家接收多少概率质量”。padding/无效 expert id 不计入。
+
+专家权重指标为 `expert_norm_mean/std/min/max`, `shared_expert_norm`, `shared_routed_ratio`。这些指标需要宿主在 FP8 trainable 权重释放前调用 `collect_expert_norms()`；未接入该生命周期的宿主仍可采集 router、assignment 与 gate-mass 指标。
+
+## PLE Health
+
+仅 Megatron PLE 模型适用：
+
+| 指标 | 计算 |
+| --- | --- |
+| `token_ple_norm`, `proj_ple_norm`, `per_layer_inputs_norm` | token/projection PLE 分支及合并输入 norm |
+| `token_proj_cosine` | 两分支 cosine |
+| `residual_ratio` | $\lVert output-input\rVert/\lVert input\rVert$ |
+| `gate_activation_mean`, `gate_sparsity` | gate 激活强度与低激活比例 |
+
+## mHC Health
+
+对 attention 与 MLP 两个 hyper-connection 组件分别输出：
+
+| 指标模板 | 计算 |
+| --- | --- |
+| `{attn,mlp}_h_pre_mean/std` | 聚合门统计 |
+| `{attn,mlp}_h_post_mean/std` | 扩展门统计 |
+| `{attn,mlp}_amax_gain_fwd/bwd` | 单层 residual 映射绝对行和/列和上界 |
+| `{attn,mlp}_composite_amax_gain_fwd/bwd` | PP/VPP chunk 内复合映射增益 |
+
+无 mHC 层时 monitor 自动 no-op；VPP chunk 分别维护复合映射，step 结束释放缓存。
+
+## PaddleFleet 生命周期
+
+```text
+on_train_begin      -> setup monitors and hooks
+forward             -> GPU-buffer metrics
+on_step_end         -> flush GPU buffers and runtime status
+on_log              -> distributed aggregation
+```
+
+未知 monitor 会告警并跳过；已知 monitor 初始化失败会终止 setup，避免训练在诊断能力缺失时静默继续。

--- a/src/internal_medicine/__init__.py
+++ b/src/internal_medicine/__init__.py
@@ -9,6 +9,8 @@ Monitors:
 - qk_stats: Attention QK statistics (entropy, max logits, sink weights)
 - moe_health: MoE health metrics (router, experts, tokens, shared)
 - ple_health: Per-Layer Embedding health (Megatron only)
+- massive_act: Residual-stream and module-output activation health
+- mhc_health: Manifold-Constrained Hyper-Connections mapping health
 
 Usage:
     from internal_medicine import setup_internal_medicine, training_logs
@@ -59,6 +61,7 @@ def setup_internal_medicine(
             - 'moe_health': MoE health metrics
             - 'ple_health': PLE health (Megatron only)
             - 'massive_act': Massive activation metrics
+            - 'mhc_health': mHC mapping metrics
             - 'all': Enable all available monitors. None defaults to all.
         monitor_dict: Dict to store monitor instances
         monitor_interval: Steps between monitoring

--- a/src/internal_medicine/backends/megatron/triton_kernels.py
+++ b/src/internal_medicine/backends/megatron/triton_kernels.py
@@ -64,6 +64,9 @@ def compute_qk_stats_triton(q: torch.Tensor, k: torch.Tensor, causal: bool = Tru
         max_logits.stride(1),
         scale=scale,
         apply_causal_mask=causal,
+        apply_sliding_window=False,
+        window_left=0,
+        window_right=0,
         ROW_STRIDE=1,  # full-sequence (exact) behavior, unchanged
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -46,11 +46,12 @@ def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, 
 
     if monitors is None:
         monitors = ["all"]
+    elif isinstance(monitors, str):
+        monitors = [name.strip() for name in monitors.split(",") if name.strip()]
     if "all" in monitors:
         monitors = list(_MONITOR_MAP.keys())
     if monitor_dict is None:
         monitor_dict = {}
-
     model_monitor_dict = getattr(model, _MODEL_MONITOR_ATTR, None)
     if model_monitor_dict is None:
         model_monitor_dict = {}
@@ -87,6 +88,7 @@ def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, 
             logger.info(f"[InternalMedicine/paddlefleet] Enabled monitor: {name}")
         except Exception as e:
             logger.error(f"[InternalMedicine/paddlefleet] Failed to setup {name}: {e}")
+            raise
 
     return model
 

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -48,6 +48,20 @@ from .massive_activation_metrics import (
 
 logger = logging.getLogger(__name__)
 
+_POSITIONS = ("layer_input", "attn_out", "post_attn_residual", "ffn_or_moe_out", "post_ffn_residual")
+
+
+def _position_stats(tensor: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    value = tensor.detach().astype("float32")
+    absolute = value.abs()
+    rms = paddle.sqrt(value.square().mean())
+    return {
+        "rms": rms,
+        "abs_max": absolute.max(),
+        "abs_p99": paddle.quantile(absolute.reshape([-1]), 0.99),
+        "outlier_ratio": (absolute > 10.0 * rms.clip(min=1e-10)).astype("float32").mean(),
+    }
+
 
 class PaddleMassiveActivationMonitor(PaddleProbe):
     """Monitor massive activations in the residual stream.
@@ -66,7 +80,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         "topk_channel_norm",
         "activation_rms",
         "massive_act_channel_count",
-    }
+    } | {f"{position}_{metric}" for position in _POSITIONS for metric in ("rms", "abs_max", "abs_p99")}
 
     def __init__(
         self,
@@ -103,6 +117,11 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         self._warned_per_channel_aggregate = False
         self._post_norm_failed_layers: set[int] = set()
         self._hc_aggregate_failed_layers: set[int] = set()
+        self._layer_cache: dict[int, paddle.Tensor] = {}
+
+    def step(self):
+        super().step()
+        self._layer_cache.clear()
 
     def register_hooks(self, model: nn.Layer):
         try:
@@ -166,6 +185,11 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                 continue
             for m in metric_names:
                 self.declare_layer_metric(item.idx, m, attn_type=item.attn_type)
+            for position in _POSITIONS:
+                for metric in ("rms", "abs_max", "abs_p99", "outlier_ratio"):
+                    self.declare_layer_metric(item.idx, f"{position}_{metric}", attn_type=item.attn_type)
+            for metric in ("attn_update_rms_ratio", "ffn_update_rms_ratio"):
+                self.declare_layer_metric(item.idx, metric, attn_type=item.attn_type)
             registered += 1
 
         self.allocate_buffers()
@@ -175,7 +199,14 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                 continue
             hook = item.layer.register_forward_pre_hook(self._make_residual_hook(item.idx, item.attn_type))
             self.hooks.append(hook)
+            attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
+            if attn is not None:
+                self.hooks.append(attn.register_forward_post_hook(self._make_attn_post_hook(item.idx, item.attn_type)))
+            ffn = getattr(item.layer, "mlp", None) or getattr(item.layer, "moe", None)
+            if ffn is not None:
+                self.hooks.append(ffn.register_forward_post_hook(self._make_ffn_post_hook(item.idx, item.attn_type)))
 
+        self._set_compatible_sources(registered)
         logger.info(f"[MassiveActMonitor] Registered {registered} hooks.")
 
     def _make_residual_hook(self, layer_idx: int, attn_type: str | None = None):
@@ -190,10 +221,63 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     return
 
                 with paddle.no_grad():
+                    self._layer_cache[layer_idx] = hidden_states.detach()
+                    self._record_position(layer_idx, "layer_input", hidden_states, attn_type)
                     self._compute_and_log(layer_idx, hidden_states.detach(), module, attn_type=attn_type)
             except Exception as e:
+                self._record_error()
                 if self.verbose:
                     logger.error(f"[MassiveActMonitor] Error at layer {layer_idx}: {e}")
+
+        return hook_fn
+
+    def _record_position(
+        self, layer_idx: int, position: str, tensor: paddle.Tensor, attn_type: str | None = None
+    ) -> paddle.Tensor:
+        value = tensor.detach()
+        for metric, stat in _position_stats(value).items():
+            self.record_layer_metric(layer_idx, f"{position}_{metric}", stat, attn_type=attn_type)
+        return paddle.sqrt(value.astype("float32").square().mean())
+
+    def _make_attn_post_hook(self, layer_idx: int, attn_type: str | None):
+        def hook_fn(_module, _inputs, outputs):
+            layer_input = self._layer_cache.get(layer_idx)
+            if layer_input is None or not self._should_monitor():
+                return
+            attn_out = self._extract_output_tensor(outputs)
+            if attn_out is None:
+                return
+            with paddle.no_grad():
+                attn_rms = self._record_position(layer_idx, "attn_out", attn_out, attn_type)
+                input_rms = paddle.sqrt(layer_input.astype("float32").square().mean())
+                post_attn = layer_input + attn_out.detach()
+                self._record_position(layer_idx, "post_attn_residual", post_attn, attn_type)
+                self.record_layer_metric(
+                    layer_idx, "attn_update_rms_ratio", attn_rms / input_rms.clip(min=1e-30), attn_type=attn_type
+                )
+                self._layer_cache[layer_idx] = post_attn
+
+        return hook_fn
+
+    def _make_ffn_post_hook(self, layer_idx: int, attn_type: str | None):
+        def hook_fn(_module, _inputs, outputs):
+            post_attn = self._layer_cache.get(layer_idx)
+            if post_attn is None or not self._should_monitor():
+                return
+            ffn_out = self._extract_output_tensor(outputs)
+            if ffn_out is None:
+                return
+            with paddle.no_grad():
+                ffn_rms = self._record_position(layer_idx, "ffn_or_moe_out", ffn_out, attn_type)
+                residual_rms = paddle.sqrt(post_attn.astype("float32").square().mean())
+                self._record_position(layer_idx, "post_ffn_residual", post_attn + ffn_out.detach(), attn_type)
+                self.record_layer_metric(
+                    layer_idx,
+                    "ffn_update_rms_ratio",
+                    ffn_rms / residual_rms.clip(min=1e-30),
+                    attn_type=attn_type,
+                )
+                self._layer_cache.pop(layer_idx, None)
 
         return hook_fn
 
@@ -214,6 +298,16 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             return first
         return None
 
+    @staticmethod
+    def _extract_output_tensor(outputs):
+        if isinstance(outputs, paddle.Tensor):
+            return outputs
+        if isinstance(outputs, dict):
+            return outputs.get("hidden_states")
+        if isinstance(outputs, tuple | list) and outputs:
+            return PaddleMassiveActivationMonitor._extract_output_tensor(outputs[0])
+        return None
+
     def _compute_and_log(
         self, layer_idx: int, hidden_states: paddle.Tensor, module: nn.Layer, attn_type: str | None = None
     ):
@@ -228,9 +322,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     analysis_input = aggregated
             except Exception as e:
                 if self.verbose and layer_idx not in self._hc_aggregate_failed_layers:
-                    logger.warning(
-                        f"[MassiveActMonitor] hyper_connection aggregate failed at layer {layer_idx}: {e}"
-                    )
+                    logger.warning(f"[MassiveActMonitor] hyper_connection aggregate failed at layer {layer_idx}: {e}")
                     self._hc_aggregate_failed_layers.add(layer_idx)
 
         per_channel_max = compute_per_channel_max(analysis_input)
@@ -267,9 +359,11 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     attn_type=attn_type,
                 )
             except Exception as e:
+                self._record_error()
                 if self.verbose and layer_idx not in self._post_norm_failed_layers:
                     logger.warning(f"[MassiveActMonitor] Post-norm metrics disabled at layer {layer_idx}: {e}")
                     self._post_norm_failed_layers.add(layer_idx)
+        self._record_observation(layer_idx)
 
     def _aggregate_per_channel_max(self, per_channel_max: paddle.Tensor) -> paddle.Tensor:
         """Aggregate token-sharded per-channel maxima across TP + CP groups when available.

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -215,6 +215,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             return
         self.allocate_buffers()
         self._attach(all_targets)
+        self._set_compatible_sources(len(self._wrapped))
 
     def remove_hooks(self):
         # Restore the original bound methods and drop all cross-call state so
@@ -300,7 +301,9 @@ class PaddleMHCHealthMonitor(PaddleProbe):
 
                     self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_fwd", amax_gain(M, axis=-1))
                     self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_bwd", amax_gain(M, axis=-2))
+                    self._record_observation(layer_idx)
             except Exception as e:
+                self._record_error()
                 if self.verbose:
                     logger.error(f"[PaddleMHCMonitor] Error layer {layer_idx}/{component}: {e}")
             return out

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -16,6 +16,7 @@ return tuple. Currently adapted for StandardMoEGate (PaddleFormers).
 """
 
 import logging
+import math
 
 import paddle
 import paddle.nn as nn
@@ -32,6 +33,42 @@ def _compute_router_entropy(probs):
     probs = probs / probs.sum(axis=-1, keepdim=True)
     entropy = -(probs * probs.log()).sum(axis=-1)
     return entropy.mean()
+
+
+def _distribution_metrics(mass: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    mass = mass.astype("float32").reshape([-1]).clip(min=0.0)
+    fraction = mass / mass.sum().clip(min=1e-30)
+    num_experts = int(fraction.numel())
+    uniform = 1.0 / max(num_experts, 1)
+    safe = fraction.clip(min=1e-12)
+    entropy = -(fraction * safe.log()).sum()
+    entropy_norm = entropy / math.log(num_experts) if num_experts > 1 else entropy * 0.0 + 1.0
+    minimum = fraction.min()
+    return {
+        "cv": paddle.sqrt(((fraction - uniform) ** 2).mean()) / uniform,
+        "entropy_norm": entropy_norm,
+        "kl_uniform": (fraction * (safe * num_experts).log()).sum(),
+        "max_frac": fraction.max(),
+        "min_frac": minimum,
+        "max_min_ratio": fraction.max() / minimum.clip(min=1e-12),
+    }
+
+
+def _assignment_mass(probabilities: paddle.Tensor, expert_indices: paddle.Tensor):
+    num_experts = int(probabilities.shape[-1])
+    flat_probabilities = probabilities.reshape([-1, num_experts])
+    expert_indices = expert_indices.reshape([flat_probabilities.shape[0], -1])
+    flat_indices = expert_indices.reshape([-1])
+    valid = ((flat_indices >= 0) & (flat_indices < num_experts)).astype("float32")
+    safe_indices = flat_indices.clip(min=0, max=num_experts - 1)
+    assignment = paddle.bincount(safe_indices, weights=valid, minlength=num_experts)
+    selected_mass = paddle.take_along_axis(
+        flat_probabilities,
+        expert_indices.clip(min=0, max=num_experts - 1),
+        axis=-1,
+    ).reshape([-1])
+    gate_mass = paddle.bincount(safe_indices, weights=selected_mass * valid, minlength=num_experts)
+    return assignment, gate_mass
 
 
 def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=1, topk_group=1):
@@ -107,8 +144,26 @@ def _norm_stats(norms):
 
 class PaddleMoEMonitor(PaddleProbe):
     METRIC_PREFIX = "moe_health"
-    MAX_AGGREGATED = {"score_sum_max", "expert_norm_max", "expert_bias_max"}
-    MIN_AGGREGATED = {"score_sum_min", "expert_norm_min", "expert_bias_min"}
+    MAX_AGGREGATED = {
+        "score_sum_max",
+        "expert_norm_max",
+        "expert_bias_max",
+        "router_input_abs_max",
+        "router_input_abs_p99",
+        "router_logit_abs_max",
+        "assignment_load_max_frac",
+        "assignment_load_max_min_ratio",
+        "gate_mass_max_frac",
+        "gate_mass_max_min_ratio",
+    }
+    MIN_AGGREGATED = {
+        "score_sum_min",
+        "expert_norm_min",
+        "expert_bias_min",
+        "assignment_load_min_frac",
+        "gate_mass_min_frac",
+        "router_margin_min",
+    }
 
     def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
         super().__init__(
@@ -135,6 +190,24 @@ class PaddleMoEMonitor(PaddleProbe):
         # Declare metric schema
         for layer_idx, moe_layer in moe_layers:
             gate_metrics = ["router_entropy", "score_sum_mean", "score_sum_min", "score_sum_max"]
+            gate_metrics += [
+                "router_input_rms",
+                "router_input_abs_max",
+                "router_input_abs_p99",
+                "router_logit_mean",
+                "router_logit_std",
+                "router_logit_abs_max",
+                "prob_entropy_norm",
+                "router_margin_mean",
+                "router_margin_min",
+                "router_margin_p10",
+                "router_margin_p01",
+            ]
+            for prefix in ("assignment_load", "gate_mass"):
+                gate_metrics += [
+                    f"{prefix}_{suffix}"
+                    for suffix in ("cv", "entropy_norm", "kl_uniform", "max_frac", "min_frac", "max_min_ratio")
+                ]
             if hasattr(moe_layer, "gate") and hasattr(moe_layer.gate, "e_score_correction_bias"):
                 gate_metrics += [
                     "bias_affinity_jaccard",
@@ -171,6 +244,7 @@ class PaddleMoEMonitor(PaddleProbe):
             f"[PaddleMoEMonitor] Registered {len(self.hooks)} gate hooks and "
             f"{len(self._expert_norm_layers)} expert-norm layers on {len(moe_layers)} MoE layers."
         )
+        self._set_compatible_sources(len(moe_layers))
 
     def _patch_gate_cache(self, gate):
         """Monkey-patch gate.gate_score_func to cache pre-bias gates."""
@@ -186,6 +260,7 @@ class PaddleMoEMonitor(PaddleProbe):
         monitor = self
 
         def cached_gate_score_func(logits):
+            gate._cached_logits = logits.detach()
             result = original_fn(logits)
             if monitor._should_monitor():
                 gate._cached_gates = result.detach()
@@ -270,20 +345,27 @@ class PaddleMoEMonitor(PaddleProbe):
             if not layer.training:
                 if hasattr(layer, "_cached_gates"):
                     layer._cached_gates = None
+                if hasattr(layer, "_cached_logits"):
+                    layer._cached_logits = None
                 return
             if not self._should_monitor():
                 if hasattr(layer, "_cached_gates"):
                     layer._cached_gates = None
+                if hasattr(layer, "_cached_logits"):
+                    layer._cached_logits = None
                 return
             try:
                 with paddle.no_grad():
-                    self._compute_gate_metrics(layer_idx, layer, outputs, moe_layer)
+                    self._compute_gate_metrics(layer_idx, layer, inputs, outputs, moe_layer)
             except Exception as e:
+                self._record_error()
                 if self.verbose:
                     logger.error(f"[PaddleMoEMonitor] Gate hook error layer {layer_idx}: {e}")
             finally:
                 if hasattr(layer, "_cached_gates"):
                     layer._cached_gates = None
+                if hasattr(layer, "_cached_logits"):
+                    layer._cached_logits = None
 
         return hook_fn
 
@@ -299,7 +381,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 if self.verbose:
                     logger.error(f"[PaddleMoEMonitor] expert-norm collect error layer {layer_idx}: {e}")
 
-    def _compute_gate_metrics(self, layer_idx, gate, outputs, moe_layer):
+    def _compute_gate_metrics(self, layer_idx, gate, inputs, outputs, moe_layer):
         """Compute router metrics from gate forward output."""
         cached_gates = getattr(gate, "_cached_gates", None)
         k = getattr(gate, "num_experts_per_tok", None)
@@ -309,13 +391,53 @@ class PaddleMoEMonitor(PaddleProbe):
                 logger.warning(f"[PaddleMoEMonitor] layer {layer_idx}: _cached_gates is None, gate patch may not work")
             return
 
+        router_input = inputs[0] if inputs and isinstance(inputs[0], paddle.Tensor) else None
+        if router_input is not None:
+            router_input = router_input.detach().astype("float32")
+            absolute = router_input.abs()
+            self.record_layer_metric(layer_idx, "router_input_rms", paddle.sqrt(router_input.square().mean()))
+            self.record_layer_metric(layer_idx, "router_input_abs_max", absolute.max())
+            self.record_layer_metric(layer_idx, "router_input_abs_p99", paddle.quantile(absolute.reshape([-1]), 0.99))
+        logits = getattr(gate, "_cached_logits", None)
+        if logits is not None:
+            logits = logits.astype("float32")
+            self.record_layer_metric(layer_idx, "router_logit_mean", logits.mean())
+            self.record_layer_metric(layer_idx, "router_logit_std", logits.std())
+            self.record_layer_metric(layer_idx, "router_logit_abs_max", logits.abs().max())
+
         self.record_layer_metric(layer_idx, "router_entropy", _compute_router_entropy(cached_gates))
+        num_experts = int(cached_gates.shape[-1])
+        self.record_layer_metric(
+            layer_idx,
+            "prob_entropy_norm",
+            _compute_router_entropy(cached_gates) / math.log(num_experts)
+            if num_experts > 1
+            else cached_gates.sum() * 0 + 1,
+        )
         if k is not None:
-            topk_vals, _ = paddle.topk(cached_gates, k, axis=-1)
+            topk_vals, topk_idx = paddle.topk(cached_gates, k, axis=-1)
             score_sum = topk_vals.sum(axis=-1)
             self.record_layer_metric(layer_idx, "score_sum_mean", score_sum.mean())
             self.record_layer_metric(layer_idx, "score_sum_min", score_sum.min())
             self.record_layer_metric(layer_idx, "score_sum_max", score_sum.max())
+            if k < num_experts:
+                boundary = paddle.topk(cached_gates, k + 1, axis=-1, sorted=True)[0]
+                margin = boundary[..., k - 1] - boundary[..., k]
+                self.record_layer_metric(layer_idx, "router_margin_mean", margin.mean())
+                self.record_layer_metric(layer_idx, "router_margin_min", margin.min())
+                self.record_layer_metric(layer_idx, "router_margin_p10", paddle.quantile(margin, 0.10))
+                self.record_layer_metric(layer_idx, "router_margin_p01", paddle.quantile(margin, 0.01))
+
+            actual_idx = topk_idx
+            if isinstance(outputs, tuple) and len(outputs) >= 3 and isinstance(outputs[2], paddle.Tensor):
+                actual_idx = outputs[2].astype("int64").reshape([-1, k])
+            assignment, gate_mass = _assignment_mass(cached_gates, actual_idx)
+            for prefix, values in (
+                ("assignment_load", _distribution_metrics(assignment)),
+                ("gate_mass", _distribution_metrics(gate_mass)),
+            ):
+                for name, value in values.items():
+                    self.record_layer_metric(layer_idx, f"{prefix}_{name}", value)
 
         if hasattr(gate, "e_score_correction_bias"):
             top_idx_with_bias = None
@@ -334,6 +456,7 @@ class PaddleMoEMonitor(PaddleProbe):
             self.record_layer_metric(layer_idx, "expert_bias_std", bias.std())
             self.record_layer_metric(layer_idx, "expert_bias_max", bias.max())
             self.record_layer_metric(layer_idx, "expert_bias_min", bias.min())
+        self._record_observation(layer_idx)
 
     def _compute_expert_metrics(self, layer_idx, moe_layer):
         routed_norm_mean = None
@@ -396,7 +519,13 @@ class PaddleMoEMonitor(PaddleProbe):
             original_hash_routing = getattr(gate, "_im_original_hash_routing", None)
             if original_hash_routing is not None:
                 gate._hash_routing = original_hash_routing
-            for attr in ("_im_original_gate_score_func", "_im_original_hash_routing", "_im_patched", "_cached_gates"):
+            for attr in (
+                "_im_original_gate_score_func",
+                "_im_original_hash_routing",
+                "_im_patched",
+                "_cached_gates",
+                "_cached_logits",
+            ):
                 if hasattr(gate, attr):
                     delattr(gate, attr)
         self._patched_gates = []

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -100,6 +100,8 @@ def _compute_qk_stats_triton(
     heads_per_group: int = 1,
     row_stride: int = 1,
     q_row_offset: int = 0,
+    sliding_window: tuple[int, int] | list[int] | None = None,
+    softmax_scale: float | None = None,
 ) -> dict:
     """Triton kernel path for paddle tensors.
 
@@ -119,7 +121,8 @@ def _compute_qk_stats_triton(
 
     batch, num_heads, seq_len_q, head_dim = q.shape
     seq_len_k = k.shape[2]
-    scale = 1.0 / (head_dim**0.5)
+    scale = softmax_scale or 1.0 / (head_dim**0.5)
+    window_left, window_right = sliding_window or (0, 0)
 
     BLOCK_M = 64
     BLOCK_N = 64
@@ -171,6 +174,9 @@ def _compute_qk_stats_triton(
         partial_max.strides[2],
         scale=scale,
         apply_causal_mask=causal,
+        apply_sliding_window=sliding_window is not None,
+        window_left=int(window_left),
+        window_right=int(window_right),
         ROW_STRIDE=row_stride,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
@@ -202,6 +208,8 @@ def compute_qk_stats_paddle(
     causal: bool = True,
     row_stride: int = 1,
     q_row_offset: int = 0,
+    sliding_window: tuple[int, int] | list[int] | None = None,
+    softmax_scale: float | None = None,
 ) -> dict:
     """Compute QK stats via Triton kernel.
 
@@ -235,12 +243,21 @@ def compute_qk_stats_paddle(
         heads_per_group=heads_per_group,
         row_stride=row_stride,
         q_row_offset=q_row_offset,
+        sliding_window=sliding_window,
+        softmax_scale=softmax_scale,
     )
 
 
 class PaddleQKStatsMonitor(PaddleProbe):
     METRIC_PREFIX = "qk_stats"
-    MAX_AGGREGATED = {"max", "entropy_max", "sink_head_max"}
+    MAX_AGGREGATED = {
+        "q_norm_max",
+        "k_norm_max",
+        "v_norm_max",
+        "max",
+        "entropy_max",
+        "sink_head_max",
+    }
     MIN_AGGREGATED = {"entropy_min"}
 
     def __init__(
@@ -312,8 +329,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
 
         if self.verbose:
             logger.info(
-                f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. "
-                f"TP={self.tp_size} CP={self.cp_size}"
+                f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. TP={self.tp_size} CP={self.cp_size}"
             )
 
         if self.cp_size > 1:
@@ -328,6 +344,12 @@ class PaddleQKStatsMonitor(PaddleProbe):
 
         for layer_idx, _attn_module, attn_type in attention_layers:
             for m in (
+                "q_norm_mean",
+                "q_norm_max",
+                "k_norm_mean",
+                "k_norm_max",
+                "v_norm_mean",
+                "v_norm_max",
                 "max",
                 "mean",
                 "entropy_avg",
@@ -350,6 +372,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 )
                 self.hooks.append(hook)
 
+        self._set_compatible_sources(len(attention_layers))
         logger.info(f"[PaddleQKMonitor] Registered {len(self.hooks)} hooks.")
 
     def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer, str | None]]:
@@ -406,7 +429,14 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 return
             try:
                 query, key = inputs[0], inputs[1]
+                value = inputs[2] if len(inputs) > 2 else None
                 with paddle.no_grad():
+                    for name, tensor in (("q", query), ("k", key), ("v", value)):
+                        if not isinstance(tensor, paddle.Tensor):
+                            continue
+                        norm = paddle.linalg.norm(tensor.detach().astype("float32"), axis=-1)
+                        self.record_layer_metric(layer_idx, f"{name}_norm_mean", norm.mean(), attn_type=attn_type)
+                        self.record_layer_metric(layer_idx, f"{name}_norm_max", norm.max(), attn_type=attn_type)
                     if self.cp_size > 1:
                         # CP > 1: gather K only, keep Q local.
                         query = query.detach()
@@ -443,6 +473,8 @@ class PaddleQKStatsMonitor(PaddleProbe):
                         causal=self.causal,
                         row_stride=effective_stride,
                         q_row_offset=q_row_offset,
+                        sliding_window=getattr(layer, "sliding_window", None),
+                        softmax_scale=getattr(layer, "softmax_scale", None),
                     )
 
                     if self.cp_size > 1 and self.cp_group is not None:
@@ -467,7 +499,9 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 sink_class = compute_sink_head_classification(sink_for_classify, threshold=self.sink_head_threshold)
                 for name, val in sink_class.items():
                     self.record_layer_metric(layer_idx, name, val, attn_type=attn_type)
+                self._record_observation(layer_idx)
             except Exception as e:
+                self._record_error()
                 logger.error(f"[PaddleQKMonitor] Error layer {layer_idx}: {e}")
 
         return hook_fn

--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -30,6 +30,8 @@ class Probe(ABC):
     MIN_AGGREGATED: set[str] = set()
 
     def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
+        if monitor_interval < 1:
+            raise ValueError(f"monitor_interval must be positive, got {monitor_interval}")
         self.log_per_layer = log_per_layer
         self.log_global = log_global
         self.monitor_interval = monitor_interval
@@ -40,6 +42,10 @@ class Probe(ABC):
         self._global_accum: dict[str, float] = {}
         self._global_metric_counts: dict[str, int] = {}
         self._global_count: int = 0
+        self._compatible_sources = 0
+        self._observation_count = 0
+        self._observed_layers: set[int] = set()
+        self._runtime_error_count = 0
 
     @abstractmethod
     def register_hooks(self, model) -> None: ...
@@ -50,10 +56,16 @@ class Probe(ABC):
         self.hooks = []
 
     def step(self):
-        self.step_count += 1
+        sampled = self._should_monitor()
         self._flush_buffers()
         if self.log_global and self._global_accum:
             self._flush_global_metrics()
+        if sampled:
+            self._emit_status_metrics()
+            self._observation_count = 0
+            self._observed_layers.clear()
+            self._runtime_error_count = 0
+        self.step_count += 1
 
     def _flush_buffers(self) -> None:
         """Hook for backend-specific batched flush. Default: no-op.
@@ -63,9 +75,33 @@ class Probe(ABC):
         return None
 
     def _should_monitor(self) -> bool:
-        if not self.monitor_interval:
-            return False
         return self.step_count % self.monitor_interval == 0
+
+    def _set_compatible_sources(self, count: int) -> None:
+        self._compatible_sources = max(0, int(count))
+
+    def _record_observation(self, layer_idx: int) -> None:
+        self._observation_count += 1
+        if layer_idx >= 0:
+            self._observed_layers.add(int(layer_idx))
+
+    def _record_error(self) -> None:
+        self._runtime_error_count += 1
+
+    def _emit_status_metrics(self) -> None:
+        prefix = self.METRIC_PREFIX or self.__class__.__name__
+        values = {
+            "compatible_sources": self._compatible_sources,
+            "observations": self._observation_count,
+            "observed_layers": len(self._observed_layers),
+        }
+        metrics = {
+            f"monitor_status/{prefix}/{name}_{reduction}": value
+            for name, value in values.items()
+            for reduction in ("min", "max")
+        }
+        metrics[f"monitor_status/{prefix}/runtime_errors_max"] = self._runtime_error_count
+        training_logs.update(**metrics)
 
     # ------------------------------------------------------------------
     # Legacy CPU-float API
@@ -79,6 +115,7 @@ class Probe(ABC):
         """
         if not metrics:
             return
+        self._record_observation(layer_idx)
         self._log_per_layer_metrics(layer_idx, metrics)
         if self.log_global:
             self._accumulate_global(metrics)

--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -47,6 +47,9 @@ def qk_stats_kernel(
     # Configs
     scale: tl.constexpr,
     apply_causal_mask: tl.constexpr,
+    apply_sliding_window: tl.constexpr,
+    window_left: tl.constexpr,
+    window_right: tl.constexpr,
     ROW_STRIDE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -66,12 +69,11 @@ def qk_stats_kernel(
     ``heads_per_group=1`` for MHA (no grouping).
 
     Query-row subsampling: only every ``ROW_STRIDE``-th query row is visited
-    in the outer loop. The mean-class statistics (mean_logit, entropy, sink)
-    are row-averages, so a uniform stride is an unbiased estimator of the
-    full-sequence average at O(S/ROW_STRIDE) cost instead of O(S). Pass
-    ``ROW_STRIDE=1`` to recover the exact full-sequence behavior. Note that
-    ``max_logit`` is an extremum over the visited rows; with ROW_STRIDE>1 it
-    is a (typically tight) lower bound on the true max.
+    in the outer loop. Mean-class statistics (mean_logit, entropy, sink) are
+    deterministic approximations of their full-sequence row averages at
+    O(S/ROW_STRIDE) cost instead of O(S). Pass ``ROW_STRIDE=1`` to recover
+    exact full-sequence behavior. ``max_logit`` is an extremum over the
+    visited rows; with ROW_STRIDE>1 it is a lower bound on the true max.
     """
     pid = tl.program_id(0)
     batch_idx = pid // num_heads
@@ -138,6 +140,11 @@ def qk_stats_kernel(
             if apply_causal_mask:
                 causal = m_global[:, None] >= n_offsets[None, :]
                 mask_val = mask_val & causal
+            if apply_sliding_window:
+                in_window = (n_offsets[None, :] >= m_global[:, None] - window_left) & (
+                    n_offsets[None, :] <= m_global[:, None] + window_right
+                )
+                mask_val = mask_val & in_window
 
             logits = tl.where(mask_val, logits, -1e10)
 
@@ -200,8 +207,7 @@ def qk_stats_kernel(
     out_offset = batch_idx * stride_out_batch + head_idx * stride_out_head
 
     # NOTE: mean_logit uses row-first semantics (mean over valid rows of the
-    # per-row mean logit) rather than count-weighted position mean. 
-    safe_count = tl.maximum(head_valid_count, 1.0)
+    # per-row mean logit) rather than count-weighted position mean.
     safe_rows = tl.maximum(head_valid_rows, 1.0)
 
     tl.store(max_logits_ptr + out_offset, head_max_logit)
@@ -249,6 +255,9 @@ def qk_stats_partial_kernel(
     # Configs
     scale: tl.constexpr,
     apply_causal_mask: tl.constexpr,
+    apply_sliding_window: tl.constexpr,
+    window_left: tl.constexpr,
+    window_right: tl.constexpr,
     ROW_STRIDE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -322,6 +331,11 @@ def qk_stats_partial_kernel(
         if apply_causal_mask:
             causal = m_global[:, None] >= n_offsets[None, :]
             mask_val = mask_val & causal
+        if apply_sliding_window:
+            in_window = (n_offsets[None, :] >= m_global[:, None] - window_left) & (
+                n_offsets[None, :] <= m_global[:, None] + window_right
+            )
+            mask_val = mask_val & in_window
 
         logits = tl.where(mask_val, logits, -1e10)
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -18,7 +18,8 @@ except Exception as exc:  # pragma: no cover - depends on optional backend insta
 PaddleMassiveActivationMonitor = importlib.import_module(
     "internal_medicine.backends.paddlefleet.massive_activation_monitor"
 ).PaddleMassiveActivationMonitor
-PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor").PaddleMoEMonitor
+moe_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
+PaddleMoEMonitor = moe_monitor_module.PaddleMoEMonitor
 PaddleQKStatsMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor").PaddleQKStatsMonitor
 paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
 layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
@@ -102,6 +103,12 @@ class PaddleFleetSetupTest(unittest.TestCase):
         self.assertEqual(len(created), 2)
         self.assertTrue(first["dummy"].removed)
         self.assertIs(second["dummy"], created[1])
+
+    def test_all_contains_only_supported_forward_monitors(self):
+        self.assertEqual(
+            set(paddlefleet_backend._MONITOR_MAP),
+            {"qk_stats", "moe_health", "massive_act", "mhc_health"},
+        )
 
 
 class PaddleLayerDiscoveryTest(unittest.TestCase):
@@ -197,6 +204,23 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         latest = training_logs.get_latest(prefix="moe_health")
         self.assertAlmostEqual(latest["moe_health/layer_0/router_entropy"], 2.0, places=4)
         self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 2.0, places=4)
+
+    def test_hard_load_distribution_metrics_distinguish_balance(self):
+        balanced = moe_monitor_module._distribution_metrics(paddle.to_tensor([1.0, 1.0, 1.0, 1.0]))
+        imbalanced = moe_monitor_module._distribution_metrics(paddle.to_tensor([4.0, 0.0, 0.0, 0.0]))
+
+        self.assertAlmostEqual(float(balanced["cv"]), 0.0, places=6)
+        self.assertAlmostEqual(float(balanced["entropy_norm"]), 1.0, places=6)
+        self.assertGreater(float(imbalanced["cv"]), float(balanced["cv"]))
+        self.assertLess(float(imbalanced["entropy_norm"]), float(balanced["entropy_norm"]))
+
+    def test_moe_gate_metrics_ignore_all_invalid_expert_ids(self):
+        probabilities = paddle.to_tensor([[[0.7, 0.2, 0.1], [0.1, 0.3, 0.6]]])
+        invalid_assignments = paddle.to_tensor([[[-1, 3], [4, -2]]], dtype="int64")
+        assignment, gate_mass = moe_monitor_module._assignment_mass(probabilities, invalid_assignments)
+
+        self.assertEqual(float(assignment.sum()), 0.0)
+        self.assertEqual(float(gate_mass.sum()), 0.0)
 
     def test_mtp_layer_marker_is_encoded_in_metric_key(self):
         monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
@@ -531,12 +555,38 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
                 f"{key} mismatch: grouped={grouped[key].item()} expanded={expanded[key].item()}",
             )
 
-    def test_row_stride_is_near_unbiased_for_mean_class_metrics(self):
-        """Subsampling query rows must keep the row-averaged metrics close to
-        the full pass. entropy_global / mean_global / sink_global are all
-        uniform averages over query rows, so a uniform stride is an unbiased,
-        low-variance estimator. entropy has real magnitude -> tight relative
-        check; mean and sink sit near zero for N(0,1) inputs -> absolute check.
+    def test_sliding_window_matches_dense_reference(self):
+        q, k = self._gqa_inputs(S=64, Hq=4, Hkv=4, D=16, seed=7)
+        window = [8, 0]
+        actual = self.qk.compute_qk_stats_paddle(q, k, causal=True, sliding_window=window)
+
+        qh = q.transpose([0, 2, 1, 3])
+        kh = k.transpose([0, 2, 1, 3])
+        logits = paddle.matmul(qh, kh.transpose([0, 1, 3, 2])) / (q.shape[-1] ** 0.5)
+        query_pos = paddle.arange(q.shape[1]).reshape([-1, 1])
+        key_pos = paddle.arange(k.shape[1]).reshape([1, -1])
+        valid = (key_pos <= query_pos) & (key_pos >= query_pos - window[0])
+        logits = paddle.where(
+            valid.reshape([1, 1, q.shape[1], k.shape[1]]),
+            logits,
+            paddle.full_like(logits, float("-inf")),
+        )
+        probability = paddle.nn.functional.softmax(logits, axis=-1)
+        entropy = -paddle.where(
+            probability > 0,
+            probability * paddle.log(probability),
+            paddle.zeros_like(probability),
+        ).sum(axis=-1)
+
+        self.assertTrue(paddle.allclose(actual["max_global"], logits.max(), atol=5e-3, rtol=1e-4).item())
+        self.assertTrue(paddle.allclose(actual["entropy_global"], entropy.mean(), atol=1e-3, rtol=1e-4).item())
+        self.assertTrue(paddle.allclose(actual["sink_global"], probability[..., 0].mean(), atol=1e-4, rtol=1e-4).item())
+
+    def test_row_stride_approximates_mean_class_metrics(self):
+        """Subsampling query rows should keep row-averaged metrics close to
+        the full pass for representative random inputs. Entropy has meaningful
+        magnitude, so use a relative check; mean and sink sit near zero for
+        N(0,1) inputs, so use an absolute check.
         """
         q, k = self._gqa_inputs(S=512, seed=1)
         full = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1)
@@ -589,12 +639,8 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
         q_a = q[:, :half, :, :]
         q_b = q[:, half:, :, :]
 
-        sub_a = self.qk.compute_qk_stats_paddle(
-            q_a, k, causal=True, row_stride=1, q_row_offset=0
-        )
-        sub_b = self.qk.compute_qk_stats_paddle(
-            q_b, k, causal=True, row_stride=1, q_row_offset=half
-        )
+        sub_a = self.qk.compute_qk_stats_paddle(q_a, k, causal=True, row_stride=1, q_row_offset=0)
+        sub_b = self.qk.compute_qk_stats_paddle(q_b, k, causal=True, row_stride=1, q_row_offset=half)
 
         # Per-head means: average the two halves (rows split evenly).
         for key in ("entropy_per_head", "sink_per_head", "mean_per_head"):
@@ -631,9 +677,7 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
         """Passing q_row_offset=0 must be a no-op vs. the default path."""
         q, k = self._gqa_inputs(seed=4)
         default_pass = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1)
-        with_zero_offset = self.qk.compute_qk_stats_paddle(
-            q, k, causal=True, row_stride=1, q_row_offset=0
-        )
+        with_zero_offset = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1, q_row_offset=0)
         for key in ("max_global", "mean_global", "entropy_global", "sink_global"):
             self.assertTrue(
                 paddle.allclose(default_pass[key], with_zero_offset[key], atol=1e-6).item(),


### PR DESCRIPTION
## Summary

This PR expands the PaddleFleet forward-monitoring capabilities of `llm-internal-medicine` while preserving compatibility with the existing ErnieBot/PaddleFormers callback lifecycle.

The change remains forward-only. It does not introduce optimizer lifecycle dependencies or gradient/update monitoring.

## Changes

### QK Stats

- Add Q/K/V activation norm statistics.
- Use the model's actual attention softmax scale.
- Support sliding-window attention masks.
- Improve GQA handling without materializing repeated KV heads.
- Support context-parallel K gathering and query-row offsets.
- Add deterministic query-row subsampling for lower monitoring overhead.
- Preserve full-attention and SWA layer labels across PP/VPP and MTP layouts.

### MoE Health

- Add router-input and router-logit distribution statistics.
- Add normalized router entropy and top-k margin statistics.
- Separate hard expert assignment load from routed probability mass.
- Add CV, normalized entropy, uniform KL, extrema, and imbalance ratios.
- Ignore padding and out-of-range expert IDs when computing expert load.
- Improve support for grouped, fused, and hash-routed expert implementations.

### Massive Activation

- Add activation statistics at five mechanism-level positions:
  - layer input
  - attention output
  - post-attention residual
  - FFN/MoE output
  - post-FFN residual
- Add attention and FFN/MoE residual update ratios.
- Preserve support for TP, CP, and hyper-connection layouts.

### Runtime Robustness

- Add per-monitor status metrics for compatible sources, observations, observed layers, and runtime errors.
- Reject invalid monitor intervals.
- Reuse existing monitors when setup is repeated with the same configuration.
- Replace and clean up hooks when the configuration changes.
- Raise monitor setup failures instead of silently continuing with incomplete diagnostics.
- Add a capability reference covering metric definitions, formulas, backend support, and lifecycle requirements.

## Compatibility

The PaddleFleet backend exposes the following forward monitors:

- `qk_stats`
- `moe_health`
- `massive_act`
- `mhc_health`

The existing Megatron `ple_health` implementation is unchanged.

This PR intentionally excludes:

- gradient and optimizer-update monitoring
- optimizer lifecycle callbacks
- `function_change` diagnostics
- ErnieBot/iCode repository changes

## Validation

- PaddleFleet CPU test suite: `44 passed, 8 skipped`
- PaddleFleet H800 GPU test suite: `50 passed, 2 skipped`
- Ruff lint and format checks: passed
- Python compilation check: passed
- Wheel build, installation, and clean import: passed
- Verified that the wheel contains no deferred gradient/update modules
- Verified compatibility with the current PaddleFormers callback API:
  `setup_monitors`, `monitor.step`, `gather_and_aggregate`, and `reset`
