### PR TITLE
fix(vha_health): postmix delta 以返回值宽度归一化两侧布局

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/vha_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/vha_metrics.py
@@ -100,9 +100,17 @@ def postmix_operator_stats(U: paddle.Tensor, V: paddle.Tensor) -> dict[str, padd
 def postmix_delta_stats(attn_out: paddle.Tensor, out: paddle.Tensor) -> dict[str, paddle.Tensor]:
     """Per-token effect of the postmix correction on the attention output.
 
-    Both tensors are the flat head-space layout ``[..., nh * v_head_dim]``:
     ``attn_out`` is the input of ``_apply_vha_postmix`` and ``out`` its return
     value, so ``delta = out − attn_out`` needs no recomputation.
+
+    The **return** value is always the flat head-space layout
+    ``[..., nh * v_head_dim]`` (every backend ends with that reshape), but the
+    **input** is not: the DSv4 hybrid attention leaves ``core_attn_out`` in the
+    unflattened ``[b, sq, nh, v_head_dim]`` layout on the fused inverse-RoPE
+    path (``apply_rope_fusion`` without ``high_precision_rope``). So the flat
+    width is taken from ``out`` and both sides are folded to
+    ``[tokens, nh * v_head_dim]`` — using each tensor's own last dim would put
+    heads on the token axis for one side and break the subtraction.
 
     Returns:
         ``postmix_delta_rel_mean`` / ``postmix_delta_rel_max`` — per-token
@@ -112,10 +120,10 @@ def postmix_delta_stats(attn_out: paddle.Tensor, out: paddle.Tensor) -> dict[str
         low-precision overflow headroom of the correction (same reading as the
         mHC ``amax_gain`` family).
     """
-    mixed = attn_out.detach().astype("float32")
-    mixed = mixed.reshape([-1, mixed.shape[-1]])
     result = out.detach().astype("float32")
-    result = result.reshape([-1, result.shape[-1]])
+    width = result.shape[-1]
+    result = result.reshape([-1, width])
+    mixed = attn_out.detach().astype("float32").reshape([-1, width])
     delta = result - mixed
 
     mixed_norm = paddle.clip(mixed.norm(axis=-1), min=_EPS)

--- a/tests/test_vha_paddlefleet_monitor.py
+++ b/tests/test_vha_paddlefleet_monitor.py
@@ -58,6 +58,19 @@ class FakeVHAAttention(nn.Layer):
         return (mixed + delta).reshape([b, sq, self.num_heads * self.v_head_dim])
 
 
+class FakeVHAAttentionHeadSpaceInput(FakeVHAAttention):
+    """DSv4 hybrid on the fused inverse-RoPE path: 4D input, flat 3D output.
+
+    ``dsv4_hybrid_attention._full_attn_forward`` reshapes ``core_attn_out`` to
+    ``[b, sq, nh, v_head_dim]`` for the inverse RoPE and only the *unfused*
+    branch reshapes it back, so with ``apply_rope_fusion=True`` the postmix call
+    receives the unflattened layout while still returning the flat one.
+    """
+
+    def _apply_vha_postmix(self, attn_out, U=None, V=None):
+        return super()._apply_vha_postmix(attn_out.reshape([attn_out.shape[0], attn_out.shape[1], -1]), U, V)
+
+
 class FakeLayer(nn.Layer):
     def __init__(self, attn):
         super().__init__()
@@ -115,6 +128,18 @@ class VHAMetricsTest(unittest.TestCase):
         # delta == mixed, so the relative correction is exactly 1.
         self.assertAlmostEqual(float(doubled["postmix_delta_rel_mean"]), 1.0, places=5)
         self.assertAlmostEqual(float(doubled["postmix_amax_gain_max"]), 2.0, places=5)
+
+    def test_delta_stats_accepts_head_space_input(self):
+        # DSv4 hybrid's fused inverse-RoPE path hands postmix a 4D
+        # [b, sq, nh, v_head_dim] input while the return stays flat 3D. Both
+        # sides must fold to the flat width, otherwise the subtraction sees
+        # [sq, nh*d] against [sq*nh, d] and raises a broadcast error.
+        flat = paddle.to_tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype="float32")
+        head_space = flat.reshape([1, 1, 2, 2])
+        stats = vha_metrics.postmix_delta_stats(head_space, flat * 2.0)
+        reference = vha_metrics.postmix_delta_stats(flat, flat * 2.0)
+        for key in reference:
+            self.assertAlmostEqual(float(stats[key]), float(reference[key]), places=6, msg=key)
 
     def test_head_output_stats(self):
         # Two heads of dim 2: norms 1 and 2, pointing the same direction.
@@ -209,6 +234,35 @@ class VHAMonitorTest(unittest.TestCase):
         self.assertGreater(latest["vha_health/layer_0/main_postmix_delta_rel_max"], 0.0)
         self.assertAlmostEqual(latest["vha_health/layer_0/main_postmix_uv_sigma_max"], 1.0, places=5)
         monitor.remove_hooks()
+
+    def test_head_space_input_still_records(self):
+        # Regression: on DSv4 hybrid + apply_rope_fusion the postmix input stays
+        # 4D, which used to make every layer throw inside the wrapper and record
+        # nothing at all.
+        u = _factor(4, [1.0, 0.0, 0.0, 0.0])
+        v = _factor(4, [0.0, 1.0, 0.0, 0.0])
+        attn = FakeVHAAttentionHeadSpaceInput(4, 2, u, v)
+        monitor = PaddleVHAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+
+        attn._apply_vha_postmix(self._attn_out().reshape([1, 3, 4, 2]))
+        monitor.step()
+        head_space = training_logs.get_latest(prefix="vha_health")
+        monitor.remove_hooks()
+
+        training_logs.reset()
+        flat_attn = FakeVHAAttention(4, 2, u, v)
+        flat_monitor = PaddleVHAHealthMonitor()
+        flat_monitor.register_hooks(_model([FakeLayer(flat_attn)]))
+        flat_attn._apply_vha_postmix(self._attn_out())
+        flat_monitor.step()
+        flat = training_logs.get_latest(prefix="vha_health")
+        flat_monitor.remove_hooks()
+
+        self.assertEqual(set(head_space), set(flat))
+        self.assertGreater(head_space["vha_health/layer_0/main_postmix_delta_rel_max"], 0.0)
+        for key in flat:
+            self.assertAlmostEqual(head_space[key], flat[key], places=5, msg=key)
 
     def test_sparse_branch_keys_do_not_collide(self):
         u = _factor(4, [1.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION

非致命（wrapper 的 try/except 兜住了，训练与 checkpoint 正常），但该监控在这类模型上等于完全失效。

## 根因

不是监控假设了"规整 3D 布局"，而是模型侧同一个函数的**入参与返回布局不一致**：

`dsv4_hybrid_attention.py::_full_attn_forward` 为了做 inverse RoPE，先把 `core_attn_out`
reshape 成 4D `[b, sq, nh, v_head_dim]`；随后

- unfused 分支：`paddle.concat(...).reshape([b, sq, -1])` → 恢复成 3D
- **fused 分支**（`apply_rope_fusion=True` 且 `high_precision_rope=False`，走
  `fused_apply_mla_rope_inplace`）→ **保持 4D**

而 `_apply_vha_postmix` 的返回值恒为扁平的 `[b, sq, nh*v_head_dim]`。模型自身不受影响
（入口 reshape 对 4D 是 no-op，下游还会再 reshape），但 `postmix_delta_stats` 原先按各自的
最后一维展平：

- `out`（3D，last=32768）→ `[8192, 32768]`
- `attn_out`（4D，last=512）→ `[524288, 512]`，524288 = 8192 tokens × 64 heads

元素总数相同、首维不等且不可广播，`result - mixed` 直接抛错。报错落在 backward 是因为该调用
被 `recompute(self._apply_vha_postmix, ...)` 包裹，反向重放时 wrapper 又跑了一遍。

触发条件（本 CE 配置全部命中）：`experimental_attention_variant=dsv4_hybrid` +
`qk_pos_emb_head_dim>0` + `apply_rope_fusion=true` + `vha_health` 启用（默认值即包含）。

## 改动

`postmix_delta_stats` 改为以**返回值的扁平宽度**为基准归一化两侧。out 在三个后端实现（attention.py、dsv4_hybrid_attention.py、 multi_latent_attention.py）都固定是 [b, sq, nh*v_head_dim]，所以这个基准对 3D / 4D 输入都成立。