### PR TITLE
fix(qk_stats): 补齐 full attention 层的 learned sink 指标

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ setup_internal_medicine()
 | 7 | `sink_head_ratio` | `qk_stats/.../sink_head_ratio` | `count(sink>θ)/N_heads` | 每层+全局 | Sink head 占比 |
 | 8 | `sink_head_max` | `qk_stats/.../sink_head_max` | `max(sink_per_head)` | 每层+全局 | 最强 sink head 权重 |
 | 9 | `sink_nonsink_gap` | `qk_stats/.../sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | 每层+全局 | Sink/非Sink 分化度 |
-| 10 | `attn_sink_logit` | `qk_stats/.../attn_sink_logit` | `mean(attn_sink)` | 每层+全局 | 仅 CSA/HCA 层；learned sink logit 量级漂移 |
+| 10 | `attn_sink_logit` | `qk_stats/.../attn_sink_logit` | `mean(sink_logit)` | 每层+全局 | learned sink logit 量级漂移；稀疏层取 `attn_sink`，full 层取 `softmax_offset` |
 
 ### 混合注意力栈的层类型标签 (attn_type)
 
@@ -230,7 +230,11 @@ setup_internal_medicine()
 
 - `sink`：该 row **可达的最早 key** 的权重。有压缩段时指向首个压缩块（概括序列/文档开头），
   否则是窗口内最旧位置；dense causal 层下退化为 token-0。
-- `attn_sink_logit`：learned sink 参数的均值，用于观察它在训练中的漂移。
+- `attn_sink_logit`：learned sink 参数的均值，用于观察它在训练中的漂移。两类层的来源不同但语义一致
+  （都是 per-head sink logit）：CSA/HCA 等稀疏层读 `compressed_sparse_attn` 的 `attn_sink` 入参；
+  MLA/MQA 等 full 层在 `add_full_attention_sink_bias=true`（或 SWA 层的 `add_swa_attention_sink_bias`）
+  时读 `core_attention.softmax_offset`——此时 `softmax_type` 被提升为 `learnable`，kernel 以
+  `learnable_sink` 接收它。`off-by-one` softmax 的 `softmax_offset` 是冻结的零 buffer，不记录。
 
 启用 learned indexer 的层（`compress_ratio` 在 `[2, 127]` 且未开 `csa_dense_mode`）压缩 key
 是运行时 top-k 选出的，统计会覆盖真实 key 的超集，注册 hook 时会打一条 warning。
@@ -439,7 +443,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **QK** | `sink_head_ratio` | `count(sink>threshold)/N_heads` | mean | Sink head 占比 |
 | **QK** | `sink_head_max` | `max(sink_per_head)` | max | 最强 sink head |
 | **QK** | `sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | mean | Sink vs 非Sink gap |
-| **QK** | `attn_sink_logit` | `mean(attn_sink)` | mean | CSA/HCA 层；learned sink 量级 |
+| **QK** | `attn_sink_logit` | `mean(sink_logit)` | mean | learned sink 量级（稀疏层 `attn_sink` / full 层 `softmax_offset`） |
 | **MassiveAct** | `channel_max` | `max(abs(H_i))` | max | 通道峰值激活 |
 | **MassiveAct** | `channel_median` | `median(per_channel_max)` | max | 通道峰值基准量级 |
 | **MassiveAct** | `channel_p95` | `p95(per_channel_max)` | max | 高分位通道幅度 |

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -562,6 +562,8 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 self.declare_layer_metric(layer_idx, m, attn_type=item.attn_type)
             if self._is_sparse_layer(item):
                 self.declare_layer_metric(layer_idx, "attn_sink_logit", attn_type=item.attn_type)
+            elif self._learnable_sink(_attn_module) is not None:
+                self.declare_layer_metric(layer_idx, "attn_sink_logit", attn_type=item.attn_type)
 
         self.allocate_buffers()
 
@@ -593,6 +595,29 @@ class PaddleQKStatsMonitor(PaddleProbe):
         core = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
         core = getattr(core, "core_attention", None)
         return hasattr(core, "compressed_sparse_attn")
+
+    @staticmethod
+    def _learnable_sink(attn_module):
+        """Return a full-attention learnable sink logit tensor, or ``None``.
+
+        Non-sparse layers get a per-head sink bias when
+        ``add_full_attention_sink_bias`` / ``add_swa_attention_sink_bias``
+        promotes ``softmax_type`` to ``"learnable"``: PaddleFleet keeps it on the
+        core attention as ``softmax_offset`` and passes it to the kernel as
+        ``learnable_sink``. Sparse layers instead receive their own ``attn_sink``
+        as a ``compressed_sparse_attn`` argument, recorded in
+        ``_patch_sparse_attn`` — so both layer kinds report ``attn_sink_logit``,
+        from different sources.
+
+        The ``"off-by-one"`` softmax also sets ``softmax_offset``, but to a frozen
+        zero buffer; ``stop_gradient`` separates it from the learned parameter so
+        a constant-0 series is never logged.
+        """
+        core = getattr(attn_module, "core_attention", None)
+        offset = getattr(core, "softmax_offset", None)
+        if offset is None or offset.stop_gradient:
+            return None
+        return offset
 
     def _patch_sparse_attn(self, layer_idx: int, attn_module, item):
         """Wrap ``CompressedSparseAttention.compressed_sparse_attn``.
@@ -780,6 +805,16 @@ class PaddleQKStatsMonitor(PaddleProbe):
                             stats[key_name] = t / float(self.cp_size)
 
                 self._record_common_stats(layer_idx, attn_type, stats)
+                # ``layer`` is the core attention here (that is where this hook is
+                # registered), so the learnable sink bias is read straight off it.
+                sink_logit = getattr(layer, "softmax_offset", None)
+                if sink_logit is not None and not sink_logit.stop_gradient:
+                    self.record_layer_metric(
+                        layer_idx,
+                        "attn_sink_logit",
+                        sink_logit.detach().astype("float32").mean(),
+                        attn_type=attn_type,
+                    )
             except Exception as e:
                 logger.error(f"[PaddleQKMonitor] Error layer {layer_idx}: {e}")
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -725,6 +725,35 @@ class CompressRatioLayerClassificationTest(unittest.TestCase):
         self.assertEqual([item.compress_ratio for item in result], [128, 128, -2])
 
 
+class LearnableSinkDetectionTest(unittest.TestCase):
+    """Full-attention layers carry their sink bias as core_attention.softmax_offset.
+
+    ``add_full_attention_sink_bias=true`` promotes softmax_type to "learnable", so
+    MLA/MQA layers own a trainable per-head sink logit even though they never see
+    the sparse ``attn_sink`` kernel argument. They must report attn_sink_logit too.
+    """
+
+    @staticmethod
+    def _attn(offset):
+        return SimpleNamespace(core_attention=SimpleNamespace(softmax_offset=offset))
+
+    def test_trainable_offset_is_detected(self):
+        offset = paddle.zeros([4], dtype="float32")
+        offset.stop_gradient = False
+        self.assertIsNotNone(PaddleQKStatsMonitor._learnable_sink(self._attn(offset)))
+
+    def test_frozen_offset_is_ignored(self):
+        # "off-by-one" softmax uses a frozen zero buffer: a constant-0 series is
+        # not worth a chart.
+        offset = paddle.zeros([4], dtype="float32")
+        offset.stop_gradient = True
+        self.assertIsNone(PaddleQKStatsMonitor._learnable_sink(self._attn(offset)))
+
+    def test_vanilla_softmax_has_no_sink(self):
+        self.assertIsNone(PaddleQKStatsMonitor._learnable_sink(self._attn(None)))
+        self.assertIsNone(PaddleQKStatsMonitor._learnable_sink(SimpleNamespace()))
+
+
 class SparseBoundsTest(unittest.TestCase):
     """Window/compressed segment bounds derived from the model's real indices."""
 


### PR DESCRIPTION
## 问题

`attn_sink_logit` 只在 CSA / HCA 等稀疏层出现，MLA / MQA 层完全没有这条曲线。

原因是采集点绑在了稀疏路径上：该指标只为 `_is_sparse_layer(item)` 为真的层声明，值取自被 patch 的 `compressed_sparse_attn(query, kv_full, attn_sink, ...)` 的 `attn_sink` 入参。而 `_is_sparse_layer` 明确排除 `compress_ratio ∈ {-2 (MLA), -1 (MQA)}`，这些层走 `core_attention` 的 forward_pre_hook，路径上没有 sink 参数可读。

但 full attention 层确实有 learned sink：`add_full_attention_sink_bias=true`（或 SWA 层的 `add_swa_attention_sink_bias`）会把 `softmax_type` 提升为 `"learnable"`，随后创建可训练的 per-head 参数 `core_attention.softmax_offset`，并作为 `learnable_sink` 传给 kernel、传给 `scale_mask_softmax`。已与算法侧确认 MLA 层确实启用了这个开关。

## 改动

- 新增 `PaddleQKStatsMonitor._learnable_sink()`，读 `core_attention.softmax_offset`；用 `stop_gradient` 区分可训练参数与 `"off-by-one"` softmax 的冻结零 buffer，后者不记录（避免一条恒为 0 的曲线）
- declare 阶段增加非稀疏层分支，两类层统一上报 `attn_sink_logit`
- record 复用已有的 `core_attention` pre-hook。hook 就注册在 `core_attention` 上，`layer.softmax_offset` 直接可取，不需要额外 patch、不增加前向开销，也没有 D2H 同步
- 口径与稀疏层保持一致，都取 per-head 的 `.mean()`

## 注意

两类层的 sink 来源不同：稀疏层的 `attn_sink` 在 `triton_qk_kernel.py:673-685` 手动 fold 进 softmax 分母和熵项，full 层的 `softmax_offset` 由 kernel 以 `learnable_sink` 处理。语义都是 per-head sink logit，但初始化和数值范围可能不同，跨层类型对比时看趋势和量级、不要直接比绝对值。README 已注明这点。