### PR TITLE
fix(qk_stats): 将 learned sink 列 fold 进 entropy/sink 统计

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,18 @@ setup_internal_medicine()
 
 指标语义：
 
-- `sink`：该 row **可达的最早 key** 的权重。有压缩段时指向首个压缩块（概括序列/文档开头），
+- `sink`：该 row **可达的最早真实 key** 的权重。有压缩段时指向首个压缩块（概括序列/文档开头），
   否则是窗口内最旧位置；dense causal 层下退化为 token-0。
+- `entropy` / `sink` 的分布口径：**learned sink 会被 fold 进 softmax**，即分布跨越「真实 key + 1 个
+  无对应 key 的 sink 列」，与模型实际计算的分布一致。稀疏层由 `compressed_sparse_attn` 的 `attn_sink`
+  入参提供，full 层由 `core_attention.softmax_offset` 提供（`off-by-one` softmax 的冻结零 buffer 同样
+  fold——`exp(0)` 照样进分母）。`max` / `mean` 只描述真实 key，不受 sink 影响。
 - `attn_sink_logit`：learned sink 参数的均值，用于观察它在训练中的漂移。两类层的来源不同但语义一致
   （都是 per-head sink logit）：CSA/HCA 等稀疏层读 `compressed_sparse_attn` 的 `attn_sink` 入参；
   MLA/MQA 等 full 层在 `add_full_attention_sink_bias=true`（或 SWA 层的 `add_swa_attention_sink_bias`）
   时读 `core_attention.softmax_offset`——此时 `softmax_type` 被提升为 `learnable`，kernel 以
-  `learnable_sink` 接收它。`off-by-one` softmax 的 `softmax_offset` 是冻结的零 buffer，不记录。
+  `learnable_sink` 接收它。`off-by-one` softmax 的 `softmax_offset` 是冻结的零 buffer，没有可追踪的
+  学习量级，故不单独上报这条曲线（但如上所述仍会 fold 进分布）。
 
 启用 learned indexer 的层（`compress_ratio` 在 `[2, 127]` 且未开 `csa_dense_mode`）压缩 key
 是运行时 top-k 选出的，统计会覆盖真实 key 的超集，注册 hook 时会打一条 warning。

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -112,6 +112,7 @@ def _compute_qk_stats_triton(
     heads_per_group: int = 1,
     row_stride: int = 1,
     q_row_offset: int = 0,
+    attn_sink: paddle.Tensor | None = None,
 ) -> dict:
     """Triton kernel path for paddle tensors.
 
@@ -152,9 +153,15 @@ def _compute_qk_stats_triton(
 
     grid = (batch * num_heads, num_m_blocks)
 
+    # A None pointer is not a valid kernel argument, so pass a dummy buffer and
+    # gate the fold on HAS_SINK (same pattern as the sparse path).
+    sink_present = attn_sink is not None
+    sink_buf = attn_sink if sink_present else paddle.zeros([num_heads], dtype="float32")
+
     qk_stats_partial_kernel[grid](
         q,
         k,
+        sink_buf,
         partial_max,
         partial_sum_logit,
         partial_sum_row_mean,
@@ -183,6 +190,7 @@ def _compute_qk_stats_triton(
         partial_max.strides[2],
         scale=scale,
         apply_causal_mask=causal,
+        HAS_SINK=sink_present,
         ROW_STRIDE=row_stride,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
@@ -214,6 +222,7 @@ def compute_qk_stats_paddle(
     causal: bool = True,
     row_stride: int = 1,
     q_row_offset: int = 0,
+    attn_sink: paddle.Tensor | None = None,
 ) -> dict:
     """Compute QK stats via Triton kernel.
 
@@ -224,6 +233,11 @@ def compute_qk_stats_paddle(
         q_row_offset: global row-index start for this Q shard. Zero unless the
             caller is running with Context-Parallel and Q is kept local. Used
             only by the kernel's causal-mask logic.
+        attn_sink: per-head sink logit ``[H]`` (float32), folded into the softmax
+            as an extra key-less column. Pass the layer's
+            ``core_attention.softmax_offset`` whenever it exists — without it the
+            reported distribution is renormalised over the real keys only and does
+            not match what the model computes.
 
     The [B, S, H, D] -> [B, H, S, D] reordering is expressed via strides
     (no contiguous copy); the triton kernel reads strided memory directly.
@@ -247,6 +261,7 @@ def compute_qk_stats_paddle(
         heads_per_group=heads_per_group,
         row_stride=row_stride,
         q_row_offset=q_row_offset,
+        attn_sink=attn_sink,
     )
 
 
@@ -788,12 +803,19 @@ class PaddleQKStatsMonitor(PaddleProbe):
                         effective_stride = 1
                     # GQA grouping is handled inside the kernel; do NOT
                     # repeat_interleave the KV tensor on the hot path.
+                    # ``layer`` is the core attention (that is where this hook is
+                    # registered), so its sink bias is read straight off it. Fold
+                    # it whenever it exists — including the frozen zero buffer of
+                    # "off-by-one" softmax, which still adds exp(0) to the
+                    # denominator and so changes entropy and sink.
+                    sink_logit = getattr(layer, "softmax_offset", None)
                     stats = compute_qk_stats_paddle(
                         query,
                         key,
                         causal=self.causal,
                         row_stride=effective_stride,
                         q_row_offset=q_row_offset,
+                        attn_sink=None if sink_logit is None else sink_logit.detach().astype("float32"),
                     )
 
                     if self.cp_size > 1 and self.cp_group is not None:
@@ -805,9 +827,8 @@ class PaddleQKStatsMonitor(PaddleProbe):
                             stats[key_name] = t / float(self.cp_size)
 
                 self._record_common_stats(layer_idx, attn_type, stats)
-                # ``layer`` is the core attention here (that is where this hook is
-                # registered), so the learnable sink bias is read straight off it.
-                sink_logit = getattr(layer, "softmax_offset", None)
+                # A frozen offset ("off-by-one") has no learned magnitude to
+                # track, so only the trainable one gets its own series.
                 if sink_logit is not None and not sink_logit.stop_gradient:
                     self.record_layer_metric(
                         layer_idx,

--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -224,6 +224,7 @@ def qk_stats_partial_kernel(
     # Pointers
     Q_ptr,
     K_ptr,
+    attn_sink_ptr,
     partial_max_ptr,
     partial_sum_logit_ptr,
     partial_sum_row_mean_ptr,
@@ -257,6 +258,7 @@ def qk_stats_partial_kernel(
     # Configs
     scale: tl.constexpr,
     apply_causal_mask: tl.constexpr,
+    HAS_SINK: tl.constexpr,
     ROW_STRIDE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -270,6 +272,13 @@ def qk_stats_partial_kernel(
     Asymmetric Q/K seq lens (for CP): ``seq_len_q`` may be smaller than
     ``seq_len_k``. Row m in Q corresponds to *global* row ``m + q_row_offset``
     which is used only for causal masking against K columns.
+
+    ``HAS_SINK``: fold a learned per-head sink logit (``attn_sink_ptr``, one
+    scalar per query head) into the same softmax. Full-attention layers carry it
+    as ``core_attention.softmax_offset`` and hand it to their kernel as
+    ``learnable_sink``; ``off-by-one`` softmax is the same thing with the logit
+    pinned to 0. Without this the reported distribution is renormalised over the
+    real keys only, which is not the distribution the model computes.
     """
     pid_bh = tl.program_id(0)
     pid_m = tl.program_id(1)
@@ -367,6 +376,23 @@ def qk_stats_partial_kernel(
         d_i = d_new
         h_i = h_new
         s_i = s_new
+
+    # Fold the sink logit into the same softmax. It is an extra key-less column,
+    # so it changes the denominator (and therefore entropy and sink) but is
+    # deliberately excluded from logit max/mean, which describe real keys. Same
+    # rescale as the in-loop update: shifting the max by (m_i - m_new) moves h by
+    # (m_i - m_new) * d, so h must be updated from the old d.
+    if HAS_SINK:
+        sink_logit = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+        m_new = tl.maximum(m_i, sink_logit)
+        alpha_prev = tl.exp(m_i - m_new)
+        h_i = (h_i + (m_i - m_new) * d_i) * alpha_prev
+        d_i = d_i * alpha_prev
+        s_i = s_i * alpha_prev
+        sink_w = tl.exp(sink_logit - m_new)
+        d_i = d_i + sink_w
+        h_i = h_i + sink_w * (sink_logit - m_new)
+        m_i = m_new
 
     # Finalize per-row stats for this M-block
     safe_d = tl.where(d_i > 0, d_i, 1.0)

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -665,6 +665,97 @@ def _build_hca_topk_idxs(seqlen, window_size, ratio):
     return paddle.concat([window, compressed], axis=-1).unsqueeze(0).astype("int32")
 
 
+class DenseSinkFoldTest(unittest.TestCase):
+    """The learned sink is a real softmax column and must be folded in.
+
+    Full-attention layers hand ``core_attention.softmax_offset`` to their kernel as
+    ``learnable_sink``, so the model's distribution spans ``real keys + 1``. Folding
+    it into the stats kernel is what makes entropy/sink describe that distribution
+    instead of one renormalised over the real keys only.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not paddle.device.is_compiled_with_cuda() or paddle.device.cuda.device_count() == 0:
+            raise unittest.SkipTest("qk_stats kernel requires a CUDA GPU")
+        paddle.device.set_device("gpu:0")
+        cls.qk = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor")
+
+    @staticmethod
+    def _inputs(B=1, S=64, Hq=4, Hkv=2, D=32, seed=7):
+        paddle.seed(seed)
+        q = paddle.randn([B, S, Hq, D], dtype="float32")
+        k = paddle.randn([B, S, Hkv, D], dtype="float32")
+        return q, k
+
+    @staticmethod
+    def _reference(q, k, sink):
+        """Materialized [S, S(+1)] softmax reference: entropy and col-0 probability."""
+        B, S, Hq, D = q.shape
+        heads_per_group = Hq // k.shape[2]
+        qh = q.transpose([0, 2, 1, 3])
+        kh = k.transpose([0, 2, 1, 3]).repeat_interleave(heads_per_group, axis=1)
+        logits = paddle.matmul(qh, kh, transpose_y=True) / (D**0.5)  # [B, Hq, S, S]
+
+        causal = paddle.tril(paddle.ones([S, S], dtype="bool"))
+        logits = paddle.where(causal, logits, paddle.full_like(logits, -1e10))
+
+        if sink is not None:
+            sink_col = sink.reshape([1, Hq, 1, 1]).expand([B, Hq, S, 1])
+            logits = paddle.concat([logits, sink_col], axis=-1)
+
+        probs = paddle.nn.functional.softmax(logits, axis=-1)
+        entropy = -(probs * paddle.log(paddle.clip(probs, min=1e-30))).sum(axis=-1)  # [B, Hq, S]
+        return entropy.mean(axis=-1), probs[..., 0].mean(axis=-1)  # both [B, Hq]
+
+    def test_folded_stats_match_materialized_reference(self):
+        q, k = self._inputs()
+        sink = paddle.to_tensor([0.5, -1.0, 2.0, 0.0], dtype="float32")
+
+        stats = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1, attn_sink=sink)
+        ref_entropy, ref_sink = self._reference(q, k, sink)
+
+        self.assertTrue(
+            paddle.allclose(stats["entropy_per_head"], ref_entropy, atol=1e-3, rtol=1e-3).item(),
+            f"entropy: kernel={stats['entropy_per_head'].numpy()} ref={ref_entropy.numpy()}",
+        )
+        self.assertTrue(
+            paddle.allclose(stats["sink_per_head"], ref_sink, atol=1e-3, rtol=1e-3).item(),
+            f"sink: kernel={stats['sink_per_head'].numpy()} ref={ref_sink.numpy()}",
+        )
+
+    def test_without_sink_matches_real_key_only_reference(self):
+        """attn_sink=None keeps the pre-existing (real-key-only) semantics."""
+        q, k = self._inputs()
+        stats = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1)
+        ref_entropy, ref_sink = self._reference(q, k, None)
+
+        self.assertTrue(paddle.allclose(stats["entropy_per_head"], ref_entropy, atol=1e-3, rtol=1e-3).item())
+        self.assertTrue(paddle.allclose(stats["sink_per_head"], ref_sink, atol=1e-3, rtol=1e-3).item())
+
+    def test_zero_sink_still_changes_the_distribution(self):
+        """"off-by-one" softmax: a frozen 0 logit still adds exp(0) to the denominator."""
+        q, k = self._inputs()
+        zeros = paddle.zeros([q.shape[2]], dtype="float32")
+
+        without = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1)
+        with_zero = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1, attn_sink=zeros)
+
+        # Extra column takes probability mass, so col-0 probability must drop.
+        self.assertLess(with_zero["sink_global"].item(), without["sink_global"].item())
+        # logit max/mean describe real keys only and must be untouched by the fold.
+        self.assertAlmostEqual(with_zero["max_global"].item(), without["max_global"].item(), places=4)
+        self.assertAlmostEqual(with_zero["mean_global"].item(), without["mean_global"].item(), places=4)
+
+    def test_large_sink_dominates_and_collapses_entropy(self):
+        q, k = self._inputs()
+        huge = paddle.full([q.shape[2]], 50.0, dtype="float32")
+        stats = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1, attn_sink=huge)
+        # Nearly all mass on the sink column -> entropy ~ 0, real-key sink ~ 0.
+        self.assertLess(stats["entropy_global"].item(), 1e-3)
+        self.assertLess(stats["sink_global"].item(), 1e-3)
+
+
 class CompressRatioLayerClassificationTest(unittest.TestCase):
     """Per-layer attention-kind classification on ``csa_compress_ratios`` stacks."""
 


### PR DESCRIPTION
## 问题

`entropy` / `sink` 描述的分布与模型实际计算的分布不一致。

learned sink 是 softmax 里一个真实存在的、无对应 key 的额外列，会抢走概率质量。稀疏层（CSA/HCA）的 monitor 因为要自己复现分布，`attn_sink` 本来就是 `compressed_sparse_attn` 的入参，顺手 fold 进了 online-softmax（`triton_qk_kernel.py:673-685`）。而 full 层的 monitor 挂在 `core_attention` 的 forward_pre_hook 上，入参只有 q/k，`softmax_offset` 不在其中，于是 dense kernel 从来没有 fold 过它——报出来的是「只在真实 key 上归一化」的分布，模型里并不存在。

偏差方向不定。按 sink 概率 `p_s` 分解 `H_actual = H_b(p_s) + (1 − p_s)·H_real`，偏差是 `H_b(p_s) − p_s·H_real`：sink 占比大时报高，真实 key 分布本身很集中时报低。`sink` 指标方向确定——分母少了一列，一律报高。

## 改动

- `qk_stats_partial_kernel` 加 `attn_sink_ptr` + `HAS_SINK`，在 N 循环结束、finalize 之前 fold sink：更新 running max、按 `alpha_prev` rescale `h_i`/`d_i`/`s_i`、把 `sink_w` 加进分母和熵项。逻辑与稀疏 kernel 一致
- `row_max_logit_raw` / `row_sum_logit_raw` 不动，`max` / `mean` 仍只描述真实 key
- `compute_qk_stats_paddle` / `_compute_qk_stats_triton` 加 `attn_sink` 参数；None 时传 dummy 零 buffer 并 `HAS_SINK=False`（同稀疏路径的写法，避免空指针）
- hook 读 `core_attention.softmax_offset` 传入。**fold 条件是「不为 None」，不看 `stop_gradient`** —— `off-by-one` softmax 的冻结零 buffer 同样 `exp(0)` 进分母，也必须 fold。`attn_sink_logit` 那条曲线仍只在可训练时上报（冻结的没有可追踪的学习量级）

## 影响范围（重要）

合入后以下情况的 `entropy_*` / `sink*` 数值会跳变，**与历史曲线不可直接对比**：

- `add_full_attention_sink_bias=true` → full 层（本次动机）
- `add_swa_attention_sink_bias` → SWA 层。**注意其默认值是 `True`**，所以跑 SWA 的配置即使没显式设过 sink 开关也会命中
- config 里直接指定 `softmax_type="off-by-one"` 或 `"learnable"`

`softmax_type="vanilla"`（默认）且两个开关都没开时 `softmax_offset` 为 None，`HAS_SINK` 是 constexpr，分支在编译期被裁掉，结果逐位不变。

`max` / `mean` 在所有情况下都不变。

## 验证

新增 `DenseSinkFoldTest`，用物化 `[S, S+1]` softmax 的 python 参考实现对齐：

- fold 后 `entropy_per_head` / `sink_per_head` 与参考实现一致（atol 1e-3）
- `attn_sink=None` 时与「只有真实 key」的参考实现一致（锁住旧行为）
- 零 sink（off-by-one）仍使 `sink_global` 下降，而 `max_global` / `mean_global` 不变
- 极大 sink（50.0）时熵塌到 ~0、真实 key 的 sink 概率 ~0

全量 64 passed（`test_megatron_monitors.py` / `test_mhc_monitor.py` 因本地缺 megatron 依赖无法收集，与本改动无关）。

## 未覆盖

megatron 后端的 legacy `qk_stats_kernel` 有同样的口径问题，本次未改。