### PR TITLE
feat(vha_health): 新增 VHA premix/postmix 监控

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 8 指标；仅在开启 mHC 层时生效)
+- **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 
 ---
 
@@ -128,7 +129,7 @@ setup_internal_medicine()
 {monitor_name}/global_{metric_name}                     # 全局聚合指标
 ```
 
-- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health`
+- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health`
 - `global_idx`: 考虑 PP (Pipeline Parallelism) 的全局层索引 = `pp_rank × local_layers + local_idx`
 - `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路
 
@@ -367,6 +368,61 @@ hc 模块处重置）——PP=1 时精确，PP>1 时为 stage 局部近似。
 
 ---
 
+## 六、VHA Health Monitor (vha_health)
+
+> **仅 paddlefleet 后端**。只在 `use_vha_attention=true` 时生效——模型不含 VHA postmix 参数时该 monitor 为彻底
+> no-op（不 wrap、不产生指标）。
+
+VHA (Virtual Head Attention) 把**物理 query head 减半**、`H_kv` 设为 2，再用两个**严格线性**的算子把表达力
+补回来：
+
+- **Q Premix** — 在每个 KV group 内对 query 做**近恒等**线性变换，把减半的物理 query head 扩展成
+  `H_v = H'_q × H_kv` 个虚拟头，恢复注意力多样性。PaddleFleet 初始化为 `I + 0.1/√d · N(0,1)`
+  （`q_head_dim == head_dim` 时；否则退化为缩放正交初始化）。需开 `use_vha_premix`，未开启不声明 premix 指标。
+- **Linear Postmix** — 在注意力输出的 head 轴上做低秩恒等残差 `I + A Bᵗ`（`r = H'_q`），融合跨组的 inter-head
+  特征。位置在 gate 与 `o_proj` **之前**；PaddleFleet 的参数名是 `vha_postmix_U` / `vha_postmix_V`，即 `A` / `B`。
+  `B` 零初始化，故初始为**精确恒等**、`delta ≡ 0`。
+
+两者在推理时都会被折叠（Premix 进 `q_proj`、Postmix 进 `o_proj`），模型退化成标准 GQA-2。**也就是说这两个矩阵
+只在训练期存在，训练期是唯一能观测其结构的时机。**
+
+这两处对其他 monitor 都不可见：`qk_stats` 采样点在 `core_attention` 的**输入**（Postmix 发生在其后），
+`massive_act` 只看残差流（Postmix 的效果被 `o_proj` 和残差加法稀释）。
+
+| # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
+|---|------|--------|------|------|----------|
+| 1 | `{b}_postmix_delta_rel_mean` | `vha_health/layer_{i}/{b}_postmix_delta_rel_mean` | `mean_t(‖delta_t‖₂ / ‖mixed_t‖₂)` | 每层+全局 | **首要指标**：从 0 起长，回答「Postmix 是否在学」 |
+| 2 | `{b}_postmix_delta_rel_max` | `vha_health/layer_{i}/{b}_postmix_delta_rel_max` | `max_t(‖delta_t‖₂ / ‖mixed_t‖₂)` | 每层+全局 | 最坏 token 的修正幅度，看突刺 |
+| 3 | `{b}_postmix_amax_gain_max` | `vha_health/layer_{i}/{b}_postmix_amax_gain_max` | `max_t(‖out_t‖_∞ / ‖mixed_t‖_∞)` | 每层+全局 | 低精度溢出余量（同 mHC `amax_gain` 口径） |
+| 4 | `{b}_postmix_uv_sigma_max` | `vha_health/layer_{i}/{b}_postmix_uv_sigma_max` | `σ_max(A Bᵗ)` | 每层+全局 | 混合算子偏离恒等的强度上界 |
+| 5 | `{b}_postmix_uv_eff_rank` | `vha_health/layer_{i}/{b}_postmix_uv_eff_rank` | `exp(-Σ p log p)`, `p = σ/Σσ` | 每层+全局 | 是否守在低秩预算内（**涨= 警告**，见下） |
+| 6 | `{b}_postmix_offdiag_ratio` | `vha_health/layer_{i}/{b}_postmix_offdiag_ratio` | `‖M − diag(M)‖_F / ‖M‖_F` | 每层+全局 | 趋 0 = 退化成 per-head 缩放，无真实跨头混合 |
+| 7 | `{b}_postmix_u_fro` / `{b}_postmix_v_fro` | `vha_health/layer_{i}/{b}_postmix_{u,v}_fro` | `‖A‖_F` / `‖B‖_F` | 每层+全局 | 哪个因子在长 |
+| 8 | `{b}_head_out_norm_max/min/std` | `vha_health/layer_{i}/{b}_head_out_norm_*` | per-head 输出范数（token 均值）的 max/min/std | 每层+全局 | 某个 head 被压成 0 或被放大 |
+| 9 | `{b}_postmix_head_cos_mean` | `vha_health/layer_{i}/{b}_postmix_head_cos_mean` | token 均值 head 向量间的平均 \|cos\| | 每层+全局 | 趋 1 = 各 head 退化成彼此的复制 |
+| 10 | `premix_identity_dev` | `vha_health/layer_{i}/premix_identity_dev` | 组均值 `‖W_g − I‖_F` | 每层+全局 | Premix 离「无操作」多远 |
+| 11 | `premix_group_div_ratio` | `vha_health/layer_{i}/premix_group_div_ratio` | `mean_{g<g'}‖W_g − W_g'‖²_F / mean_g‖W_g − I‖²_F` | 每层+全局 | group-conditioned query specialization：0 = 各组学成同一个变换，2 = 完全独立 |
+| 12 | `premix_sigma_max` | `vha_health/layer_{i}/premix_sigma_max` | `σ_max(W)` | 每层+全局 | Premix 谱范数（近恒等时约 1） |
+| 13 | `premix_orth_dev` | `vha_health/layer_{i}/premix_orth_dev` | `‖WᵀW − I‖_F` | 每层+全局 | 仅 `q_head_dim ≠ head_dim`（正交初始化）时代替 10~11 |
+
+`{b}` ∈ `{main, sparse}`：MQA 栈的 block-sparse 分支持有独立的 `sparse_vha_postmix_U/V`，两套参数分开统计。
+混合栈上注意力类型同样会前置到指标名，例如 `vha_health/layer_5/hca_main_postmix_delta_rel_max`。
+premix 的指标集由权重形状决定（方阵 → 10~12；非方阵 → 12~13；`H_kv = 1` 时无 11），形状在注册时已知，
+因此仍满足「declare 完再 allocate」。
+
+### 健康判读
+
+- `postmix_delta_rel_mean` 长期贴 0 → Postmix 没在学（检查 `B` 的梯度/学习率是否被误置零）。
+- `postmix_delta_rel_max` 出现数量级突刺，或 `postmix_amax_gain_max` 明显 > 1 → 低精度下有溢出风险。
+- `postmix_offdiag_ratio` 趋 0 而 `postmix_uv_sigma_max` 在长 → 学成了 per-head 缩放，跨头混合的容量没用上。
+- `postmix_uv_eff_rank` 持续爬向配置的 `r` → **警告而非健康**。低秩瓶颈是设计上的结构正则，VHA 论文的消融显示
+  `r = 32/128` 虽然训练 loss 更低但评测更差；有效秩顶满通常伴随过拟合倾向。
+- `postmix_head_cos_mean` 趋 1 或 `head_out_norm_min` 趋 0 → head 退化。
+- `premix_group_div_ratio` 趋 0 → 各 KV group 学成同一个 query 变换，虚拟头没有按组分化；趋 2 → 各组完全独立。
+  论文观测到的是「显著不同但并非独立」，两端都是异常。
+
+---
+
 ## 基础设施
 
 ### TrainingLogs
@@ -477,3 +533,18 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **PLE** | `residual_ratio` | `\|\|Δ\|\|/\|\|h\|\|` | mean | 适中 |
 | **PLE** | `gate_activation_mean` | `mean(\|act(gate)\|)` | mean | 非零 |
 | **PLE** | `gate_sparsity` | `dead_ratio` | mean | 不应持续上升 |
+| **VHA** | `{b}_postmix_delta_rel_mean` | `mean_t(‖delta‖/‖mixed‖)` | mean | postmix 是否在学 (0 起步) |
+| **VHA** | `{b}_postmix_delta_rel_max` | `max_t(‖delta‖/‖mixed‖)` | max | 最坏 token 修正幅度 |
+| **VHA** | `{b}_postmix_amax_gain_max` | `max_t(‖out‖_∞/‖mixed‖_∞)` | max | 低精度溢出余量 |
+| **VHA** | `{b}_postmix_uv_sigma_max` | `σ_max(A Bᵗ)` | max | 偏离恒等的强度上界 |
+| **VHA** | `{b}_postmix_uv_eff_rank` | `exp(-Σ p log p)` | mean | 是否守在低秩预算内 (涨=警告) |
+| **VHA** | `{b}_postmix_offdiag_ratio` | `‖A−diag(A)‖_F/‖I+A‖_F` | mean | 趋 0 = 退化成 per-head 缩放 |
+| **VHA** | `{b}_postmix_u_fro` / `{b}_postmix_v_fro` | `‖A‖_F` / `‖B‖_F` | mean | 哪个因子在长 |
+| **VHA** | `{b}_head_out_norm_max` | per-head 输出范数最大 | max | head 被放大 |
+| **VHA** | `{b}_head_out_norm_min` | per-head 输出范数最小 | min | head 被压成 0 |
+| **VHA** | `{b}_head_out_norm_std` | per-head 输出范数离散度 | mean | head 间幅度分化 |
+| **VHA** | `{b}_postmix_head_cos_mean` | 均值 head 向量间平均 \|cos\| | mean | 趋 1 = head 退化成复制 |
+| **VHA** | `premix_identity_dev` | 组均值 `‖W_g − I‖_F` | mean | Premix 离无操作多远 (需 use_vha_premix) |
+| **VHA** | `premix_group_div_ratio` | `mean‖W_g−W_g'‖²/mean‖W_g−I‖²` | mean | 0=各组同一变换, 2=完全独立 |
+| **VHA** | `premix_sigma_max` | `σ_max(W)` | max | premix 谱范数 (需 use_vha_premix) |
+| **VHA** | `premix_orth_dev` | `‖WᵀW − I‖_F` | mean | 仅非方阵 premix (正交初始化) |

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -8,6 +8,7 @@ from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_ma
 from .mhc_monitor import PaddleMHCHealthMonitor, setup_mhc_monitor
 from .moe_monitor import PaddleMoEMonitor, setup_moe_monitor
 from .qk_monitor import PaddleQKStatsMonitor, setup_qk_monitor
+from .vha_monitor import PaddleVHAHealthMonitor, setup_vha_monitor
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,7 @@ _MONITOR_MAP = {
     "moe_health": setup_moe_monitor,
     "massive_act": setup_massive_activation_monitor,
     "mhc_health": setup_mhc_monitor,
+    "vha_health": setup_vha_monitor,
 }
 
 _MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
@@ -102,4 +104,6 @@ __all__ = [
     "setup_massive_activation_monitor",
     "PaddleMHCHealthMonitor",
     "setup_mhc_monitor",
+    "PaddleVHAHealthMonitor",
+    "setup_vha_monitor",
 ]

--- a/src/internal_medicine/backends/paddlefleet/vha_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/vha_metrics.py
@@ -1,0 +1,233 @@
+"""VHA (Virtual Head Attention) metric kernels for PaddleFleet.
+
+VHA halves the physical query heads and sets ``H_kv = 2``, then restores
+expressiveness with two strictly linear operations (Ding et al., *Virtual Head
+Attention*):
+
+- **Q Premix** — a near-identity transform applied per KV group, expanding the
+  halved physical query heads into ``H_v = H'_q × H_kv`` virtual heads.
+- **Linear Postmix** — a low-rank identity-residual on the head axis of the
+  attention output, ``I + A Bᵗ`` with ``r = H'_q``, fusing cross-group inter-head
+  features. PaddleFleet names the factors ``vha_postmix_U`` / ``vha_postmix_V``,
+  i.e. ``A`` / ``B``::
+
+    mixed = attn_out.reshape([..., nh, v_head_dim])
+    delta = (mixed @ U) @ Vᵀ          # U, V: [nh, rank]
+    out   = mixed + delta             # operator M = I + U Vᵀ on the head axis
+
+Both fold away at inference (Premix into ``q_proj``, Postmix into ``o_proj``),
+leaving a plain GQA-2 model — so these matrices only exist during training, and
+this is the only place their trained structure can be observed.
+
+``V`` is zero-initialised, so Postmix starts as the exact identity and ``delta``
+starts at 0. Whether (and how fast) it moves away is the central question here.
+
+Grouped postmix uses ``[groups, heads_per_group, rank]`` factors and mixes heads
+only inside a group, i.e. ``M`` is block diagonal. Every function below treats
+the ungrouped case as a single group so both topologies share one code path.
+
+All functions return 0-dim GPU tensors and never sync to host: the monitor
+records them through the GPU-buffer API and a single D2H happens at flush.
+"""
+
+from __future__ import annotations
+
+import paddle
+
+_EPS = 1e-8
+
+
+def _as_grouped(factor: paddle.Tensor) -> paddle.Tensor:
+    """Return a ``[groups, heads_per_group, rank]`` view of a postmix factor."""
+    if factor.ndim == 2:
+        return factor.unsqueeze(0)
+    return factor
+
+
+def postmix_operator_stats(U: paddle.Tensor, V: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Spectral statistics of the postmix operator ``M = I + U Vᵀ``.
+
+    Cheap by construction: the factors are ``[nh, rank]`` (e.g. ``[64, 16]``),
+    so the Gram matrix is at most ``[nh, nh]``. Singular values come from
+    ``eigvalsh`` of ``AᵀA`` rather than an SVD — symmetric, batched, and with no
+    convergence caveats.
+
+    Returns:
+        ``postmix_uv_sigma_max`` — ``σ_max(U Vᵀ)``: how far the operator can
+        stretch a head-space direction beyond the identity.
+        ``postmix_uv_eff_rank`` — entropy-based effective rank of ``U Vᵀ``
+        (``exp(-Σ p log p)`` over normalised singular values). Read this as
+        "is the mixing staying inside its low-rank budget", **not** as capacity
+        utilisation: the bottleneck ``r ≪ H`` is a deliberate structural
+        regulariser, and the paper's ablation shows larger ranks (32, 128) hurt
+        evaluation despite lower training loss. Growth towards the configured
+        rank is therefore a warning, not health.
+        ``postmix_offdiag_ratio`` — off-diagonal energy share of ``M``,
+        ``‖A − diag(A)‖_F / ‖M‖_F``. Near 0 means the operator degenerated into
+        a per-head rescaling and no real cross-head mixing is happening.
+        ``postmix_u_fro`` / ``postmix_v_fro`` — factor magnitudes, to see which
+        side is growing.
+    """
+    u = _as_grouped(U.detach().astype("float32"))
+    v = _as_grouped(V.detach().astype("float32"))
+    # Per group: A_g = U_g V_gᵀ, the off-identity part of the block operator.
+    a = paddle.einsum("gjr,gkr->gjk", u, v)  # [G, n, n]
+
+    gram = paddle.matmul(a, a, transpose_x=True)  # AᵀA, symmetric PSD
+    eigenvalues = paddle.linalg.eigvalsh(gram)  # [G, n], ascending
+    singular = paddle.sqrt(paddle.clip(eigenvalues, min=0.0))
+
+    sigma_max = singular.max()
+    probabilities = singular / paddle.clip(singular.sum(axis=-1, keepdim=True), min=_EPS)
+    entropy = -(probabilities * paddle.log(paddle.clip(probabilities, min=_EPS))).sum(axis=-1)
+    eff_rank = paddle.exp(entropy).mean()
+
+    diagonal = paddle.diagonal(a, axis1=-2, axis2=-1)  # [G, n]
+    offdiag_sq = paddle.square(a).sum() - paddle.square(diagonal).sum()
+    # ‖M‖_F² with M = A + I on every block; only the diagonal shifts by 1.
+    full_sq = paddle.square(a).sum() - paddle.square(diagonal).sum() + paddle.square(diagonal + 1.0).sum()
+    offdiag_ratio = paddle.sqrt(paddle.clip(offdiag_sq, min=0.0) / paddle.clip(full_sq, min=_EPS))
+
+    return {
+        "postmix_uv_sigma_max": sigma_max,
+        "postmix_uv_eff_rank": eff_rank,
+        "postmix_offdiag_ratio": offdiag_ratio,
+        "postmix_u_fro": u.norm(),
+        "postmix_v_fro": v.norm(),
+    }
+
+
+def postmix_delta_stats(attn_out: paddle.Tensor, out: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Per-token effect of the postmix correction on the attention output.
+
+    Both tensors are the flat head-space layout ``[..., nh * v_head_dim]``:
+    ``attn_out`` is the input of ``_apply_vha_postmix`` and ``out`` its return
+    value, so ``delta = out − attn_out`` needs no recomputation.
+
+    Returns:
+        ``postmix_delta_rel_mean`` / ``postmix_delta_rel_max`` — per-token
+        ``‖delta‖₂ / ‖mixed‖₂``. This is the primary read: it starts at 0 (zero
+        init of ``V``) and its trend answers "is postmix learning anything".
+        ``postmix_amax_gain_max`` — worst-token ``‖out‖_∞ / ‖mixed‖_∞``, the
+        low-precision overflow headroom of the correction (same reading as the
+        mHC ``amax_gain`` family).
+    """
+    mixed = attn_out.detach().astype("float32")
+    mixed = mixed.reshape([-1, mixed.shape[-1]])
+    result = out.detach().astype("float32")
+    result = result.reshape([-1, result.shape[-1]])
+    delta = result - mixed
+
+    mixed_norm = paddle.clip(mixed.norm(axis=-1), min=_EPS)
+    delta_rel = delta.norm(axis=-1) / mixed_norm
+
+    mixed_amax = paddle.clip(mixed.abs().max(axis=-1), min=_EPS)
+    amax_gain = result.abs().max(axis=-1) / mixed_amax
+
+    return {
+        "postmix_delta_rel_mean": delta_rel.mean(),
+        "postmix_delta_rel_max": delta_rel.max(),
+        "postmix_amax_gain_max": amax_gain.max(),
+    }
+
+
+def head_output_stats(out: paddle.Tensor, num_heads: int) -> dict[str, paddle.Tensor]:
+    """Head-space diversity of the postmix output.
+
+    ``head_out_norm_*`` is the spread of the token-mean per-head output norm:
+    a head collapsing to ~0 or blowing up shows here first.
+
+    ``postmix_head_cos_mean`` is the mean absolute off-diagonal cosine of the
+    token-mean head vectors — the direct read on "did the mixer collapse the
+    heads into copies of each other". Using token-mean vectors (rather than a
+    per-token pairwise mean) keeps this to one ``[nh, nh]`` Gram; it is a
+    directional-agreement signal, not an exact per-token average.
+    """
+    flat = out.detach().astype("float32")
+    flat = flat.reshape([-1, num_heads, flat.shape[-1] // num_heads])
+
+    head_norm = flat.norm(axis=-1).mean(axis=0)  # [nh]
+    stats = {
+        "head_out_norm_max": head_norm.max(),
+        "head_out_norm_min": head_norm.min(),
+        "head_out_norm_std": head_norm.std() if num_heads > 1 else paddle.zeros(()),
+    }
+
+    if num_heads < 2:
+        stats["postmix_head_cos_mean"] = paddle.zeros(())
+        return stats
+
+    head_vec = flat.mean(axis=0)  # [nh, v_head_dim]
+    head_vec = head_vec / paddle.clip(head_vec.norm(axis=-1, keepdim=True), min=_EPS)
+    gram = paddle.matmul(head_vec, head_vec, transpose_y=True).abs()  # [nh, nh]
+    offdiag_sum = gram.sum() - paddle.diagonal(gram).sum()
+    stats["postmix_head_cos_mean"] = offdiag_sum / float(num_heads * (num_heads - 1))
+    return stats
+
+
+def premix_metric_names(weight: paddle.Tensor) -> tuple[str, ...]:
+    """Metric keys ``premix_stats`` will produce for this weight.
+
+    The schema depends on the weight shape, which is known at registration time,
+    so the monitor can still declare everything before allocating buffers.
+    """
+    groups = int(weight.shape[0]) if weight.ndim == 3 else 1
+    rows, cols = int(weight.shape[-2]), int(weight.shape[-1])
+    if rows != cols:
+        return ("premix_sigma_max", "premix_orth_dev")
+    names = ["premix_sigma_max", "premix_identity_dev"]
+    if groups > 1:
+        names.append("premix_group_div_ratio")
+    return tuple(names)
+
+
+def premix_stats(weight: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Structure of the trained Q Premix weight (``[H_kv, q_head_dim, head_dim]``).
+
+    Premix is **near-identity** by construction: PaddleFleet initialises it as
+    ``I + 0.1/√d · N(0, 1)`` per KV group when ``q_head_dim == head_dim``. So the
+    diagnostic is deviation from the identity, not from orthogonality.
+
+    ``premix_identity_dev`` — group-mean ``‖W_g − I‖_F``: how far each group's
+    query transform has moved from a no-op.
+
+    ``premix_group_div_ratio`` — ``mean_{g<g'} ‖W_g − W_g'‖²_F / mean_g ‖W_g − I‖²_F``.
+    This is the paper's own measurement of *group-conditioned query
+    specialization*: 0 means every group learned the same deviation (the virtual
+    heads inside different KV groups are not specialising), 2 is what fully
+    independent per-group deviations would give. The paper reports a value well
+    below 2 and far above 0 — groups learn substantially but not independently
+    different transforms. Both extremes are the warning signs.
+
+    ``premix_orth_dev`` — only for the non-square case (``q_head_dim ≠ head_dim``),
+    where PaddleFleet falls back to a scaled orthogonal init; then ``‖WᵀW − I‖_F``
+    is the meaningful drift.
+    """
+    w = weight.detach().astype("float32")
+    if w.ndim == 2:
+        w = w.unsqueeze(0)
+    groups, rows, cols = w.shape
+
+    gram = paddle.matmul(w, w, transpose_x=True)  # [G, cols, cols]
+    eigenvalues = paddle.linalg.eigvalsh(gram)
+    sigma_max = paddle.sqrt(paddle.clip(eigenvalues, min=0.0)).max()
+
+    if rows != cols:
+        identity = paddle.eye(cols, dtype=w.dtype).unsqueeze(0)
+        return {
+            "premix_sigma_max": sigma_max,
+            "premix_orth_dev": (gram - identity).norm(),
+        }
+
+    deviation = w - paddle.eye(rows, dtype=w.dtype).unsqueeze(0)  # [G, d, d]
+    deviation_sq = paddle.square(deviation).sum(axis=[-2, -1])  # [G]
+    stats = {
+        "premix_sigma_max": sigma_max,
+        "premix_identity_dev": paddle.sqrt(deviation_sq).mean(),
+    }
+    if groups > 1:
+        # Pairwise ‖W_g − W_g'‖² over the (tiny) group axis; G is H_kv, e.g. 2.
+        pair_sq = paddle.square(deviation.unsqueeze(0) - deviation.unsqueeze(1)).sum(axis=[-2, -1])
+        pair_mean = pair_sq.sum() / float(groups * (groups - 1))  # off-diagonal mean
+        stats["premix_group_div_ratio"] = pair_mean / paddle.clip(deviation_sq.mean(), min=_EPS)
+    return stats

--- a/src/internal_medicine/backends/paddlefleet/vha_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/vha_monitor.py
@@ -1,0 +1,300 @@
+"""
+VHA Health Monitor for PaddleFleet.
+
+VHA (Virtual Head Attention) halves the physical query heads and sets ``H_kv = 2``,
+then restores expressiveness with two strictly linear operations:
+
+- **Q Premix** — a near-identity transform applied *per KV group*, expanding the
+  halved physical query heads into ``H_v = H'_q × H_kv`` virtual heads to recover
+  attention diversity. Present only when ``use_vha_premix`` is set.
+- **Linear Postmix** — a low-rank identity-residual ``I + A Bᵗ`` (``r = H'_q``) on
+  the head axis of the attention output, fusing cross-group inter-head features.
+  PaddleFleet names the factors ``vha_postmix_U`` / ``vha_postmix_V``.
+
+Both fold away at inference (Premix into ``q_proj``, Postmix into ``o_proj``),
+leaving a plain GQA-2 model. These matrices therefore exist only during training,
+and training is the only time their structure can be observed at all.
+
+Neither is visible to the other monitors: ``qk_stats`` samples ``core_attention``
+inputs (Postmix happens after that call), and ``massive_act`` only sees the
+residual stream, where the Postmix effect arrives diluted by ``o_proj``.
+
+``V`` is zero-initialised, so Postmix starts as the exact identity. The headline
+metric is therefore ``postmix_delta_rel_*``: it starts at 0 and its trend says
+whether the mixer is learning anything and whether it stays bounded.
+
+Metrics produced (``{branch}`` is ``main`` or ``sparse`` — MQA stacks carry a
+separate postmix parameter set for the block-sparse branch)::
+
+    vha_health/layer_{i}/{branch}_postmix_uv_sigma_max
+    vha_health/layer_{i}/{branch}_postmix_uv_eff_rank
+    vha_health/layer_{i}/{branch}_postmix_offdiag_ratio
+    vha_health/layer_{i}/{branch}_postmix_u_fro
+    vha_health/layer_{i}/{branch}_postmix_v_fro
+    vha_health/layer_{i}/{branch}_postmix_delta_rel_mean
+    vha_health/layer_{i}/{branch}_postmix_delta_rel_max
+    vha_health/layer_{i}/{branch}_postmix_amax_gain_max
+    vha_health/layer_{i}/{branch}_head_out_norm_max
+    vha_health/layer_{i}/{branch}_head_out_norm_min
+    vha_health/layer_{i}/{branch}_head_out_norm_std
+    vha_health/layer_{i}/{branch}_postmix_head_cos_mean
+    vha_health/layer_{i}/premix_sigma_max          (only with use_vha_premix)
+    vha_health/layer_{i}/premix_identity_dev       (square premix)
+    vha_health/layer_{i}/premix_group_div_ratio    (square premix, H_kv > 1)
+    vha_health/layer_{i}/premix_orth_dev           (non-square premix)
+    vha_health/global_*
+
+On mixed stacks the attention kind is prepended to the metric name exactly like
+the other monitors, e.g. ``vha_health/layer_5/hca_main_postmix_delta_rel_max``.
+"""
+
+import logging
+
+import paddle
+import paddle.nn as nn
+
+from .base import PaddleProbe
+from .layer_discovery import get_attention_module, get_decoder_layers, iter_monitor_layers
+from .vha_metrics import (
+    head_output_stats,
+    postmix_delta_stats,
+    postmix_operator_stats,
+    premix_metric_names,
+    premix_stats,
+)
+
+logger = logging.getLogger(__name__)
+
+_BRANCHES = ("main", "sparse")
+
+_POSTMIX_METRICS = (
+    "postmix_uv_sigma_max",
+    "postmix_uv_eff_rank",
+    "postmix_offdiag_ratio",
+    "postmix_u_fro",
+    "postmix_v_fro",
+    "postmix_delta_rel_mean",
+    "postmix_delta_rel_max",
+    "postmix_amax_gain_max",
+    "head_out_norm_max",
+    "head_out_norm_min",
+    "head_out_norm_std",
+    "postmix_head_cos_mean",
+)
+
+# Premix keys depend on the weight shape (square vs not, H_kv > 1), so the exact
+# set comes from premix_metric_names() at registration time.
+_PREMIX_METRICS = (
+    "premix_sigma_max",
+    "premix_identity_dev",
+    "premix_group_div_ratio",
+    "premix_orth_dev",
+)
+
+# Extrema keep extremum semantics across microbatches / layers / ranks; the rest
+# are means. Every name below ends in `_max` / `_min`, so training_logs' suffix
+# classifier reaches the same verdict on the full key — including the attn_type
+# and branch prefixes it carries.
+_MAX_METRICS = frozenset(
+    {
+        "postmix_uv_sigma_max",
+        "postmix_delta_rel_max",
+        "postmix_amax_gain_max",
+        "head_out_norm_max",
+        "premix_sigma_max",
+    }
+)
+_MIN_METRICS = frozenset({"head_out_norm_min"})
+
+
+def _has_postmix(attn) -> bool:
+    return getattr(attn, "use_vha_postmix", False) and getattr(attn, "vha_postmix_U", None) is not None
+
+
+def _premix_weight(attn):
+    """Return the premix weight when premix is active, else ``None``."""
+    if not getattr(attn, "use_vha_premix", False):
+        return None
+    return getattr(attn, "vha_premix_weight", None)
+
+
+def _num_heads(factor: paddle.Tensor) -> int:
+    """Head count implied by a postmix factor (``[nh, r]`` or ``[g, j, r]``)."""
+    if factor.ndim == 2:
+        return int(factor.shape[0])
+    return int(factor.shape[0]) * int(factor.shape[1])
+
+
+class PaddleVHAHealthMonitor(PaddleProbe):
+    """Monitor the VHA premix / postmix structures of attention layers."""
+
+    METRIC_PREFIX = "vha_health"
+    MAX_AGGREGATED: set[str] = set()
+    MIN_AGGREGATED: set[str] = set()
+
+    def __init__(
+        self,
+        log_per_layer: bool = True,
+        log_global: bool = True,
+        monitor_interval: int = 1,
+        verbose: bool = False,
+        sample_layers: list[int] | None = None,
+    ):
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=monitor_interval,
+            verbose=verbose,
+        )
+        self.sample_layers = set(sample_layers) if sample_layers else None
+        # Branch-prefixed names, because record_layer_metric classifies on the
+        # name it is handed.
+        self.MAX_AGGREGATED = {f"{b}_{m}" for b in _BRANCHES for m in _MAX_METRICS if m in _POSTMIX_METRICS} | {
+            m for m in _MAX_METRICS if m in _PREMIX_METRICS
+        }
+        self.MIN_AGGREGATED = {f"{b}_{m}" for b in _BRANCHES for m in _MIN_METRICS}
+        # (module, original__apply_vha_postmix) pairs, for remove_hooks().
+        self._wrapped: list[tuple[nn.Layer, object]] = []
+        self._failed_layers: set[int] = set()
+
+    # ------------------------------------------------------------------
+    # Setup: discover -> declare -> allocate -> attach
+    # ------------------------------------------------------------------
+
+    def _init_parallel_state(self):
+        try:
+            from paddlefleet.parallel_state import get_pipeline_model_parallel_rank
+
+            self.pp_rank = get_pipeline_model_parallel_rank()
+        except Exception:
+            pass
+
+    def _find_targets(self, model):
+        layers = get_decoder_layers(model)
+        if not layers:
+            return []
+
+        def matches(layer):
+            attn = get_attention_module(layer)
+            return attn is not None and _has_postmix(attn)
+
+        monitor_layers = iter_monitor_layers(layers, matches, pp_rank=self.pp_rank)
+        mtp_layer_ids = [item.idx for item in monitor_layers if item.is_mtp]
+        if mtp_layer_ids:
+            self.mark_mtp_layers(mtp_layer_ids)
+
+        targets = []
+        for item in monitor_layers:
+            if self.sample_layers and item.idx not in self.sample_layers:
+                continue
+            attn = get_attention_module(item.layer)
+            branches = ["main"]
+            if getattr(attn, "sparse_vha_postmix_U", None) is not None:
+                branches.append("sparse")
+            targets.append((item.idx, attn, item.attn_type, branches))
+        return targets
+
+    def register_hooks(self, model: nn.Layer):
+        self._init_parallel_state()
+        targets = self._find_targets(model)
+        if not targets:
+            logger.info("[PaddleVHAMonitor] No VHA postmix layers found; skipping.")
+            return
+
+        for layer_idx, attn, attn_type, branches in targets:
+            for branch in branches:
+                for name in _POSTMIX_METRICS:
+                    self.declare_layer_metric(layer_idx, f"{branch}_{name}", attn_type=attn_type)
+            premix = _premix_weight(attn)
+            if premix is not None:
+                for name in premix_metric_names(premix):
+                    self.declare_layer_metric(layer_idx, name, attn_type=attn_type)
+
+        self.allocate_buffers()
+
+        for layer_idx, attn, attn_type, _branches in targets:
+            orig = attn._apply_vha_postmix
+            attn._apply_vha_postmix = self._make_capture(orig, attn, layer_idx, attn_type)
+            self._wrapped.append((attn, orig))
+
+        logger.info(f"[PaddleVHAMonitor] Wrapped {len(self._wrapped)} attention modules.")
+
+    def remove_hooks(self):
+        for attn, orig in self._wrapped:
+            try:
+                del attn._apply_vha_postmix
+            except AttributeError:
+                attn._apply_vha_postmix = orig
+        self._wrapped = []
+        super().remove_hooks()
+
+    # ------------------------------------------------------------------
+    # Capture wrapper (the hot path)
+    # ------------------------------------------------------------------
+
+    def _make_capture(self, orig, attn, layer_idx: int, attn_type: str | None):
+        """Wrap ``_apply_vha_postmix`` and derive metrics from its real I/O.
+
+        ``delta`` is ``out − attn_out``, so nothing is recomputed. Everything runs
+        detached under ``no_grad`` and writes 0-dim GPU tensors, so no D2H sync
+        and no autograd graph is pinned.
+
+        Selective recompute (``recompute_modules=[..., "vha_postmix"]``) can replay
+        this call during backward. The replay produces bit-identical tensors, so a
+        second record leaves mean (sum and count both double), max, and min
+        unchanged — no dedupe needed.
+        """
+
+        def wrapped(attn_out, *args, **kwargs):
+            out = orig(attn_out, *args, **kwargs)
+            if not self._should_monitor():
+                return out
+            try:
+                u = kwargs.get("U", args[0] if len(args) >= 1 else None)
+                v = kwargs.get("V", args[1] if len(args) >= 2 else None)
+                if u is None or v is None:
+                    branch = "main"
+                    u, v = attn.vha_postmix_U, attn.vha_postmix_V
+                else:
+                    branch = "sparse" if u is getattr(attn, "sparse_vha_postmix_U", None) else "main"
+
+                with paddle.no_grad():
+                    stats = postmix_operator_stats(u, v)
+                    stats.update(postmix_delta_stats(attn_out, out))
+                    stats.update(head_output_stats(out, _num_heads(u)))
+                    for name, value in stats.items():
+                        self.record_layer_metric(layer_idx, f"{branch}_{name}", value, attn_type=attn_type)
+
+                    premix = _premix_weight(attn)
+                    if premix is not None and branch == "main":
+                        for name, value in premix_stats(premix).items():
+                            self.record_layer_metric(layer_idx, name, value, attn_type=attn_type)
+            except Exception as e:
+                if self.verbose and layer_idx not in self._failed_layers:
+                    logger.error(f"[PaddleVHAMonitor] Error at layer {layer_idx}: {e}")
+                    self._failed_layers.add(layer_idx)
+            return out
+
+        return wrapped
+
+
+def setup_vha_monitor(
+    model,
+    log_per_layer: bool = True,
+    log_global: bool = True,
+    monitor_interval: int = 1,
+    verbose: bool = False,
+    sample_layers: list[int] | None = None,
+    monitor_dict: dict | None = None,
+):
+    monitor = PaddleVHAHealthMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+        sample_layers=sample_layers,
+    )
+    monitor.register_hooks(model)
+    if monitor_dict is not None:
+        monitor_dict["vha_health"] = monitor
+    return model

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 AVAILABLE_MONITORS = {
     "megatron": ["qk_stats", "moe_health", "ple_health", "massive_act", "mhc_health"],
-    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health"],
+    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health"],
 }
 
 

--- a/tests/test_vha_paddlefleet_monitor.py
+++ b/tests/test_vha_paddlefleet_monitor.py
@@ -1,0 +1,302 @@
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+importlib.import_module("_backend_env").skip_unless_backend("paddlefleet")
+
+try:
+    paddle = importlib.import_module("paddle")
+    nn = importlib.import_module("paddle.nn")
+except Exception as exc:  # pragma: no cover - depends on optional backend install
+    raise unittest.SkipTest(f"paddle backend unavailable: {exc}") from exc
+
+vha_metrics = importlib.import_module("internal_medicine.backends.paddlefleet.vha_metrics")
+vha_monitor = importlib.import_module("internal_medicine.backends.paddlefleet.vha_monitor")
+_training_logs_mod = importlib.import_module("internal_medicine.core.training_logs")
+training_logs = _training_logs_mod.training_logs
+TrainingLogs = _training_logs_mod.TrainingLogs
+
+PaddleVHAHealthMonitor = vha_monitor.PaddleVHAHealthMonitor
+
+
+def _factor(rows, rank_col_values):
+    """Build an ``[nh, 1]`` factor from a list of scalars."""
+    return paddle.to_tensor([[v] for v in rank_col_values], dtype="float32").reshape([rows, 1])
+
+
+class FakeVHAAttention(nn.Layer):
+    """Stand-in for a VHA attention module: same postmix math, same attributes."""
+
+    def __init__(self, num_heads, v_head_dim, u, v, sparse_u=None, sparse_v=None, premix=None):
+        super().__init__()
+        self.use_vha_postmix = True
+        self.num_heads = num_heads
+        self.v_head_dim = v_head_dim
+        self.vha_postmix_U = u
+        self.vha_postmix_V = v
+        self.sparse_vha_postmix_U = sparse_u
+        self.sparse_vha_postmix_V = sparse_v
+        self.use_vha_premix = premix is not None
+        self.vha_premix_weight = premix
+        self.calls = 0
+
+    def _apply_vha_postmix(self, attn_out, U=None, V=None):
+        if U is None:
+            U = self.vha_postmix_U
+        if V is None:
+            V = self.vha_postmix_V
+        self.calls += 1
+        b, sq = attn_out.shape[0], attn_out.shape[1]
+        mixed = attn_out.reshape([b, sq, self.num_heads, self.v_head_dim])
+        z = paddle.einsum("bthd,hr->btrd", mixed, U)
+        delta = paddle.einsum("btrd,hr->bthd", z, V)
+        return (mixed + delta).reshape([b, sq, self.num_heads * self.v_head_dim])
+
+
+class FakeLayer(nn.Layer):
+    def __init__(self, attn):
+        super().__init__()
+        self.self_attn = attn
+
+
+def _model(layers):
+    return SimpleNamespace(decoder=SimpleNamespace(layers=nn.LayerList(layers)))
+
+
+class VHAMetricsTest(unittest.TestCase):
+    def test_zero_v_is_identity_operator(self):
+        # V is zero-initialised in PaddleFleet, so postmix must start as exactly
+        # the identity: no spectral energy, no off-diagonal mixing.
+        u = _factor(4, [1.0, 0.5, -0.25, 0.0])
+        v = paddle.zeros([4, 1], dtype="float32")
+        stats = vha_metrics.postmix_operator_stats(u, v)
+        self.assertAlmostEqual(float(stats["postmix_uv_sigma_max"]), 0.0, places=6)
+        self.assertAlmostEqual(float(stats["postmix_offdiag_ratio"]), 0.0, places=6)
+        self.assertAlmostEqual(float(stats["postmix_v_fro"]), 0.0, places=6)
+
+    def test_rank_one_offdiagonal_operator(self):
+        # A = U Vᵀ has a single 1.0 at [0, 1]: sigma_max 1, eff_rank 1, and
+        # ‖A_offdiag‖_F / ‖I + A‖_F = 1 / sqrt(4 + 1).
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = _factor(4, [0.0, 1.0, 0.0, 0.0])
+        stats = vha_metrics.postmix_operator_stats(u, v)
+        self.assertAlmostEqual(float(stats["postmix_uv_sigma_max"]), 1.0, places=5)
+        self.assertAlmostEqual(float(stats["postmix_uv_eff_rank"]), 1.0, places=5)
+        self.assertAlmostEqual(float(stats["postmix_offdiag_ratio"]), 1.0 / 5.0**0.5, places=5)
+
+    def test_diagonal_operator_has_no_offdiagonal_energy(self):
+        # A per-head rescaling (diagonal A) must read as zero cross-head mixing.
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        stats = vha_metrics.postmix_operator_stats(u, v)
+        self.assertAlmostEqual(float(stats["postmix_offdiag_ratio"]), 0.0, places=6)
+        self.assertAlmostEqual(float(stats["postmix_uv_sigma_max"]), 1.0, places=5)
+
+    def test_grouped_factors_stay_block_diagonal(self):
+        # Grouped postmix mixes heads only inside a group; a group-local diagonal
+        # operator must not leak into cross-group off-diagonal energy.
+        u = paddle.to_tensor([[[1.0], [0.0]], [[1.0], [0.0]]], dtype="float32")  # [2, 2, 1]
+        stats = vha_metrics.postmix_operator_stats(u, u)
+        self.assertAlmostEqual(float(stats["postmix_offdiag_ratio"]), 0.0, places=6)
+
+    def test_delta_stats_identity_and_scaling(self):
+        attn_out = paddle.to_tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype="float32")
+        identity = vha_metrics.postmix_delta_stats(attn_out, attn_out)
+        self.assertAlmostEqual(float(identity["postmix_delta_rel_mean"]), 0.0, places=6)
+        self.assertAlmostEqual(float(identity["postmix_delta_rel_max"]), 0.0, places=6)
+        self.assertAlmostEqual(float(identity["postmix_amax_gain_max"]), 1.0, places=6)
+
+        doubled = vha_metrics.postmix_delta_stats(attn_out, attn_out * 2.0)
+        # delta == mixed, so the relative correction is exactly 1.
+        self.assertAlmostEqual(float(doubled["postmix_delta_rel_mean"]), 1.0, places=5)
+        self.assertAlmostEqual(float(doubled["postmix_amax_gain_max"]), 2.0, places=5)
+
+    def test_head_output_stats(self):
+        # Two heads of dim 2: norms 1 and 2, pointing the same direction.
+        out = paddle.to_tensor([[[1.0, 0.0, 2.0, 0.0]]], dtype="float32")
+        stats = vha_metrics.head_output_stats(out, num_heads=2)
+        self.assertAlmostEqual(float(stats["head_out_norm_max"]), 2.0, places=5)
+        self.assertAlmostEqual(float(stats["head_out_norm_min"]), 1.0, places=5)
+        self.assertAlmostEqual(float(stats["postmix_head_cos_mean"]), 1.0, places=5)
+
+    def test_premix_near_identity_weight_has_zero_deviation(self):
+        # PaddleFleet initialises premix as I + 0.1/√d · N(0,1) per KV group, so
+        # the diagnostic is deviation from identity, not from orthogonality.
+        w = paddle.eye(3, dtype="float32").unsqueeze(0)
+        stats = vha_metrics.premix_stats(w)
+        self.assertAlmostEqual(float(stats["premix_identity_dev"]), 0.0, places=5)
+        self.assertAlmostEqual(float(stats["premix_sigma_max"]), 1.0, places=5)
+        self.assertNotIn("premix_group_div_ratio", stats)  # single group
+
+    def test_premix_shared_group_deviation_gives_ratio_zero(self):
+        """Every KV group learned the same transform -> no group specialization."""
+        deviation = paddle.to_tensor([[0.0, 0.3, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype="float32")
+        w = (paddle.eye(3, dtype="float32") + deviation).unsqueeze(0).expand([2, 3, 3])
+        stats = vha_metrics.premix_stats(w)
+        self.assertAlmostEqual(float(stats["premix_group_div_ratio"]), 0.0, places=5)
+
+    def test_premix_independent_group_deviations_give_ratio_two(self):
+        """Disjoint per-group deviations -> the value expected under independence."""
+        eye = paddle.eye(3, dtype="float32")
+        d0 = paddle.zeros([3, 3], dtype="float32")
+        d0[0, 1] = 1.0
+        d1 = paddle.zeros([3, 3], dtype="float32")
+        d1[1, 0] = 1.0
+        w = paddle.stack([eye + d0, eye + d1])
+        stats = vha_metrics.premix_stats(w)
+        self.assertAlmostEqual(float(stats["premix_group_div_ratio"]), 2.0, places=5)
+
+    def test_premix_non_square_weight_reports_orthogonality(self):
+        """q_head_dim != head_dim keeps the scaled-orthogonal init, so track that."""
+        w = paddle.eye(4, dtype="float32")[:, :3].unsqueeze(0)  # [1, 4, 3]
+        stats = vha_metrics.premix_stats(w)
+        self.assertIn("premix_orth_dev", stats)
+        self.assertNotIn("premix_identity_dev", stats)
+        self.assertAlmostEqual(float(stats["premix_orth_dev"]), 0.0, places=5)
+
+    def test_premix_metric_names_match_produced_keys(self):
+        for w in (
+            paddle.eye(3, dtype="float32").unsqueeze(0),
+            paddle.eye(3, dtype="float32").unsqueeze(0).expand([2, 3, 3]),
+            paddle.eye(4, dtype="float32")[:, :3].unsqueeze(0),
+        ):
+            self.assertEqual(set(vha_metrics.premix_metric_names(w)), set(vha_metrics.premix_stats(w)))
+
+
+class VHAMonitorTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    @staticmethod
+    def _attn_out(num_heads=4, v_head_dim=2):
+        return paddle.ones([1, 3, num_heads * v_head_dim], dtype="float32")
+
+    def test_identity_postmix_records_zero_delta(self):
+        u = _factor(4, [1.0, 0.5, -0.25, 0.0])
+        v = paddle.zeros([4, 1], dtype="float32")
+        attn = FakeVHAAttention(4, 2, u, v)
+        monitor = PaddleVHAHealthMonitor(log_per_layer=True, log_global=True)
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+
+        attn._apply_vha_postmix(self._attn_out())
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="vha_health")
+        self.assertAlmostEqual(latest["vha_health/layer_0/main_postmix_delta_rel_max"], 0.0, places=6)
+        self.assertAlmostEqual(latest["vha_health/global_main_postmix_delta_rel_max"], 0.0, places=6)
+        self.assertAlmostEqual(latest["vha_health/layer_0/main_postmix_amax_gain_max"], 1.0, places=6)
+        monitor.remove_hooks()
+
+    def test_active_postmix_records_nonzero_delta(self):
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = _factor(4, [0.0, 1.0, 0.0, 0.0])
+        attn = FakeVHAAttention(4, 2, u, v)
+        monitor = PaddleVHAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+
+        attn._apply_vha_postmix(self._attn_out())
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="vha_health")
+        self.assertGreater(latest["vha_health/layer_0/main_postmix_delta_rel_max"], 0.0)
+        self.assertAlmostEqual(latest["vha_health/layer_0/main_postmix_uv_sigma_max"], 1.0, places=5)
+        monitor.remove_hooks()
+
+    def test_sparse_branch_keys_do_not_collide(self):
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = paddle.zeros([4, 1], dtype="float32")
+        sparse_u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        sparse_v = _factor(4, [0.0, 1.0, 0.0, 0.0])
+        attn = FakeVHAAttention(4, 2, u, v, sparse_u=sparse_u, sparse_v=sparse_v)
+        monitor = PaddleVHAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+
+        attn._apply_vha_postmix(self._attn_out())
+        attn._apply_vha_postmix(self._attn_out(), sparse_u, sparse_v)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="vha_health")
+        self.assertAlmostEqual(latest["vha_health/layer_0/main_postmix_uv_sigma_max"], 0.0, places=6)
+        self.assertAlmostEqual(latest["vha_health/layer_0/sparse_postmix_uv_sigma_max"], 1.0, places=5)
+        monitor.remove_hooks()
+
+    def test_repeated_call_leaves_aggregates_unchanged(self):
+        # Selective recompute replays _apply_vha_postmix with identical inputs;
+        # the extra record must not move mean/max/min.
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = _factor(4, [0.0, 1.0, 0.0, 0.0])
+        attn = FakeVHAAttention(4, 2, u, v)
+        monitor = PaddleVHAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+
+        attn._apply_vha_postmix(self._attn_out())
+        attn._apply_vha_postmix(self._attn_out())
+        monitor.step()
+        replayed = training_logs.get_latest(prefix="vha_health")
+
+        training_logs.reset()
+        monitor.remove_hooks()
+        attn2 = FakeVHAAttention(4, 2, u, v)
+        monitor2 = PaddleVHAHealthMonitor()
+        monitor2.register_hooks(_model([FakeLayer(attn2)]))
+        attn2._apply_vha_postmix(self._attn_out())
+        monitor2.step()
+        once = training_logs.get_latest(prefix="vha_health")
+        monitor2.remove_hooks()
+
+        self.assertEqual(set(replayed), set(once))
+        for key in once:
+            self.assertAlmostEqual(replayed[key], once[key], places=5, msg=key)
+
+    def test_remove_hooks_restores_original_method(self):
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = paddle.zeros([4, 1], dtype="float32")
+        attn = FakeVHAAttention(4, 2, u, v)
+        monitor = PaddleVHAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        monitor.remove_hooks()
+
+        attn._apply_vha_postmix(self._attn_out())
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="vha_health"), {})
+
+    def test_no_vha_layers_is_a_noop(self):
+        plain = FakeLayer(nn.Linear(4, 4))
+        monitor = PaddleVHAHealthMonitor()
+        monitor.register_hooks(_model([plain]))
+        self.assertEqual(monitor._wrapped, [])
+
+    def test_extremum_keys_are_classified_as_extrema(self):
+        # Guards the naming contract: training_logs must reach the same verdict
+        # as the monitor for every key, prefixes included.
+        for key in (
+            "vha_health/layer_0/hca_main_postmix_delta_rel_max",
+            "vha_health/layer_0/hca_sparse_postmix_uv_sigma_max",
+            "vha_health/global_hca_main_head_out_norm_max",
+            "vha_health/layer_0/premix_sigma_max",
+        ):
+            self.assertTrue(TrainingLogs._is_max_metric(key), key)
+        for key in (
+            "vha_health/layer_0/hca_main_head_out_norm_min",
+            "vha_health/global_hca_main_head_out_norm_min",
+        ):
+            self.assertTrue(TrainingLogs._is_min_metric(key), key)
+        for key in (
+            "vha_health/layer_0/hca_main_postmix_delta_rel_mean",
+            "vha_health/layer_0/hca_main_postmix_offdiag_ratio",
+            "vha_health/layer_0/hca_main_head_out_norm_std",
+        ):
+            self.assertFalse(TrainingLogs._is_max_metric(key), key)
+            self.assertFalse(TrainingLogs._is_min_metric(key), key)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

VHA（Virtual Head Attention）把物理 query head 减半、`H_kv = 2`，再用两个**严格线性**算子补回表达力：

- **Q Premix**：每个 KV group 内对 query 做近恒等线性变换，把减半的物理 head 扩成 `H_v = H'_q × H_kv` 个虚拟头
- **Linear Postmix**：注意力输出在 head 轴上的低秩恒等残差 `M = I + U Vᵀ`（`r = H'_q`），融合跨组 inter-head 特征

推理时 Premix 折进 `q_proj`、Postmix 折进 `o_proj`，模型退化为标准 GQA-2。**这两个矩阵只在训练期存在**，是唯一的观测窗口。

## 改动

新增 `vha_health` monitor（paddlefleet 后端）：

- `backends/paddlefleet/vha_metrics.py` — 纯计算，无状态
- `backends/paddlefleet/vha_monitor.py` — 发现 / 声明 / 包装 / 记录
- `core/registry.py`、`backends/paddlefleet/__init__.py` — 注册 `vha_health`
- `tests/test_vha_paddlefleet_monitor.py` — 18 个用例
- `README.md` — 新增 VHA 章节（指标表 + 健康判读）

### 采集点

包装 `attn._apply_vha_postmix`，而不是挂 forward hook：该函数的入参就是 postmix 前的 `attn_out`、返回值就是 postmix 后的 `out`，`delta = out − attn_out` 无需重算，也能拿到当次真实使用的 `U`/`V`。全部在 `paddle.no_grad()` 下对 `detach()` 后的张量计算，不污染训练图。

### 指标（12 postmix + 4 premix）

**Postmix 算子结构**（权重侧）
`postmix_uv_sigma_max`、`postmix_uv_eff_rank`、`postmix_offdiag_ratio`、`postmix_u_fro`、`postmix_v_fro`
奇异值走 `eigvalsh(AᵀA)` 而非 SVD——对称、可批、无收敛问题，且因子只有 `[nh, r]`，开销可忽略。

**Postmix 实际效果**（激活侧，逐 token）
`postmix_delta_rel_mean`（**首要指标**）、`postmix_delta_rel_max`、`postmix_amax_gain_max`

**Head 空间健康**
`head_out_norm_max/min/std`、`postmix_head_cos_mean`

**Premix**（按论文口径，指标集由权重形状在注册时决定）
`premix_identity_dev`（方阵）、`premix_group_div_ratio`（方阵且 `H_kv > 1`）、`premix_sigma_max`、`premix_orth_dev`（非方阵）

## 约束

- Postmix 要求 **TP=1**（PaddleFleet 侧 `multi_latent_attention.py` 直接 raise）
- 无 VHA 的模型上是硬 no-op：找不到 postmix 层就不注册任何指标、不挂任何包装

## 测试

`python -m pytest tests/ -q --ignore=tests/test_megatron_monitors.py --ignore=tests/test_mhc_monitor.py`
→ **92 passed**（master 基线 74 + VHA 18）