### PR TITLE
feat(qk_stats): exact statistics for window + compressed-KV layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 包含五大监控模块：
 - **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (13 指标)
-- **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标)
-- **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (21 指标)
+- **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
+- **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 8 指标；仅在开启 mHC 层时生效)
 
@@ -202,6 +202,49 @@ setup_internal_medicine()
 | 7 | `sink_head_ratio` | `qk_stats/.../sink_head_ratio` | `count(sink>θ)/N_heads` | 每层+全局 | Sink head 占比 |
 | 8 | `sink_head_max` | `qk_stats/.../sink_head_max` | `max(sink_per_head)` | 每层+全局 | 最强 sink head 权重 |
 | 9 | `sink_nonsink_gap` | `qk_stats/.../sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | 每层+全局 | Sink/非Sink 分化度 |
+| 10 | `attn_sink_logit` | `qk_stats/.../attn_sink_logit` | `mean(attn_sink)` | 每层+全局 | 仅 CSA/HCA 层；learned sink logit 量级漂移 |
+
+### 混合注意力栈的层类型标签 (attn_type)
+
+指标键会带上层类型前缀，避免不同注意力类型的统计混在同一张图里。
+
+- **`csa_compress_ratios` 描述的栈**（由 `experimental_attention_variant="dsv4_hybrid"` 标记）：
+  按每层 ratio 分类为 `mla`(-2) / `mqa`(-1) / `window`(0) / `csa`(2..127) / `hca`(128)。
+  例：`qk_stats/layer_8/hca_entropy_avg`、`qk_stats/global_mla_entropy_avg`。
+  这类 config 不设 `sliding_window`，层类型完全由 ratio 决定。
+- **`sliding_window`（+ `window_attn_skip_freq`）描述的栈**：用 `Attention.__init__` 逐层算出的
+  `is_swa` → `swa` / `full`。
+- **两个字段都没有的栈**：无标签，键布局保持不变（向后兼容，避免已有看板断档）。
+
+### CSA / HCA 层的统计口径
+
+这类层的 query 不做全因果注意力，key 集合是「sliding window ∪ 压缩 KV」，且 softmax 分母里
+还有一个 learned per-head `attn_sink`。qk_stats 对它们走独立路径：包裹
+`CompressedSparseAttention.compressed_sparse_attn`，从调用入参直接取真实的
+`topk_idxs` / `kv_full` / `attn_sink` / `softmax_scale`（层自身的 `v_head_dim ** -0.5`），
+再用两段式稀疏 kernel（`qk_stats_sparse_partial_kernel`）在真实 key 集合上做单次 softmax
+统计。索引取自模型自身，因此 document mask 下的文档边界重置、以及 learned indexer 的 top-k
+选择都自动覆盖。
+
+指标语义：
+
+- `sink`：该 row **可达的最早 key** 的权重。有压缩段时指向首个压缩块（概括序列/文档开头），
+  否则是窗口内最旧位置；dense causal 层下退化为 token-0。
+- `attn_sink_logit`：learned sink 参数的均值，用于观察它在训练中的漂移。
+
+启用 learned indexer 的层（`compress_ratio` 在 `[2, 127]` 且未开 `csa_dense_mode`）压缩 key
+是运行时 top-k 选出的，统计会覆盖真实 key 的超集，注册 hook 时会打一条 warning。
+
+读数注意 —— **`sink` 与 `entropy` 的绝对值不可跨层类型比较**：
+
+- 粒度不同：dense 层的 key 是单个 token，压缩段的 key 是一个 `compress_ratio` 大小的聚合块
+- key 集合大小不同：dense 层 O(S)，稀疏层 O(window + S/ratio)，熵的上界随之不同
+- logit 尺度不同：压缩 key 由 Compressor 的独立参数产出，与原始 K 不在同一尺度，
+  而 softmax 对 logit 尺度敏感
+- 分母组成不同：稀疏层含 learned `attn_sink`，dense 路径默认没有对应项
+
+因此只做**同类层之间的横向对比**（如 `hca_sink` 随层号的变化）或**同一 key 的纵向趋势**。
+global 指标已按层类型拆分，不要再把不同类型平均到一起。
 
 ---
 
@@ -396,6 +439,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **QK** | `sink_head_ratio` | `count(sink>threshold)/N_heads` | mean | Sink head 占比 |
 | **QK** | `sink_head_max` | `max(sink_per_head)` | max | 最强 sink head |
 | **QK** | `sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | mean | Sink vs 非Sink gap |
+| **QK** | `attn_sink_logit` | `mean(attn_sink)` | mean | CSA/HCA 层；learned sink 量级 |
 | **MassiveAct** | `channel_max` | `max(abs(H_i))` | max | 通道峰值激活 |
 | **MassiveAct** | `channel_median` | `median(per_channel_max)` | max | 通道峰值基准量级 |
 | **MassiveAct** | `channel_p95` | `p95(per_channel_max)` | max | 高分位通道幅度 |

--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -162,10 +162,12 @@ class PaddleProbe(Probe):
         1. 根据 MAX_AGGREGATED/MIN_AGGREGATED 选择聚合方式，注册 layer key
         2. 建立 layer_key → global_key 的分组映射，flush 时自动推导 global
 
-        ``attn_type`` (optional): when set (``"swa"`` / ``"full"``), the tag is
-        prepended to ``metric_name`` in both layer and global keys so the
-        viewer renders window vs full statistics in separate charts. When
-        ``None``, legacy key layout is preserved.
+        ``attn_type`` (optional): when set (``"mla"`` / ``"hca"`` / ``"csa"`` /
+        ``"window"`` / ``"mqa"`` on ``csa_compress_ratios`` stacks, ``"swa"`` /
+        ``"full"`` on ``sliding_window`` stacks), the tag is prepended to
+        ``metric_name`` in both layer and global keys so the viewer renders each
+        attention kind in a separate chart. When ``None``, legacy key layout is
+        preserved.
         """
         if not (self.log_per_layer or self.log_global):
             return

--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -13,12 +13,40 @@ class MonitorLayer:
     idx: int
     layer: object
     is_mtp: bool = False
-    # Attention type tag for models that mix window / full attention (e.g. ernie-lite).
-    # ``"swa"`` for sliding-window layers, ``"full"`` for full-attention layers,
-    # ``None`` when the layer does not expose an ``is_swa`` flag (backward compat
-    # for eb5_v2 / dsv4). Monitors use this to split metric keys so window vs
-    # full statistics never mix in the same chart.
+    # Attention kind tag for stacks that mix kinds across layers. Which config
+    # field describes the mix decides the value space (see classify_attn_type):
+    #   - ``csa_compress_ratios`` present  -> ``"mla"`` / ``"mqa"`` /
+    #     ``"window"`` / ``"csa"`` / ``"hca"``
+    #   - ``sliding_window`` present       -> ``"swa"`` / ``"full"``
+    #   - neither                          -> ``None`` (homogeneous stack; keeps
+    #     the legacy untagged metric keys)
+    # Monitors prepend this to the metric name so statistics of different
+    # attention kinds never mix in one chart.
     attn_type: str | None = None
+    # Structural metadata needed to reproduce the real attention key set (see
+    # ``qk_monitor``). Only available on ``csa_compress_ratios`` stacks.
+    compress_ratio: int | None = None
+    window_size: int | None = None
+    # True when the layer runs a learned Lightning Indexer, i.e. the compressed
+    # key set is top-k selected at runtime and cannot be reconstructed from
+    # ``csa_compress_ratios`` alone.
+    has_indexer: bool = False
+
+
+# Sentinel values of ``config.csa_compress_ratios``; keep in sync with
+# ``paddlefleet.transformer.transformer_config`` validation and
+# ``paddlefleet.transformer.csa_attention``.
+MLA_RATIO = -2
+MQA_RATIO = -1
+WINDOW_RATIO = 0
+HCA_RATIO = 128
+
+_RATIO_KINDS = {
+    MLA_RATIO: "mla",
+    MQA_RATIO: "mqa",
+    WINDOW_RATIO: "window",
+    HCA_RATIO: "hca",
+}
 
 
 def _flatten_model_chunks(model) -> list[object] | None:
@@ -77,28 +105,94 @@ def unwrap_mtp_layer(layer):
     return getattr(layer, "transformer_layer", None) if is_mtp_wrapper(layer) else layer
 
 
-def classify_attn_type(layer) -> str | None:
-    """Classify a transformer layer as sliding-window or full attention.
-
-    Reads ``layer.self_attn.is_swa`` (or ``layer.self_attention.is_swa``) — a
-    boolean set at model init by the attention module. Returns:
-
-    - ``"swa"`` if the layer uses sliding-window attention
-    - ``"full"`` if the layer uses full attention
-    - ``None`` if the attention module does not expose ``is_swa`` (e.g.
-      eb5_v2 / dsv4 where all layers are homogeneous). Callers should treat
-      ``None`` as "do not tag metrics with attention type" so those models
-      keep their existing metric key layout.
-    """
+def get_attention_module(layer):
+    """Return the layer's self-attention module, or ``None``."""
     attn = getattr(layer, "self_attn", None)
     if attn is None:
         attn = getattr(layer, "self_attention", None)
-    if attn is None:
+    return attn
+
+
+def _uses_compress_ratios(attn) -> bool:
+    """True when the stack describes its per-layer attention kind via ratios.
+
+    Signalled by ``config.experimental_attention_variant == "dsv4_hybrid"``,
+    which is what makes ``config.csa_compress_ratios`` authoritative. Gating on
+    the field (not on a model name) keeps stacks that carry no mix information
+    on their existing untagged metric keys.
+    """
+    config = getattr(attn, "config", None)
+    if config is None:
+        return False
+    return getattr(config, "experimental_attention_variant", None) == "dsv4_hybrid"
+
+
+def _compress_ratio_meta(attn) -> tuple[str, int | None, int | None, bool] | None:
+    """Classify one layer of a ``csa_compress_ratios`` stack.
+
+    Returns ``(kind, compress_ratio, window_size, has_indexer)``, or ``None``
+    when the stack is not ratio-described.
+
+    Layers whose ratio selects sparse attention build a
+    ``CompressedSparseAttention`` core that carries the per-layer
+    ``compress_ratio``; ratio ``-2`` builds an ``MLASelfAttention`` instead,
+    which exposes no ratio.
+    """
+    if not _uses_compress_ratios(attn):
         return None
+    core = getattr(attn, "core_attention", None)
+    ratio = getattr(core, "compress_ratio", None)
+    if ratio is None:
+        # No CSA core in a ratio-described stack -> this is the MLA branch (-2).
+        return ("mla", MLA_RATIO, None, False)
+    ratio = int(ratio)
+    kind = _RATIO_KINDS.get(ratio)
+    if kind is None:
+        kind = "csa" if 2 <= ratio < HCA_RATIO else "unknown"
+    window_size = getattr(core, "window_size", None)
+    has_indexer = getattr(core, "indexer", None) is not None
+    return (kind, ratio, window_size, has_indexer)
+
+
+def attn_meta(layer) -> tuple[str | None, int | None, int | None, bool]:
+    """Return ``(attn_type, compress_ratio, window_size, has_indexer)``.
+
+    Ratio-described stacks are classified from ``compress_ratio``; otherwise the
+    ``is_swa`` flag is used (see :func:`classify_attn_type`).
+    """
+    attn = get_attention_module(layer)
+    if attn is None:
+        return (None, None, None, False)
+    by_ratio = _compress_ratio_meta(attn)
+    if by_ratio is not None:
+        return by_ratio
     is_swa = getattr(attn, "is_swa", None)
     if is_swa is None:
-        return None
-    return "swa" if is_swa else "full"
+        return (None, None, None, False)
+    return ("swa" if is_swa else "full", None, None, False)
+
+
+def classify_attn_type(layer) -> str | None:
+    """Classify a transformer layer's attention kind.
+
+    Which config field describes the layer mix decides the value space; the two
+    mechanisms are independent and never both apply:
+
+    1. ``csa_compress_ratios`` (flagged by
+       ``experimental_attention_variant="dsv4_hybrid"``): the per-layer kind
+       implied by the ratio — ``"mla"`` (-2), ``"mqa"`` (-1), ``"window"`` (0),
+       ``"csa"`` (2..127), ``"hca"`` (128). ``is_swa`` is useless here because
+       it is derived from ``config.sliding_window``, which these configs do not
+       set, so every layer would look like ``"full"``.
+    2. ``config.sliding_window`` (+ ``window_attn_skip_freq``): the ``is_swa``
+       flag that ``Attention.__init__`` computes per layer → ``"swa"`` /
+       ``"full"``.
+
+    Returns ``None`` when neither field is present (homogeneous stack), which
+    callers treat as "do not tag metrics with attention kind" so those runs keep
+    their existing metric key layout.
+    """
+    return attn_meta(layer)[0]
 
 
 def resolve_layer_idx(layer, local_idx: int, num_local_layers: int, pp_rank: int = 0, layer_offset: int = 0) -> int:
@@ -135,11 +229,21 @@ def iter_monitor_layers(
     num_main_layers = len(matched_main_layers)
     monitor_layers: list[MonitorLayer] = []
 
+    def _make(idx: int, layer: object, is_mtp: bool) -> MonitorLayer:
+        kind, ratio, window_size, has_indexer = attn_meta(layer)
+        return MonitorLayer(
+            idx=idx,
+            layer=layer,
+            is_mtp=is_mtp,
+            attn_type=kind,
+            compress_ratio=ratio,
+            window_size=window_size,
+            has_indexer=has_indexer,
+        )
+
     for local_idx, layer in enumerate(matched_main_layers):
         idx = resolve_layer_idx(layer, local_idx, num_main_layers, pp_rank=pp_rank, layer_offset=layer_offset)
-        monitor_layers.append(
-            MonitorLayer(idx=idx, layer=layer, is_mtp=False, attn_type=classify_attn_type(layer))
-        )
+        monitor_layers.append(_make(idx, layer, False))
 
     next_mtp_idx = max((item.idx for item in monitor_layers), default=layer_offset - 1) + 1
     for mtp_idx, wrapper in enumerate(mtp_wrappers):
@@ -147,8 +251,6 @@ def iter_monitor_layers(
         if not matches(layer):
             continue
         idx = next_mtp_idx + mtp_idx
-        monitor_layers.append(
-            MonitorLayer(idx=idx, layer=layer, is_mtp=True, attn_type=classify_attn_type(layer))
-        )
+        monitor_layers.append(_make(idx, layer, True))
 
     return monitor_layers

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -11,9 +11,21 @@ import paddle
 import paddle.nn as nn
 
 from .base import PaddleProbe
-from .layer_discovery import get_decoder_layers, iter_monitor_layers
+from .layer_discovery import MLA_RATIO, MQA_RATIO, get_decoder_layers, iter_monitor_layers
 
 logger = logging.getLogger(__name__)
+
+
+class _MethodPatch:
+    """Handle for a monkey-patched bound method, shaped like a paddle hook."""
+
+    def __init__(self, module, name: str, original):
+        self._module = module
+        self._name = name
+        self._original = original
+
+    def remove(self) -> None:
+        setattr(self._module, self._name, self._original)
 
 
 def compute_sink_head_classification(sink_per_head: paddle.Tensor, threshold: float = 0.3) -> dict:
@@ -238,11 +250,219 @@ def compute_qk_stats_paddle(
     )
 
 
+def _segment_bounds(idx: paddle.Tensor, base: int) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
+    """Reduce a per-row key-index set to inclusive ``[lo, hi]`` bounds.
+
+    ``idx`` is ``[B, S, K]`` with ``-1`` marking unused slots (the convention
+    used by PaddleFleet's window / compressed index helpers). Rows whose set is
+    empty get ``lo = base, hi = base - 1`` so the kernel skips them without
+    dragging the block's scalar loop bounds outside the segment.
+    """
+    valid = idx >= 0
+    far = paddle.full_like(idx, 1 << 30)
+    lo = paddle.where(valid, idx, far).min(axis=-1)
+    hi = paddle.where(valid, idx, paddle.full_like(idx, -1)).max(axis=-1)
+    empty = hi < lo
+    lo = paddle.where(empty, paddle.full_like(lo, base), lo)
+    hi = paddle.where(empty, paddle.full_like(hi, base - 1), hi)
+    return lo.astype("int32"), hi.astype("int32")
+
+
+def sparse_bounds_from_topk(topk_idxs: paddle.Tensor, seq_len_orig: int) -> dict:
+    """Split the model's real key indices into window / compressed segments.
+
+    ``topk_idxs`` is what ``CompressedSparseAttention`` feeds to its sparse
+    attention kernel: ``[B, S, K]`` indices into ``kv_full = concat([kv,
+    compressed_kv])``, with ``-1`` for unused slots. Indices below
+    ``seq_len_orig`` address original KV (the sliding window), the rest address
+    compressed KV. Splitting by value rather than by column width keeps this
+    correct regardless of how the model orders the concatenation.
+
+    Both segments are contiguous whenever the compressed keys are taken whole
+    (``compress_ratio`` 128, or any ratio under ``csa_dense_mode``). A learned
+    indexer selects a sparse subset instead, and the ranges then cover a
+    superset of the real keys — layers with an indexer are warned about once at
+    hook registration.
+
+    ``sink_col`` is the row's earliest reachable key — the first compressed
+    block when there is one (it summarises the start of the sequence/document),
+    otherwise the oldest in-window position. For dense causal attention this
+    degenerates to column 0, matching the legacy ``sink`` metric.
+    """
+    orig = paddle.where(topk_idxs < seq_len_orig, topk_idxs, paddle.full_like(topk_idxs, -1))
+    comp = paddle.where(topk_idxs >= seq_len_orig, topk_idxs, paddle.full_like(topk_idxs, -1))
+
+    win_lo, win_hi = _segment_bounds(orig, 0)
+    cmp_lo, cmp_hi = _segment_bounds(comp, seq_len_orig)
+
+    has_comp = cmp_hi >= cmp_lo
+    sink_col = paddle.where(has_comp, cmp_lo, win_lo)
+
+    return {
+        "win_lo": win_lo,
+        "win_hi": win_hi,
+        "cmp_lo": cmp_lo,
+        "cmp_hi": cmp_hi,
+        "sink_col": sink_col.astype("int32"),
+    }
+
+
+def _compute_qk_stats_sparse_triton(
+    q: paddle.Tensor,
+    k: paddle.Tensor,
+    bounds: dict,
+    attn_sink: paddle.Tensor | None,
+    scale: float,
+    heads_per_group: int = 1,
+    row_stride: int = 1,
+) -> dict:
+    """Triton path for two-segment sparse attention stats.
+
+    ``q``: ``[B, H, S_q, D]``, ``k``: ``[B, H_kv, S_k, D]`` (``S_k`` covers
+    ``kv_full``). Reuses the same partial-buffer reduction as the dense path so
+    both produce identical metric semantics.
+    """
+    _ensure_triton_driver()
+    from ...core.triton_qk_kernel import qk_stats_sparse_partial_kernel
+
+    batch, num_heads, seq_len_q, head_dim = q.shape
+    seq_len_k = k.shape[2]
+
+    BLOCK_M = 64
+    BLOCK_N = 64
+    BLOCK_K = 64 if head_dim <= 64 else 128
+
+    m_block_span = BLOCK_M * row_stride
+    num_m_blocks = (seq_len_q + m_block_span - 1) // m_block_span
+
+    partial_shape = [batch, num_heads, num_m_blocks]
+    partial_max = paddle.empty(partial_shape, dtype="float32")
+    partial_sum_logit = paddle.empty(partial_shape, dtype="float32")
+    partial_sum_row_mean = paddle.empty(partial_shape, dtype="float32")
+    partial_count = paddle.empty(partial_shape, dtype="float32")
+    partial_sum_entropy = paddle.empty(partial_shape, dtype="float32")
+    partial_sum_sink = paddle.empty(partial_shape, dtype="float32")
+    partial_valid_rows = paddle.empty(partial_shape, dtype="float32")
+
+    win_lo = bounds["win_lo"]
+    sink_present = attn_sink is not None
+    sink_buf = attn_sink if sink_present else paddle.zeros([num_heads], dtype="float32")
+
+    grid = (batch * num_heads, num_m_blocks)
+    qk_stats_sparse_partial_kernel[grid](
+        q,
+        k,
+        win_lo,
+        bounds["win_hi"],
+        bounds["cmp_lo"],
+        bounds["cmp_hi"],
+        bounds["sink_col"],
+        sink_buf,
+        partial_max,
+        partial_sum_logit,
+        partial_sum_row_mean,
+        partial_count,
+        partial_sum_entropy,
+        partial_sum_sink,
+        partial_valid_rows,
+        batch,
+        num_heads,
+        seq_len_q,
+        seq_len_k,
+        head_dim,
+        heads_per_group,
+        num_m_blocks,
+        q.strides[0],
+        q.strides[1],
+        q.strides[2],
+        q.strides[3],
+        k.strides[0],
+        k.strides[1],
+        k.strides[2],
+        k.strides[3],
+        win_lo.strides[0],
+        win_lo.strides[1],
+        partial_max.strides[0],
+        partial_max.strides[1],
+        partial_max.strides[2],
+        scale=scale,
+        HAS_SINK=sink_present,
+        ROW_STRIDE=row_stride,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+    )
+
+    max_logits = partial_max.max(axis=-1)
+    total_rows = partial_valid_rows.sum(axis=-1).clip(min=1.0)
+    mean_logits = partial_sum_row_mean.sum(axis=-1) / total_rows
+    entropy = partial_sum_entropy.sum(axis=-1) / total_rows
+    sink = partial_sum_sink.sum(axis=-1) / total_rows
+
+    return {
+        "max_per_head": max_logits,
+        "mean_per_head": mean_logits,
+        "entropy_per_head": entropy,
+        "sink_per_head": sink,
+        "max_global": max_logits.max(),
+        "mean_global": mean_logits.mean(),
+        "entropy_global": entropy.mean(),
+        "sink_global": sink.mean(),
+    }
+
+
+def compute_qk_stats_sparse_paddle(
+    query: paddle.Tensor,
+    kv_full: paddle.Tensor,
+    topk_idxs: paddle.Tensor,
+    softmax_scale: float,
+    attn_sink: paddle.Tensor | None = None,
+    row_stride: int = 1,
+) -> dict:
+    """QK stats over the exact key set of a window + compressed-KV layer.
+
+    Args:
+        query: ``[B, S, H, D]`` as handed to the model's sparse attention.
+        kv_full: ``[B, S + n_compressed, D]`` single-head (MQA) keys, i.e.
+            original KV concatenated with compressed KV.
+        topk_idxs: ``[B, S, K]`` real key indices into ``kv_full``.
+        softmax_scale: the scale the layer itself uses (``v_head_dim ** -0.5``),
+            not ``1 / sqrt(head_dim)`` of the monitored tensor.
+        attn_sink: learned per-head sink logit ``[H]``, folded into the softmax
+            denominator. ``None`` to omit.
+    """
+    if not query.place.is_gpu_place():
+        raise RuntimeError("[PaddleQKMonitor] QK stats requires GPU (triton kernel)")
+
+    seq_len_orig = query.shape[1]
+    if kv_full.ndim == 3:
+        kv_full = kv_full.unsqueeze(2)  # [B, S_k, 1, D]
+
+    num_q_heads = query.shape[2]
+    num_k_heads = kv_full.shape[2]
+    heads_per_group = num_q_heads // num_k_heads if num_k_heads > 0 else 1
+
+    bounds = sparse_bounds_from_topk(topk_idxs, seq_len_orig)
+
+    q = query.transpose([0, 2, 1, 3])
+    k = kv_full.transpose([0, 2, 1, 3])
+
+    stats = _compute_qk_stats_sparse_triton(
+        q,
+        k,
+        bounds,
+        attn_sink,
+        scale=softmax_scale,
+        heads_per_group=heads_per_group,
+        row_stride=row_stride,
+    )
+    return stats
+
+
 class PaddleQKStatsMonitor(PaddleProbe):
     METRIC_PREFIX = "qk_stats"
     MAX_AGGREGATED = {"max", "entropy_max", "sink_head_max"}
     MIN_AGGREGATED = {"entropy_min"}
-
     def __init__(
         self,
         causal=True,
@@ -326,7 +546,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 self.cp_size,
             )
 
-        for layer_idx, _attn_module, attn_type in attention_layers:
+        for layer_idx, _attn_module, item in attention_layers:
             for m in (
                 "max",
                 "mean",
@@ -339,20 +559,126 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 "sink_head_max",
                 "sink_nonsink_gap",
             ):
-                self.declare_layer_metric(layer_idx, m, attn_type=attn_type)
+                self.declare_layer_metric(layer_idx, m, attn_type=item.attn_type)
+            if self._is_sparse_layer(item):
+                self.declare_layer_metric(layer_idx, "attn_sink_logit", attn_type=item.attn_type)
 
         self.allocate_buffers()
 
-        for layer_idx, attn_module, attn_type in attention_layers:
+        for layer_idx, attn_module, item in attention_layers:
+            if self._is_sparse_layer(item):
+                patch = self._patch_sparse_attn(layer_idx, attn_module, item)
+                if patch is not None:
+                    self.hooks.append(patch)
+                    continue
             if hasattr(attn_module, "core_attention"):
                 hook = attn_module.core_attention.register_forward_pre_hook(
-                    self._make_compute_hook(layer_idx, attn_type)
+                    self._make_compute_hook(layer_idx, item.attn_type)
                 )
                 self.hooks.append(hook)
 
         logger.info(f"[PaddleQKMonitor] Registered {len(self.hooks)} hooks.")
 
-    def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer, str | None]]:
+    def _is_sparse_layer(self, item) -> bool:
+        """True for layers whose core attention is window + compressed KV.
+
+        That is any ratio-described layer other than ``-2`` (MLA) and ``-1``
+        (full-causal MQA). Those layers attend to a sliding window plus
+        compressed KV under one softmax, which the dense causal kernel cannot
+        describe.
+        """
+        ratio = item.compress_ratio
+        if ratio is None or ratio in (MLA_RATIO, MQA_RATIO):
+            return False
+        core = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
+        core = getattr(core, "core_attention", None)
+        return hasattr(core, "compressed_sparse_attn")
+
+    def _patch_sparse_attn(self, layer_idx: int, attn_module, item):
+        """Wrap ``CompressedSparseAttention.compressed_sparse_attn``.
+
+        That call receives everything needed for an exact reproduction of the
+        layer's attention distribution — the post-RoPE query, ``kv_full``, the
+        real ``topk_idxs``, the learned ``attn_sink`` and the layer's own
+        ``softmax_scale`` — so nothing has to be re-derived and the
+        document-mask / indexer variants are covered by construction.
+        """
+        core = getattr(attn_module, "core_attention", None)
+        original = getattr(core, "compressed_sparse_attn", None)
+        if original is None:
+            return None
+        if self.cp_size > 1:
+            logger.warning(
+                "[PaddleQKMonitor] CP=%d with sparse (CSA/HCA) layers is not "
+                "supported; skipping qk_stats for layer %d.",
+                self.cp_size,
+                layer_idx,
+            )
+            return None
+        if item.has_indexer:
+            # A learned indexer picks a sparse subset of the compressed blocks,
+            # so the two [lo, hi] ranges cover a superset of the real keys.
+            logger.warning(
+                "[PaddleQKMonitor] layer %d runs a learned indexer; its qk_stats "
+                "cover a superset of the selected compressed keys.",
+                layer_idx,
+            )
+
+        monitor = self
+        attn_type = item.attn_type
+
+        def wrapped(query, kv_full, attn_sink, topk_idxs, softmax_scale, topk_length=None):
+            out = original(query, kv_full, attn_sink, topk_idxs, softmax_scale, topk_length=topk_length)
+            if core.training and monitor._should_monitor():
+                monitor._record_sparse_stats(
+                    layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale
+                )
+            return out
+
+        core.compressed_sparse_attn = wrapped
+        return _MethodPatch(core, "compressed_sparse_attn", original)
+
+    def _record_sparse_stats(
+        self, layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale
+    ) -> None:
+        try:
+            with paddle.no_grad():
+                stats = compute_qk_stats_sparse_paddle(
+                    query.detach(),
+                    kv_full.detach(),
+                    topk_idxs.detach(),
+                    float(softmax_scale),
+                    attn_sink=None if attn_sink is None else attn_sink.detach().astype("float32"),
+                    row_stride=self.row_stride,
+                )
+                self._record_common_stats(layer_idx, attn_type, stats)
+                if attn_sink is not None:
+                    self.record_layer_metric(
+                        layer_idx,
+                        "attn_sink_logit",
+                        attn_sink.detach().astype("float32").mean(),
+                        attn_type=attn_type,
+                    )
+        except Exception as e:
+            logger.error(f"[PaddleQKMonitor] Error sparse layer {layer_idx}: {e}")
+
+    def _record_common_stats(self, layer_idx, attn_type, stats) -> None:
+        all_heads = stats["entropy_per_head"]
+        self.record_layer_metric(layer_idx, "max", stats["max_global"], attn_type=attn_type)
+        self.record_layer_metric(layer_idx, "mean", stats["mean_global"], attn_type=attn_type)
+        self.record_layer_metric(layer_idx, "entropy_avg", stats["entropy_global"], attn_type=attn_type)
+        self.record_layer_metric(layer_idx, "sink", stats["sink_global"], attn_type=attn_type)
+        self.record_layer_metric(layer_idx, "entropy_min", all_heads.min(), attn_type=attn_type)
+        self.record_layer_metric(layer_idx, "entropy_max", all_heads.max(), attn_type=attn_type)
+        self.record_layer_metric(layer_idx, "entropy_std", all_heads.std(), attn_type=attn_type)
+        # sink_per_head: [B, H] — average across batch to get [H]
+        sink_per_head = stats["sink_per_head"]
+        sink_for_classify = sink_per_head.mean(axis=0) if sink_per_head.ndim > 1 else sink_per_head
+        sink_class = compute_sink_head_classification(sink_for_classify, threshold=self.sink_head_threshold)
+        for name, val in sink_class.items():
+            self.record_layer_metric(layer_idx, name, val, attn_type=attn_type)
+
+    def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer, object]]:
         def has_attention(layer):
             return hasattr(layer, "self_attn") or hasattr(layer, "self_attention")
 
@@ -369,7 +695,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
         for item in monitor_layers:
             attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
             if attn is not None:
-                attention_layers.append((item.idx, attn, item.attn_type))
+                attention_layers.append((item.idx, attn, item))
         return attention_layers
 
     def _cp_gather_seq(self, tensor: paddle.Tensor) -> paddle.Tensor | None:
@@ -453,20 +779,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
                             dist.all_reduce(t, op=dist.ReduceOp.SUM, group=self.cp_group)
                             stats[key_name] = t / float(self.cp_size)
 
-                all_heads = stats["entropy_per_head"]
-                self.record_layer_metric(layer_idx, "max", stats["max_global"], attn_type=attn_type)
-                self.record_layer_metric(layer_idx, "mean", stats["mean_global"], attn_type=attn_type)
-                self.record_layer_metric(layer_idx, "entropy_avg", stats["entropy_global"], attn_type=attn_type)
-                self.record_layer_metric(layer_idx, "sink", stats["sink_global"], attn_type=attn_type)
-                self.record_layer_metric(layer_idx, "entropy_min", all_heads.min(), attn_type=attn_type)
-                self.record_layer_metric(layer_idx, "entropy_max", all_heads.max(), attn_type=attn_type)
-                self.record_layer_metric(layer_idx, "entropy_std", all_heads.std(), attn_type=attn_type)
-                # sink_per_head: [B, H] — average across batch to get [H]
-                sink_per_head = stats["sink_per_head"]
-                sink_for_classify = sink_per_head.mean(axis=0) if sink_per_head.ndim > 1 else sink_per_head
-                sink_class = compute_sink_head_classification(sink_for_classify, threshold=self.sink_head_threshold)
-                for name, val in sink_class.items():
-                    self.record_layer_metric(layer_idx, name, val, attn_type=attn_type)
+                self._record_common_stats(layer_idx, attn_type, stats)
             except Exception as e:
                 logger.error(f"[PaddleQKMonitor] Error layer {layer_idx}: {e}")
 

--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -7,6 +7,15 @@ Supports asymmetric Q/K sequence lengths for Context-Parallel (CP) monitoring:
 each CP rank keeps its local Q shard (``seq_len_q = S/CP``) but sees the
 full-sequence K (``seq_len_k = S``) after an all_gather. Passing
 ``q_row_offset = cp_rank * seq_len_q`` restores correct causal masking.
+
+Two families of kernels live here:
+
+* ``qk_stats_kernel`` / ``qk_stats_partial_kernel`` — dense causal attention.
+* ``qk_stats_sparse_partial_kernel`` — two-segment sparse attention, used for
+  stacks whose per-layer kind comes from ``csa_compress_ratios``, where a query
+  attends to a sliding window over the original KV plus a contiguous run of
+  compressed KV entries, under a single softmax that also includes a learned
+  per-head sink logit.
 """
 
 import triton
@@ -200,8 +209,7 @@ def qk_stats_kernel(
     out_offset = batch_idx * stride_out_batch + head_idx * stride_out_head
 
     # NOTE: mean_logit uses row-first semantics (mean over valid rows of the
-    # per-row mean logit) rather than count-weighted position mean. 
-    safe_count = tl.maximum(head_valid_count, 1.0)
+    # per-row mean logit) rather than count-weighted position mean.
     safe_rows = tl.maximum(head_valid_rows, 1.0)
 
     tl.store(max_logits_ptr + out_offset, head_max_logit)
@@ -371,6 +379,321 @@ def qk_stats_partial_kernel(
     block_max_logit = tl.max(tl.where(m_mask, row_max_logit_raw, -1e10))
     block_sum_logit = tl.sum(tl.where(valid_mask, row_sum_logit_raw, 0.0))
     # Row-first mean: sum of per-row means (needed so CP composes via mean-of-means).
+    safe_row_count = tl.where(row_count_raw > 0, row_count_raw, 1.0)
+    row_mean_logit = row_sum_logit_raw / safe_row_count
+    block_sum_row_mean = tl.sum(tl.where(valid_mask, row_mean_logit, 0.0))
+    block_count = tl.sum(tl.where(m_mask, row_count_raw, 0.0))
+    block_sum_entropy = tl.sum(tl.where(valid_mask, row_entropy, 0.0))
+    block_sum_sink = tl.sum(tl.where(valid_mask, row_sink, 0.0))
+    block_valid_rows = tl.sum(valid_mask.to(tl.float32))
+
+    out_offset = batch_idx * stride_p_batch + head_idx * stride_p_head + pid_m * stride_p_m
+
+    tl.store(partial_max_ptr + out_offset, block_max_logit)
+    tl.store(partial_sum_logit_ptr + out_offset, block_sum_logit)
+    tl.store(partial_sum_row_mean_ptr + out_offset, block_sum_row_mean)
+    tl.store(partial_count_ptr + out_offset, block_count)
+    tl.store(partial_sum_entropy_ptr + out_offset, block_sum_entropy)
+    tl.store(partial_sum_sink_ptr + out_offset, block_sum_sink)
+    tl.store(partial_valid_rows_ptr + out_offset, block_valid_rows)
+
+
+@triton.jit
+def _accumulate_segment(
+    q_base,
+    k_base,
+    m_offsets,
+    m_mask,
+    row_lo,
+    row_hi,
+    sink_col,
+    seg_start,
+    seg_stop,
+    seq_len_k,
+    head_dim,
+    stride_q_seq,
+    stride_q_dim,
+    stride_k_seq,
+    stride_k_dim,
+    m_i,
+    d_i,
+    h_i,
+    s_i,
+    row_max_logit_raw,
+    row_sum_logit_raw,
+    row_count_raw,
+    scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Fold one contiguous key segment into the running online-softmax state.
+
+    ``row_lo`` / ``row_hi`` are per-row *inclusive* key bounds within this
+    segment; a row with ``row_hi < row_lo`` contributes nothing. ``seg_start`` /
+    ``seg_stop`` are the scalar loop bounds covering the union of the block's
+    rows, so the visited column span stays proportional to the segment width
+    instead of the full sequence.
+
+    Calling this twice (window segment, then compressed segment) yields exactly
+    the same result as one softmax over the union of both key sets, because the
+    online-softmax state composes across disjoint column ranges.
+    """
+    for n_start in range(seg_start, seg_stop, BLOCK_N):
+        n_offsets = n_start + tl.arange(0, BLOCK_N)
+        n_mask = n_offsets < seq_len_k
+
+        acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        for k_start in range(0, head_dim, BLOCK_K):
+            k_offsets = k_start + tl.arange(0, BLOCK_K)
+            k_mask = k_offsets < head_dim
+
+            q_ptr = q_base + m_offsets[:, None] * stride_q_seq + k_offsets[None, :] * stride_q_dim
+            q = tl.load(q_ptr, mask=m_mask[:, None] & k_mask[None, :], other=0.0)
+
+            k_ptr = k_base + n_offsets[:, None] * stride_k_seq + k_offsets[None, :] * stride_k_dim
+            k = tl.load(k_ptr, mask=n_mask[:, None] & k_mask[None, :], other=0.0)
+
+            acc += tl.dot(q, tl.trans(k))
+
+        logits = acc * scale
+
+        in_range = (n_offsets[None, :] >= row_lo[:, None]) & (n_offsets[None, :] <= row_hi[:, None])
+        mask_val = n_mask[None, :] & m_mask[:, None] & in_range
+
+        logits = tl.where(mask_val, logits, -1e10)
+
+        block_max = tl.max(logits, 1)
+        row_max_logit_raw = tl.maximum(row_max_logit_raw, block_max)
+
+        logits_zeroed = tl.where(mask_val, logits, 0.0)
+        row_sum_logit_raw += tl.sum(logits_zeroed, 1)
+        row_count_raw += tl.sum(mask_val.to(tl.float32), 1)
+
+        # Online softmax update
+        m_new = tl.maximum(m_i, block_max)
+
+        alpha_prev = tl.exp(m_i - m_new)
+        alpha_curr = tl.exp(logits - m_new[:, None])
+        alpha_curr = tl.where(mask_val, alpha_curr, 0.0)
+
+        # h tracks sum of p_unnorm * (logit - m); rescaling it on an m shift
+        # needs the *previous* d, so update h before d.
+        h_term_prev = h_i * alpha_prev + (m_i - m_new) * d_i * alpha_prev
+        logits_diff = logits - m_new[:, None]
+        h_i = h_term_prev + tl.sum(tl.where(mask_val, logits_diff * alpha_curr, 0.0), 1)
+
+        d_i = d_i * alpha_prev + tl.sum(alpha_curr, 1)
+
+        # Sink weight follows the row's earliest reachable key (column 0 for
+        # dense causal attention, the first compressed block otherwise), so it
+        # can be picked up from any segment, not just the first block.
+        is_sink = n_offsets[None, :] == sink_col[:, None]
+        sink_contrib = tl.sum(tl.where(is_sink & mask_val, alpha_curr, 0.0), 1)
+        s_i = s_i * alpha_prev + sink_contrib
+
+        m_i = m_new
+
+    return m_i, d_i, h_i, s_i, row_max_logit_raw, row_sum_logit_raw, row_count_raw
+
+
+@triton.jit
+def qk_stats_sparse_partial_kernel(
+    # Pointers
+    Q_ptr,
+    K_ptr,
+    win_lo_ptr,
+    win_hi_ptr,
+    cmp_lo_ptr,
+    cmp_hi_ptr,
+    sink_col_ptr,
+    attn_sink_ptr,
+    partial_max_ptr,
+    partial_sum_logit_ptr,
+    partial_sum_row_mean_ptr,
+    partial_count_ptr,
+    partial_sum_entropy_ptr,
+    partial_sum_sink_ptr,
+    partial_valid_rows_ptr,
+    # Shapes
+    batch,
+    num_heads,
+    seq_len_q,
+    seq_len_k,
+    head_dim,
+    heads_per_group,
+    num_m_blocks,
+    # Strides for Q/K (input layout [B, H, S, D])
+    stride_q_batch,
+    stride_q_head,
+    stride_q_seq,
+    stride_q_dim,
+    stride_k_batch,
+    stride_k_head,
+    stride_k_seq,
+    stride_k_dim,
+    # Strides for the per-row bound tensors (layout [B, S_q])
+    stride_b_batch,
+    stride_b_seq,
+    # Strides for partial buffers (layout [B, H, num_m_blocks])
+    stride_p_batch,
+    stride_p_head,
+    stride_p_m,
+    # Configs
+    scale: tl.constexpr,
+    HAS_SINK: tl.constexpr,
+    ROW_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """QK statistics over a two-segment sparse key set (window + compressed KV).
+
+    Grid: ``(batch * num_heads, num_m_blocks)`` — same split-M layout as
+    :func:`qk_stats_partial_kernel`, and it writes the same partial buffers so
+    the host-side reduction is shared.
+
+    The key set of query row ``g`` is ``[win_lo[g], win_hi[g]]`` over the
+    original KV plus ``[cmp_lo[g], cmp_hi[g]]`` over the compressed KV, both
+    inclusive, both indexing the concatenated ``kv_full``. An empty segment is
+    encoded as ``hi < lo``. These bounds come from the very same index helpers
+    the model uses, so document-boundary resets are honoured.
+
+    ``attn_sink_ptr`` holds the learned per-head sink logit that the model adds
+    to the softmax denominator; it is folded in after both segments so entropy
+    and sink ratios match the distribution the layer actually computes.
+    """
+    pid_bh = tl.program_id(0)
+    pid_m = tl.program_id(1)
+
+    batch_idx = pid_bh // num_heads
+    head_idx = pid_bh % num_heads
+    kv_head_idx = head_idx // heads_per_group
+
+    q_base = Q_ptr + batch_idx * stride_q_batch + head_idx * stride_q_head
+    k_base = K_ptr + batch_idx * stride_k_batch + kv_head_idx * stride_k_head
+
+    m_block_span = BLOCK_M * ROW_STRIDE
+    m_start = pid_m * m_block_span
+
+    m_offsets = m_start + tl.arange(0, BLOCK_M) * ROW_STRIDE
+    m_mask = m_offsets < seq_len_q
+
+    bound_ptr = win_lo_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq
+    win_lo = tl.load(bound_ptr, mask=m_mask, other=0)
+    win_hi = tl.load(
+        win_hi_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1
+    )
+    cmp_lo = tl.load(
+        cmp_lo_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=0
+    )
+    cmp_hi = tl.load(
+        cmp_hi_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1
+    )
+    sink_col = tl.load(
+        sink_col_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1
+    )
+
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - 1e10
+    d_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    h_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    s_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    row_max_logit_raw = tl.zeros([BLOCK_M], dtype=tl.float32) - 1e10
+    row_sum_logit_raw = tl.zeros([BLOCK_M], dtype=tl.float32)
+    row_count_raw = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # Window segment
+    win_start = tl.min(tl.where(m_mask, win_lo, seq_len_k))
+    win_stop = tl.max(tl.where(m_mask, win_hi, -1)) + 1
+    m_i, d_i, h_i, s_i, row_max_logit_raw, row_sum_logit_raw, row_count_raw = _accumulate_segment(
+        q_base,
+        k_base,
+        m_offsets,
+        m_mask,
+        win_lo,
+        win_hi,
+        sink_col,
+        win_start,
+        win_stop,
+        seq_len_k,
+        head_dim,
+        stride_q_seq,
+        stride_q_dim,
+        stride_k_seq,
+        stride_k_dim,
+        m_i,
+        d_i,
+        h_i,
+        s_i,
+        row_max_logit_raw,
+        row_sum_logit_raw,
+        row_count_raw,
+        scale=scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+    )
+
+    # Compressed segment
+    cmp_start = tl.min(tl.where(m_mask, cmp_lo, seq_len_k))
+    cmp_stop = tl.max(tl.where(m_mask, cmp_hi, -1)) + 1
+    m_i, d_i, h_i, s_i, row_max_logit_raw, row_sum_logit_raw, row_count_raw = _accumulate_segment(
+        q_base,
+        k_base,
+        m_offsets,
+        m_mask,
+        cmp_lo,
+        cmp_hi,
+        sink_col,
+        cmp_start,
+        cmp_stop,
+        seq_len_k,
+        head_dim,
+        stride_q_seq,
+        stride_q_dim,
+        stride_k_seq,
+        stride_k_dim,
+        m_i,
+        d_i,
+        h_i,
+        s_i,
+        row_max_logit_raw,
+        row_sum_logit_raw,
+        row_count_raw,
+        scale=scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+    )
+
+    # Fold the learned sink logit into the same softmax. The sink is an extra
+    # (key-less) column, so it changes the denominator and the entropy but is
+    # deliberately excluded from logit max/mean, which describe real keys.
+    if HAS_SINK:
+        sink_logit = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+        m_new = tl.maximum(m_i, sink_logit)
+        alpha_prev = tl.exp(m_i - m_new)
+        # Same rescale as the in-loop update: shifting the max by (m_i - m_new)
+        # moves h by (m_i - m_new) * d, so h must be updated from the old d.
+        h_i = (h_i + (m_i - m_new) * d_i) * alpha_prev
+        d_i = d_i * alpha_prev
+        s_i = s_i * alpha_prev
+        sink_w = tl.exp(sink_logit - m_new)
+        d_i = d_i + sink_w
+        h_i = h_i + sink_w * (sink_logit - m_new)
+        m_i = m_new
+
+    # Finalize per-row stats for this M-block
+    safe_d = tl.where(d_i > 0, d_i, 1.0)
+    row_entropy = tl.log(safe_d) - (h_i / safe_d)
+    row_sink = s_i / safe_d
+
+    row_has_data = row_count_raw > 0
+    valid_mask = row_has_data & m_mask
+
+    block_max_logit = tl.max(tl.where(m_mask, row_max_logit_raw, -1e10))
+    block_sum_logit = tl.sum(tl.where(valid_mask, row_sum_logit_raw, 0.0))
     safe_row_count = tl.where(row_count_raw > 0, row_count_raw, 1.0)
     row_mean_logit = row_sum_logit_raw / safe_row_count
     block_sum_row_mean = tl.sum(tl.where(valid_mask, row_mean_logit, 0.0))

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -155,7 +155,7 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertEqual([item.attn_type for item in result], ["full", "swa", "full"])
 
     def test_iter_monitor_layers_attn_type_is_none_for_backward_compat_models(self):
-        """Models without an is_swa flag (eb5_v2 / dsv4) must yield attn_type=None."""
+        """Stacks with neither sliding_window nor csa_compress_ratios yield attn_type=None."""
         layer = SimpleNamespace(self_attn=SimpleNamespace())  # no is_swa
         result = layer_discovery.iter_monitor_layers([layer], lambda x: hasattr(x, "self_attn"))
         self.assertEqual(len(result), 1)
@@ -639,6 +639,242 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
                 paddle.allclose(default_pass[key], with_zero_offset[key], atol=1e-6).item(),
                 f"{key} diverged with q_row_offset=0",
             )
+
+
+def _build_hca_topk_idxs(seqlen, window_size, ratio):
+    """Rebuild what CompressedSparseAttention feeds its sparse attention kernel.
+
+    Mirrors ``get_window_topk_idxs`` + ``get_compress_topk_idxs`` (simple causal
+    branch) from ``paddlefleet.transformer.csa_attention``: a left-inclusive
+    sliding window over original KV, concatenated with every causally valid
+    compressed block, offset by ``seqlen`` because both index ``kv_full``.
+    """
+    base = paddle.arange(seqlen).unsqueeze(1)
+    offsets = paddle.arange(window_size)
+    window = paddle.clip(base - window_size + 1, min=0) + offsets
+    window = paddle.where(window > base, paddle.full_like(window, -1), window)
+
+    n_compressed = seqlen // ratio
+    k_indices = paddle.arange(n_compressed).unsqueeze(0).expand([seqlen, -1])
+    causal_bound = paddle.arange(1, seqlen + 1).unsqueeze(1) // ratio
+    compressed = paddle.where(
+        k_indices >= causal_bound,
+        paddle.full_like(k_indices, -1),
+        k_indices + seqlen,
+    )
+    return paddle.concat([window, compressed], axis=-1).unsqueeze(0).astype("int32")
+
+
+class CompressRatioLayerClassificationTest(unittest.TestCase):
+    """Per-layer attention-kind classification on ``csa_compress_ratios`` stacks."""
+
+    @staticmethod
+    def _ratio_layer(compress_ratio=None, window_size=None, indexer=None):
+        # experimental_attention_variant is what makes csa_compress_ratios
+        # authoritative for the per-layer kind.
+        config = SimpleNamespace(experimental_attention_variant="dsv4_hybrid")
+        if compress_ratio is None:
+            core = SimpleNamespace()  # MLA branch: no CSA core
+        else:
+            core = SimpleNamespace(
+                compress_ratio=compress_ratio,
+                window_size=window_size,
+                indexer=indexer,
+                compressed_sparse_attn=lambda *a, **k: None,
+            )
+        return SimpleNamespace(self_attn=SimpleNamespace(config=config, core_attention=core))
+
+    def test_ratio_maps_to_layer_kind(self):
+        cases = {-2: "mla", -1: "mqa", 0: "window", 4: "csa", 128: "hca"}
+        for ratio, expected in cases.items():
+            layer = self._ratio_layer(compress_ratio=ratio)
+            self.assertEqual(layer_discovery.classify_attn_type(layer), expected, f"ratio={ratio}")
+
+    def test_mla_branch_without_csa_core_is_tagged_mla(self):
+        """Ratio -2 builds MLASelfAttention, which exposes no compress_ratio."""
+        layer = self._ratio_layer(compress_ratio=None)
+        kind, ratio, window, has_indexer = layer_discovery.attn_meta(layer)
+        self.assertEqual(kind, "mla")
+        self.assertEqual(ratio, layer_discovery.MLA_RATIO)
+        self.assertIsNone(window)
+        self.assertFalse(has_indexer)
+
+    def test_meta_carries_window_size_and_indexer_flag(self):
+        layer = self._ratio_layer(compress_ratio=4, window_size=128, indexer=object())
+        kind, ratio, window, has_indexer = layer_discovery.attn_meta(layer)
+        self.assertEqual((kind, ratio, window), ("csa", 4, 128))
+        self.assertTrue(has_indexer)
+
+    def test_hca_has_no_indexer(self):
+        layer = self._ratio_layer(compress_ratio=128, window_size=128, indexer=None)
+        self.assertFalse(layer_discovery.attn_meta(layer)[3])
+
+    def test_stack_without_the_variant_field_keeps_is_swa_fallback(self):
+        """Stacks with no ratio field must not gain ratio tags (metric-key compat)."""
+        swa = SimpleNamespace(self_attn=SimpleNamespace(is_swa=True, config=SimpleNamespace()))
+        self.assertEqual(layer_discovery.classify_attn_type(swa), "swa")
+
+    def test_iter_monitor_layers_tags_mixed_hca_mla_stack(self):
+        layers = [
+            self._ratio_layer(compress_ratio=128, window_size=128),
+            self._ratio_layer(compress_ratio=128, window_size=128),
+            self._ratio_layer(compress_ratio=None),
+        ]
+        result = layer_discovery.iter_monitor_layers(layers, lambda layer: True)
+        self.assertEqual([item.attn_type for item in result], ["hca", "hca", "mla"])
+        self.assertEqual([item.compress_ratio for item in result], [128, 128, -2])
+
+
+class SparseBoundsTest(unittest.TestCase):
+    """Window/compressed segment bounds derived from the model's real indices."""
+
+    def setUp(self):
+        self.qk = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor")
+
+    def _hca_topk_idxs(self, seqlen, window_size, ratio):
+        return _build_hca_topk_idxs(seqlen, window_size, ratio)
+
+    def test_bounds_reproduce_the_index_set_exactly(self):
+        seqlen, window_size, ratio = 32, 8, 4
+        topk = self._hca_topk_idxs(seqlen, window_size, ratio)
+        bounds = self.qk.sparse_bounds_from_topk(topk, seqlen)
+
+        # Rebuild membership from the [lo, hi] ranges and compare to the real set.
+        cols = paddle.arange(seqlen + seqlen // ratio).astype("int32")
+        in_win = (cols.unsqueeze(0) >= bounds["win_lo"][0].unsqueeze(1)) & (
+            cols.unsqueeze(0) <= bounds["win_hi"][0].unsqueeze(1)
+        )
+        in_cmp = (cols.unsqueeze(0) >= bounds["cmp_lo"][0].unsqueeze(1)) & (
+            cols.unsqueeze(0) <= bounds["cmp_hi"][0].unsqueeze(1)
+        )
+        from_ranges = in_win | in_cmp
+
+        expected = paddle.zeros_like(from_ranges)
+        for row in range(seqlen):
+            live = [int(v) for v in topk[0, row].tolist() if v >= 0]
+            for col in live:
+                expected[row, col] = True
+
+        self.assertTrue(bool((from_ranges == expected).all()))
+
+    def test_sink_col_points_at_first_compressed_block_when_present(self):
+        seqlen, window_size, ratio = 32, 8, 4
+        topk = self._hca_topk_idxs(seqlen, window_size, ratio)
+        bounds = self.qk.sparse_bounds_from_topk(topk, seqlen)
+        sink = bounds["sink_col"][0]
+        # Row 0 sees no compressed block yet -> falls back to the window start.
+        self.assertEqual(int(sink[0]), 0)
+        # Later rows summarise sequence start via compressed block 0 (== seqlen).
+        self.assertEqual(int(sink[seqlen - 1]), seqlen)
+
+    def test_ranges_cover_a_superset_for_non_contiguous_topk(self):
+        """A learned indexer selects a sparse compressed subset; ranges bracket it."""
+        seqlen = 8
+        window = paddle.arange(seqlen).unsqueeze(1).astype("int32")
+        # Compressed picks blocks 0 and 3 only.
+        compressed = paddle.to_tensor([[seqlen, seqlen + 3]] * seqlen, dtype="int32")
+        topk = paddle.concat([window, compressed], axis=-1).unsqueeze(0)
+        bounds = self.qk.sparse_bounds_from_topk(topk, seqlen)
+        # The compressed range spans the selected blocks (and the gap between).
+        self.assertEqual(int(bounds["cmp_lo"][0][0]), seqlen)
+        self.assertEqual(int(bounds["cmp_hi"][0][0]), seqlen + 3)
+
+
+class SparseQKKernelComputeTest(unittest.TestCase):
+    """GPU numerical test: sparse kernel == explicit masked softmax reference."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not paddle.device.is_compiled_with_cuda() or paddle.device.cuda.device_count() == 0:
+            raise unittest.SkipTest("qk_stats kernel requires a CUDA GPU")
+        paddle.device.set_device("gpu:0")
+        cls.qk = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor")
+
+    @staticmethod
+    def _reference_stats(query, kv_full, topk_idxs, scale, attn_sink):
+        """Dense reference: one softmax over exactly the listed keys (+ sink)."""
+        b, s, h, d = query.shape
+        s_k = kv_full.shape[1]
+        logits = paddle.matmul(query.transpose([0, 2, 1, 3]), kv_full.unsqueeze(1), transpose_y=True)
+        logits = logits * scale  # [B, H, S, S_k]
+
+        allowed = paddle.zeros([b, s, s_k], dtype="bool")
+        for bi in range(b):
+            for row in range(s):
+                for col in topk_idxs[bi, row].tolist():
+                    if col >= 0:
+                        allowed[bi, row, int(col)] = True
+        mask = allowed.unsqueeze(1)
+
+        neg = paddle.full_like(logits, -1e10)
+        masked = paddle.where(mask, logits, neg)
+        row_max = masked.max(axis=-1, keepdim=True)
+        exp = paddle.where(mask, paddle.exp(masked - row_max), paddle.zeros_like(masked))
+        denom = exp.sum(axis=-1, keepdim=True)
+        if attn_sink is not None:
+            sink_logit = attn_sink.reshape([1, h, 1, 1])
+            denom = denom + paddle.exp(sink_logit - row_max)
+        probs = exp / denom
+        entropy = -(probs * paddle.log(probs.clip(min=1e-30))).sum(axis=-1)
+        if attn_sink is not None:
+            p_sink = paddle.exp(attn_sink.reshape([1, h, 1, 1]) - row_max) / denom
+            p_sink = p_sink.squeeze(-1)
+            entropy = entropy - (p_sink * paddle.log(p_sink.clip(min=1e-30)))
+        return {
+            "entropy_per_head": entropy.mean(axis=-1),
+            "max_per_head": masked.max(axis=-1).max(axis=-1),
+        }
+
+    def _hca_case(self, seqlen=32, window_size=8, ratio=4, heads=2, dim=32, seed=7):
+        paddle.seed(seed)
+        n_compressed = seqlen // ratio
+        query = paddle.randn([1, seqlen, heads, dim], dtype="float32")
+        kv_full = paddle.randn([1, seqlen + n_compressed, dim], dtype="float32")
+        topk = _build_hca_topk_idxs(seqlen, window_size, ratio)
+        return query, kv_full, topk
+
+    def test_sparse_stats_match_masked_reference(self):
+        query, kv_full, topk = self._hca_case()
+        scale = float(query.shape[-1]) ** -0.5
+        stats = self.qk.compute_qk_stats_sparse_paddle(
+            query, kv_full, topk, scale, attn_sink=None, row_stride=1
+        )
+        ref = self._reference_stats(query, kv_full, topk, scale, None)
+        self.assertTrue(
+            paddle.allclose(stats["entropy_per_head"], ref["entropy_per_head"], atol=1e-3, rtol=1e-3).item(),
+            f"entropy mismatch: {stats['entropy_per_head']} vs {ref['entropy_per_head']}",
+        )
+        self.assertTrue(
+            paddle.allclose(stats["max_per_head"], ref["max_per_head"], atol=1e-3, rtol=1e-3).item()
+        )
+
+    def test_attn_sink_lowers_entropy_and_is_folded_into_denominator(self):
+        query, kv_full, topk = self._hca_case(seed=11)
+        scale = float(query.shape[-1]) ** -0.5
+        heads = query.shape[2]
+        sink = paddle.full([heads], 5.0, dtype="float32")  # dominant sink logit
+
+        no_sink = self.qk.compute_qk_stats_sparse_paddle(
+            query, kv_full, topk, scale, attn_sink=None, row_stride=1
+        )
+        with_sink = self.qk.compute_qk_stats_sparse_paddle(
+            query, kv_full, topk, scale, attn_sink=sink, row_stride=1
+        )
+        ref = self._reference_stats(query, kv_full, topk, scale, sink)
+
+        self.assertTrue(
+            paddle.allclose(with_sink["entropy_per_head"], ref["entropy_per_head"], atol=1e-3, rtol=1e-3).item(),
+            f"entropy with sink mismatch: {with_sink['entropy_per_head']} vs {ref['entropy_per_head']}",
+        )
+        # A dominant sink absorbs probability mass, so real-key entropy drops.
+        self.assertLess(
+            float(with_sink["entropy_global"]),
+            float(no_sink["entropy_global"]),
+        )
+        # The sink is not a real key, so logit max/mean must be unchanged.
+        self.assertTrue(
+            paddle.allclose(with_sink["max_per_head"], no_sink["max_per_head"], atol=1e-6).item()
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

qk_stats 对所有层都按 dense causal attention 统计。对 key 集合是「sliding window ∪ 压缩 KV」的层（`csa_compress_ratios` 描述的栈）这是不准确的：假设的 key 集合远大于真实集合，且 softmax 分母里缺少 learned per-head `attn_sink`，导致 entropy / sink / logit 统计描述的不是该层实际计算的分布。同时这些层的 `is_swa` 恒为 False（它由 `config.sliding_window` 推导，而这类 config 不设该字段），所以层类型也识别不出来，不同口径的指标会混在同一组 key 里。

## 改动

**层类型识别**
- `classify_attn_type()` 在 `csa_compress_ratios` 为权威时（由`experimental_attention_variant="dsv4_hybrid"` 标记）改为从 `core_attention.compress_ratio`推导：`mla`(-2) / `mqa`(-1) / `window`(0) / `csa`(2..127) / `hca`(128)
- `MonitorLayer` 新增 `compress_ratio` / `window_size` / `has_indexer`
- 由 `sliding_window` 描述的栈继续走 `is_swa` → `swa`/`full`；两个字段都没有的栈保持无标签，指标键布局不变（向后兼容）

**统计口径**
- 稀疏层包裹 `CompressedSparseAttention.compressed_sparse_attn`，从调用入参直接取真实的 `topk_idxs` / `kv_full` / `attn_sink` / `softmax_scale`。索引不做重建，因此 document mask 的文档边界重置、以及 learned indexer 的 top-k 都自动覆盖
- 新增 `qk_stats_sparse_partial_kernel`：把 window 段与压缩段两个连续区间折进同一次 online softmax，并把 sink logit 计入分母。**legacy kernel 未改动**，megatron 后端与 MLA 层行为不变
- `softmax_scale` 改用层自身的值，不再用监控张量的 `1/sqrt(head_dim)`
- `sink` 语义推广为「该 row 可达的最早 key」：有压缩段时指向首个压缩块，否则是窗口内最旧位置； dense causal 层下退化为 token-0
- 新增指标 `attn_sink_logit`

## 验证

- 新增单测覆盖：ratio→层类型映射、区间表示与真实索引集合逐元素一致、稀疏 kernel 与显式 masked-softmax 参考实现数值对齐、sink logit 折入分母后 entropy 变化方向及 logit max 不变
- 混合 hca/mla 栈实跑：层类型与 `csa_compress_ratios` 逐位一致，稀疏层 entropy 落入真实 key 数所隐含的范围，MLA 层数值与改动前一致（确认 dense 路径未被影响）