### PR TITLE
fix(moe_health): split-feature routing 下累加两个 gate view 的分数

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -172,6 +172,17 @@ class PaddleMoEMonitor(PaddleProbe):
             f"{len(self._expert_norm_layers)} expert-norm layers on {len(moe_layers)} MoE layers."
         )
 
+    @staticmethod
+    def _uses_split_routing(gate) -> bool:
+        """True when the router scores on the sum of two gate projections.
+
+        ``moe_split_feature_routing`` gives the router a second projection
+        (``weight_1``) and routes on ``f(logits_0) + f(logits_1)``. Hash layers
+        opt out (``use_split = split and not is_hash_layer`` in moe_router) and
+        capture their scores through the ``_hash_routing`` patch instead.
+        """
+        return bool(getattr(gate, "moe_split_feature_routing", False)) and not getattr(gate, "is_hash_layer", False)
+
     def _patch_gate_cache(self, gate):
         """Monkey-patch gate.gate_score_func to cache pre-bias gates."""
         if not hasattr(gate, "gate_score_func"):
@@ -187,10 +198,22 @@ class PaddleMoEMonitor(PaddleProbe):
 
         def cached_gate_score_func(logits):
             result = original_fn(logits)
-            if monitor._should_monitor():
-                gate._cached_gates = result.detach()
-            else:
+            if not monitor._should_monitor():
                 gate._cached_gates = None
+                return result
+            scores = result.detach()
+            # Split-feature routing calls this twice per forward and routes on the
+            # SUM of the two views (moe_router: gates = f(logits_0) + f(logits_1)),
+            # so overwriting would leave us with view 1 alone — half of the routing
+            # signal. Accumulate instead. The gate post-hook clears _cached_gates
+            # after every forward, so nothing leaks across forwards. Only the split
+            # path accumulates, so a stray double call elsewhere stays visible
+            # rather than being silently summed.
+            if monitor._uses_split_routing(gate):
+                previous = getattr(gate, "_cached_gates", None)
+                if previous is not None and previous.shape == scores.shape:
+                    scores = previous + scores
+            gate._cached_gates = scores
             return result
 
         gate._im_original_gate_score_func = original_fn

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -382,6 +382,88 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertIsNone(gate._cached_gates)
 
 
+class SplitFeatureRoutingCaptureTest(unittest.TestCase):
+    """``moe_split_feature_routing`` routes on the SUM of two gate views.
+
+    ``moe_router`` computes ``gates = f(logits_0) + f(logits_1)``, so the patched
+    ``gate_score_func`` fires twice per forward. Overwriting the cache would leave
+    the monitor with view 1 alone — half the routing signal — which silently skews
+    every metric derived from it (router_entropy, score_sum_*, bias_affinity_jaccard).
+    """
+
+    class FakeGate:
+        def __init__(self, split):
+            self.moe_split_feature_routing = split
+            self.num_experts_per_tok = 2
+
+        def gate_score_func(self, logits):
+            return paddle.nn.functional.sigmoid(logits)
+
+    def _patched_gate(self, split):
+        monitor = PaddleMoEMonitor()
+        gate = self.FakeGate(split)
+        monitor._patch_gate_cache(gate)
+        return monitor, gate
+
+    def test_split_routing_accumulates_both_views(self):
+        _monitor, gate = self._patched_gate(split=True)
+        logits_0 = paddle.to_tensor([[1.0, -1.0, 0.5, 0.0]], dtype="float32")
+        logits_1 = paddle.to_tensor([[-2.0, 2.0, 0.0, 0.25]], dtype="float32")
+
+        gate.gate_score_func(logits_0)
+        gate.gate_score_func(logits_1)
+
+        expected = paddle.nn.functional.sigmoid(logits_0) + paddle.nn.functional.sigmoid(logits_1)
+        self.assertTrue(paddle.allclose(gate._cached_gates, expected, atol=1e-6).item())
+
+    def test_split_routing_top_experts_come_from_the_sum(self):
+        """View 1 alone ranks experts differently from the sum the router uses."""
+        _monitor, gate = self._patched_gate(split=True)
+        logits_0 = paddle.to_tensor([[4.0, 4.0, -4.0, -4.0]], dtype="float32")
+        logits_1 = paddle.to_tensor([[-1.0, -2.0, 3.0, 2.0]], dtype="float32")
+
+        gate.gate_score_func(logits_0)
+        gate.gate_score_func(logits_1)
+
+        summed_top = paddle.topk(gate._cached_gates, 2, axis=-1)[1].numpy().flatten().tolist()
+        view1_top = paddle.topk(paddle.nn.functional.sigmoid(logits_1), 2, axis=-1)[1].numpy().flatten().tolist()
+        self.assertEqual(sorted(summed_top), [0, 1])
+        self.assertNotEqual(sorted(summed_top), sorted(view1_top))
+
+    def test_single_view_router_keeps_last_write(self):
+        """Without split routing the cache must not accumulate."""
+        _monitor, gate = self._patched_gate(split=False)
+        logits_0 = paddle.to_tensor([[1.0, -1.0, 0.5, 0.0]], dtype="float32")
+        logits_1 = paddle.to_tensor([[-2.0, 2.0, 0.0, 0.25]], dtype="float32")
+
+        gate.gate_score_func(logits_0)
+        gate.gate_score_func(logits_1)
+
+        expected = paddle.nn.functional.sigmoid(logits_1)
+        self.assertTrue(paddle.allclose(gate._cached_gates, expected, atol=1e-6).item())
+
+    def test_hash_layers_opt_out_of_split_accumulation(self):
+        """Hash layers bypass split routing and capture via _hash_routing instead."""
+        gate = self.FakeGate(split=True)
+        gate.is_hash_layer = True
+        self.assertFalse(PaddleMoEMonitor._uses_split_routing(gate))
+
+    def test_cache_cleared_between_forwards_prevents_leakage(self):
+        """The gate post-hook clears the cache, so forwards never accumulate."""
+        _monitor, gate = self._patched_gate(split=True)
+        logits = paddle.to_tensor([[1.0, -1.0, 0.5, 0.0]], dtype="float32")
+
+        gate.gate_score_func(logits)
+        gate.gate_score_func(logits)
+        two_views = gate._cached_gates.clone()
+
+        gate._cached_gates = None  # what _make_gate_hook's finally block does
+        gate.gate_score_func(logits)
+        gate.gate_score_func(logits)
+
+        self.assertTrue(paddle.allclose(gate._cached_gates, two_views, atol=1e-6).item())
+
+
 class PaddleMassiveActivationMonitorTest(unittest.TestCase):
     def setUp(self):
         training_logs.reset()


### PR DESCRIPTION
## 问题

开启 `moe_split_feature_routing` 时，monitor 抓到的路由分数只有一半。

router 在这个模式下用两套投影各算一次 sigmoid，以**两者之和**作为路由分数（`moe_router.py`）：

```python
gates = self.gate_score_func(logits_0) + self.gate_score_func(logits_1)
```

而 monitor 是 patch `gate.gate_score_func` 抓分数的，一次 forward 里被调两次，第二次直接覆盖第一次：

```python
gate._cached_gates = result.detach()   # 覆盖
```

于是 `_cached_gates` 只剩 view 1，而 router 实际选择用的是 view 0 + view 1。所有从它派生的 router 指标都偏了。

## 改动

- 新增 `_uses_split_routing(gate)`：`moe_split_feature_routing` 为真且非 hash 层。hash 层在 router 里 `use_split = split and not is_hash_layer` 走单 gate，分数由 `_hash_routing` 的 patch 单独抓
- `cached_gate_score_func` 在 split 路径下累加而非覆盖。**只有 split 累加**，非 split 保持「最后一次写入」语义不变——这样万一别处出现意外的重复调用，仍会表现为可被发现的症状，而不是被静默求和掩盖
- 跨 forward 不会泄漏：gate 的 post-hook 在 `finally` 里会把 `_cached_gates` 置 None

未开 `moe_split_feature_routing` 的配置计算路径完全不变（该开关关闭时 router 本身也只调 `gate_score_func` 一次）。


## 单测

新增 `SplitFeatureRoutingCaptureTest`：

- split 下两次调用后缓存等于两个 view 的 sigmoid 之和
- 构造 view 1 单独排序与「和」排序不同的 logits，断言缓存里的 top-k 来自「和」（直接对应线上现象）
- 非 split 不累加，保持最后一次写入
- hash 层不参与累加
- 模拟 post-hook 清空后再来一轮，结果与第一轮一致（防跨 forward 泄漏）

全量 69 passed（`test_megatron_monitors.py` / `test_mhc_monitor.py` 因本地缺 megatron 依赖无法收集，与本改动无关）。

## 影响

开了 `moe_split_feature_routing` 的 run，`bias_affinity_jaccard` / `score_sum_*` / `router_entropy` 数值都会变，历史曲线不可与之直接对比。未开该开关的配置不受影响。