### PR TITLE
fix(moe_health): bias_affinity_jaccard 的组分数对齐 router 的 top-2 之和

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -46,6 +46,12 @@ def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=
         k: num_experts_per_tok
         n_group / topk_group: group-limited topk params
 
+    Group score is the sum of the group's top-2 experts, mirroring a literal in both
+    router paths (``moe_router.TopKRouter`` and ``moe_topk_fusion``'s ``m1 + m2``);
+    a group max would pick different groups and read < 1 even with an all-zero bias.
+    Follow the router if it ever parameterises that 2. ``min(2, group_size)`` is only
+    a shape guard.
+
     Returns:
         mean Jaccard similarity (1 = identical routing, 0 = completely different)
     """
@@ -54,8 +60,8 @@ def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=
     if n_group > 1 and topk_group >= 1:
         group_size = num_experts // n_group
         gates_reshaped = gates_no_bias.reshape([num_tokens, n_group, group_size])
-        group_max = gates_reshaped.max(axis=-1)
-        _, top_groups = paddle.topk(group_max, topk_group, axis=-1)
+        group_scores = gates_reshaped.topk(min(2, group_size), axis=-1)[0].sum(axis=-1)
+        _, top_groups = paddle.topk(group_scores, topk_group, axis=-1)
         group_mask = paddle.zeros([num_tokens, n_group], dtype="int32")
         group_mask = group_mask.put_along_axis(top_groups, paddle.to_tensor(1, dtype="int32"), axis=1)
         group_mask = group_mask.unsqueeze(-1).expand([-1, -1, group_size]).reshape([num_tokens, num_experts])

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -19,6 +19,7 @@ PaddleMassiveActivationMonitor = importlib.import_module(
     "internal_medicine.backends.paddlefleet.massive_activation_monitor"
 ).PaddleMassiveActivationMonitor
 PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor").PaddleMoEMonitor
+moe_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
 PaddleQKStatsMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor").PaddleQKStatsMonitor
 paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
 layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
@@ -462,6 +463,97 @@ class SplitFeatureRoutingCaptureTest(unittest.TestCase):
         gate.gate_score_func(logits)
 
         self.assertTrue(paddle.allclose(gate._cached_gates, two_views, atol=1e-6).item())
+
+
+class BiasAffinityJaccardTest(unittest.TestCase):
+    """The bias-free branch must mirror the router's group-limited topk exactly.
+
+    PaddleFleet scores a group by the sum of its top-2 experts (tensor path
+    ``moe_router.TopKRouter``, fused path ``moe_topk_fusion``: ``score = m1 + m2``).
+    Using a group max instead selects different groups, so the metric would report
+    routing divergence even with an all-zero correction bias.
+    """
+
+    @staticmethod
+    def _router_topk(scores, k, n_group, topk_group):
+        """Reference: the router's own selection (group score = top-2 sum)."""
+        num_tokens, num_experts = scores.shape
+        group_size = num_experts // n_group
+        grouped = scores.reshape([num_tokens, n_group, group_size])
+        group_scores = grouped.topk(2, axis=-1)[0].sum(axis=-1)
+        _, top_groups = paddle.topk(group_scores, topk_group, axis=-1)
+        mask = paddle.zeros([num_tokens, n_group], dtype="int32")
+        mask = mask.put_along_axis(top_groups, paddle.to_tensor(1, dtype="int32"), axis=1)
+        mask = mask.unsqueeze(-1).expand([-1, -1, group_size]).reshape([num_tokens, num_experts])
+        masked = paddle.where(mask > 0, scores, paddle.full_like(scores, float("-inf")))
+        return paddle.topk(masked, k, axis=-1)[1]
+
+    def test_zero_bias_gives_identical_routing(self):
+        """correction_bias is zero-initialised, so step 1 must read exactly 1.0."""
+        paddle.seed(0)
+        scores = paddle.rand([16, 8], dtype="float32")
+        k, n_group, topk_group = 2, 2, 1
+
+        top_idx = self._router_topk(scores, k, n_group, topk_group)
+        jaccard = moe_monitor_module._compute_bias_affinity_jaccard(top_idx, scores, k, n_group, topk_group)
+        self.assertAlmostEqual(float(jaccard), 1.0, places=6)
+
+    def test_group_score_uses_top2_sum_not_max(self):
+        """A case where max and top-2 sum disagree on which group wins.
+
+        group0 has the single strongest expert, group1 the stronger pair:
+        max picks group0, top-2 sum picks group1. The router picks group1, so a
+        max-based reimplementation would score 0 here instead of 1.
+        """
+        scores = paddle.to_tensor(
+            [[0.90, 0.05, 0.03, 0.02, 0.80, 0.70, 0.05, 0.05]],
+            dtype="float32",
+        )
+        k, n_group, topk_group = 2, 2, 1
+
+        top_idx = self._router_topk(scores, k, n_group, topk_group)
+        # Sanity: the router really did take group1 (experts 4 and 5).
+        self.assertEqual(sorted(top_idx.numpy().flatten().tolist()), [4, 5])
+
+        jaccard = moe_monitor_module._compute_bias_affinity_jaccard(top_idx, scores, k, n_group, topk_group)
+        self.assertAlmostEqual(float(jaccard), 1.0, places=6)
+
+    def test_nonzero_bias_lowers_the_score(self):
+        """With a bias that flips the winning group, the score must drop below 1."""
+        scores = paddle.to_tensor(
+            [[0.90, 0.80, 0.05, 0.05, 0.40, 0.30, 0.05, 0.05]],
+            dtype="float32",
+        )
+        bias = paddle.to_tensor([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0], dtype="float32")
+        k, n_group, topk_group = 2, 2, 1
+
+        top_idx = self._router_topk(scores + bias, k, n_group, topk_group)
+        jaccard = moe_monitor_module._compute_bias_affinity_jaccard(top_idx, scores, k, n_group, topk_group)
+        self.assertAlmostEqual(float(jaccard), 0.0, places=6)
+
+    def test_ungrouped_router_path(self):
+        paddle.seed(1)
+        scores = paddle.rand([8, 6], dtype="float32")
+        top_idx = paddle.topk(scores, 3, axis=-1)[1]
+        jaccard = moe_monitor_module._compute_bias_affinity_jaccard(top_idx, scores, 3, n_group=1, topk_group=1)
+        self.assertAlmostEqual(float(jaccard), 1.0, places=6)
+
+    def test_single_expert_groups_do_not_crash(self):
+        """group_size == 1 has no second expert to add; top-2 clamps to top-1."""
+        scores = paddle.to_tensor([[0.9, 0.1, 0.5, 0.4]], dtype="float32")
+        k, n_group, topk_group = 2, 4, 2
+        num_tokens, num_experts = scores.shape
+        grouped = scores.reshape([num_tokens, n_group, num_experts // n_group])
+        _, top_groups = paddle.topk(grouped.squeeze(-1), topk_group, axis=-1)
+        mask = paddle.zeros([num_tokens, n_group], dtype="int32")
+        mask = mask.put_along_axis(top_groups, paddle.to_tensor(1, dtype="int32"), axis=1)
+        masked = paddle.where(mask > 0, scores, paddle.full_like(scores, float("-inf")))
+        top_idx = paddle.topk(masked, k, axis=-1)[1]
+
+        jaccard = moe_monitor_module._compute_bias_affinity_jaccard(top_idx, scores, k, n_group, topk_group)
+        self.assertAlmostEqual(float(jaccard), 1.0, places=6)
+
+
 
 
 class PaddleMassiveActivationMonitorTest(unittest.TestCase):


### PR DESCRIPTION
## 问题

monitor 复现「不带 bias 的路由」时没有复刻 router 的组选择准则。

router 的 group-limited topk 用组内 **top-2 之和**作为组分数：

- 张量路径 `moe_router.py`：`.topk(2, axis=-1)[0].sum(axis=-1)`
- fused triton 路径 `moe_topk_fusion.py`：`score = m1 + m2`

而 monitor 用的是组内 **max**（`moe_monitor.py`）。两个准则会选出不同的组，进而选出不同的专家集合。

这个指标的意义在于「除了 bias，其他都一样」——只要组选择准则与 router 不一致，它测到的就混进了实现差异，而不只是 bias 的影响。

## 改动

组分数改为 `gates_reshaped.topk(min(2, group_size), axis=-1)[0].sum(axis=-1)`，与两条 router 路径一致。`min(2, group_size)` 兜住 `group_size == 1`。docstring 里注明了这个 `2` 是跟随 router 的字面量（无配置项，来自 DeepSeek V3 的 node-limited routing），router 若参数化需同步。

## 单测

新增 `BiasAffinityJaccardTest`（含 router 选择的参考实现）：

- 零 bias 时 Jaccard 必须为 1.0
- max 与 top-2 之和分歧的对抗样例必须为 1.0（旧实现在此为 0，是本次的回归保护）
- bias 翻转获胜组时必须为 0.0（确认指标仍能反映真实路由变化）
- `n_group=1` 路径、`group_size=1` 边界

## 影响

- 开了 `n_group > 1` 的配置，该指标数值会上移（此前被系统性低估），历史曲线不可与之直接对比
- `n_group = 1`（当前默认）走非分组分支，不受影响
- megatron 后端的 `compute_bias_affinity_jaccard` 若也有分组逻辑，需要同样核对，本次未改