### PR TITLE
fix(training_logs): keep prefixed channel-count metrics max-aggregate…

### DIFF
--- a/src/internal_medicine/core/training_logs.py
+++ b/src/internal_medicine/core/training_logs.py
@@ -20,7 +20,12 @@ MAX_AGGREGATED_SUFFIXES = (
     "channel_p95",
     "channel_p99",
     "activation_rms",
+    "massive_act_channel_count",
 )
+
+# Absolute-threshold channel counts: the threshold is the trailing token
+# (``channel_count_gt_10``), so this cannot be a fixed suffix.
+CHANNEL_COUNT_GT_MARKER = "channel_count_gt_"
 
 
 class SmoothedValue:
@@ -109,13 +114,11 @@ class TrainingLogs:
 
     @staticmethod
     def _is_max_metric(key: str) -> bool:
-        metric_name = key.rsplit("/", 1)[-1]
         return (
             "/max" in key
             or key.endswith("_max")
             or key.endswith(MAX_AGGREGATED_SUFFIXES)
-            or metric_name == "massive_act_channel_count"
-            or metric_name.startswith("channel_count_gt_")
+            or CHANNEL_COUNT_GT_MARKER in key
         )
 
     @staticmethod

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -99,6 +99,10 @@ class CoreMonitoringTest(unittest.TestCase):
             "massive_act/global_spectral_norm_max",
             "massive_act/layer_0/lipschitz_max",
             "massive_act/global_lipschitz_max",
+            # attn_type-tagged keys (paddlefleet prepends mla_/hca_/csa_/...)
+            "massive_act/layer_0/hca_massive_act_channel_count",
+            "massive_act/layer_0/hca_channel_count_gt_10",
+            "massive_act/global_hca_channel_count_gt_10",
         ):
             self.assertTrue(training_logs._is_max_metric(key), key)
 


### PR DESCRIPTION
## 问题

`channel_count_gt_*` 和 `massive_act_channel_count` 是整数计数，但线上曲线出现小数（如 310.29）。

`TrainingLogs._is_max_metric` 决定 `SmoothedValue` 的 mode 和 `gather_and_aggregate` 的跨 rank 聚合方式。这两个指标原来用精确比较 / 前缀匹配判定，有两种情况会失配并退化成 mean（跨 rank `sum/len`）：

- paddlefleet 会在 metric name 前加 attn_type 标签（`paddlefleet/base.py` 的 `hca_` / `mla_` / `csa_` 等）→ `hca_channel_count_gt_10` 匹配不上
- global key 的名字自带 `global_` 前缀 → `global_massive_act_channel_count` 匹配不上，这一条在两个后端上一直是错的，与 attn_type 无关

## 改动

- `MAX_AGGREGATED_SUFFIXES` 增加 `massive_act_channel_count`，走统一的 `endswith` 判定
- 新增 `CHANNEL_COUNT_GT_MARKER`，用子串匹配（阈值是名字的结尾 token，无法用固定后缀）
- `_is_max_metric` 移除 `key.rsplit("/", 1)[-1]`，全部改为对完整 key 做后缀 / 子串匹配，对任何前缀免疫

## 验证

- 单机 8 卡实跑对比（临时下调阈值使计数非零）：修复前 720 个 count 采样点中 284 个是小数；修复后 360 个采样点中 0 个小数，值由跨 rank 平均变为跨 rank 最大值（`global_hca_massive_act_channel_count` 314 → 412）
- `tests/test_core_monitoring.py` 补充 3 个带 attn_type 前缀的断言用例
- 单测 57 passed（`test_megatron_monitors.py` / `test_mhc_monitor.py` 因本地缺 megatron 依赖无法收集，与本改动无关）