### PR TITLE
chore: 补齐 ruff format 与 ruff --fix 的遗留改动

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -228,9 +228,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     analysis_input = aggregated
             except Exception as e:
                 if self.verbose and layer_idx not in self._hc_aggregate_failed_layers:
-                    logger.warning(
-                        f"[MassiveActMonitor] hyper_connection aggregate failed at layer {layer_idx}: {e}"
-                    )
+                    logger.warning(f"[MassiveActMonitor] hyper_connection aggregate failed at layer {layer_idx}: {e}")
                     self._hc_aggregate_failed_layers.add(layer_idx)
 
         per_channel_max = compute_per_channel_max(analysis_input)

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -478,6 +478,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
     METRIC_PREFIX = "qk_stats"
     MAX_AGGREGATED = {"max", "entropy_max", "sink_head_max"}
     MIN_AGGREGATED = {"entropy_min"}
+
     def __init__(
         self,
         causal=True,
@@ -547,8 +548,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
 
         if self.verbose:
             logger.info(
-                f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. "
-                f"TP={self.tp_size} CP={self.cp_size}"
+                f"[PaddleQKMonitor] Found {len(attention_layers)} attention layers. TP={self.tp_size} CP={self.cp_size}"
             )
 
         if self.cp_size > 1:
@@ -575,9 +575,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 "sink_nonsink_gap",
             ):
                 self.declare_layer_metric(layer_idx, m, attn_type=item.attn_type)
-            if self._is_sparse_layer(item):
-                self.declare_layer_metric(layer_idx, "attn_sink_logit", attn_type=item.attn_type)
-            elif self._learnable_sink(_attn_module) is not None:
+            if self._is_sparse_layer(item) or self._learnable_sink(_attn_module) is not None:
                 self.declare_layer_metric(layer_idx, "attn_sink_logit", attn_type=item.attn_type)
 
         self.allocate_buffers()
@@ -670,17 +668,13 @@ class PaddleQKStatsMonitor(PaddleProbe):
         def wrapped(query, kv_full, attn_sink, topk_idxs, softmax_scale, topk_length=None):
             out = original(query, kv_full, attn_sink, topk_idxs, softmax_scale, topk_length=topk_length)
             if core.training and monitor._should_monitor():
-                monitor._record_sparse_stats(
-                    layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale
-                )
+                monitor._record_sparse_stats(layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale)
             return out
 
         core.compressed_sparse_attn = wrapped
         return _MethodPatch(core, "compressed_sparse_attn", original)
 
-    def _record_sparse_stats(
-        self, layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale
-    ) -> None:
+    def _record_sparse_stats(self, layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale) -> None:
         try:
             with paddle.no_grad():
                 stats = compute_qk_stats_sparse_paddle(

--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -607,18 +607,10 @@ def qk_stats_sparse_partial_kernel(
 
     bound_ptr = win_lo_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq
     win_lo = tl.load(bound_ptr, mask=m_mask, other=0)
-    win_hi = tl.load(
-        win_hi_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1
-    )
-    cmp_lo = tl.load(
-        cmp_lo_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=0
-    )
-    cmp_hi = tl.load(
-        cmp_hi_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1
-    )
-    sink_col = tl.load(
-        sink_col_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1
-    )
+    win_hi = tl.load(win_hi_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1)
+    cmp_lo = tl.load(cmp_lo_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=0)
+    cmp_hi = tl.load(cmp_hi_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1)
+    sink_col = tl.load(sink_col_ptr + batch_idx * stride_b_batch + m_offsets * stride_b_seq, mask=m_mask, other=-1)
 
     m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - 1e10
     d_i = tl.zeros([BLOCK_M], dtype=tl.float32)

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -554,8 +554,6 @@ class BiasAffinityJaccardTest(unittest.TestCase):
         self.assertAlmostEqual(float(jaccard), 1.0, places=6)
 
 
-
-
 class PaddleMassiveActivationMonitorTest(unittest.TestCase):
     def setUp(self):
         training_logs.reset()
@@ -763,12 +761,8 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
         q_a = q[:, :half, :, :]
         q_b = q[:, half:, :, :]
 
-        sub_a = self.qk.compute_qk_stats_paddle(
-            q_a, k, causal=True, row_stride=1, q_row_offset=0
-        )
-        sub_b = self.qk.compute_qk_stats_paddle(
-            q_b, k, causal=True, row_stride=1, q_row_offset=half
-        )
+        sub_a = self.qk.compute_qk_stats_paddle(q_a, k, causal=True, row_stride=1, q_row_offset=0)
+        sub_b = self.qk.compute_qk_stats_paddle(q_b, k, causal=True, row_stride=1, q_row_offset=half)
 
         # Per-head means: average the two halves (rows split evenly).
         for key in ("entropy_per_head", "sink_per_head", "mean_per_head"):
@@ -805,9 +799,7 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
         """Passing q_row_offset=0 must be a no-op vs. the default path."""
         q, k = self._gqa_inputs(seed=4)
         default_pass = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1)
-        with_zero_offset = self.qk.compute_qk_stats_paddle(
-            q, k, causal=True, row_stride=1, q_row_offset=0
-        )
+        with_zero_offset = self.qk.compute_qk_stats_paddle(q, k, causal=True, row_stride=1, q_row_offset=0)
         for key in ("max_global", "mean_global", "entropy_global", "sink_global"):
             self.assertTrue(
                 paddle.allclose(default_pass[key], with_zero_offset[key], atol=1e-6).item(),
@@ -908,7 +900,7 @@ class DenseSinkFoldTest(unittest.TestCase):
         self.assertTrue(paddle.allclose(stats["sink_per_head"], ref_sink, atol=1e-3, rtol=1e-3).item())
 
     def test_zero_sink_still_changes_the_distribution(self):
-        """"off-by-one" softmax: a frozen 0 logit still adds exp(0) to the denominator."""
+        """ "off-by-one" softmax: a frozen 0 logit still adds exp(0) to the denominator."""
         q, k = self._inputs()
         zeros = paddle.zeros([q.shape[2]], dtype="float32")
 
@@ -1130,17 +1122,13 @@ class SparseQKKernelComputeTest(unittest.TestCase):
     def test_sparse_stats_match_masked_reference(self):
         query, kv_full, topk = self._hca_case()
         scale = float(query.shape[-1]) ** -0.5
-        stats = self.qk.compute_qk_stats_sparse_paddle(
-            query, kv_full, topk, scale, attn_sink=None, row_stride=1
-        )
+        stats = self.qk.compute_qk_stats_sparse_paddle(query, kv_full, topk, scale, attn_sink=None, row_stride=1)
         ref = self._reference_stats(query, kv_full, topk, scale, None)
         self.assertTrue(
             paddle.allclose(stats["entropy_per_head"], ref["entropy_per_head"], atol=1e-3, rtol=1e-3).item(),
             f"entropy mismatch: {stats['entropy_per_head']} vs {ref['entropy_per_head']}",
         )
-        self.assertTrue(
-            paddle.allclose(stats["max_per_head"], ref["max_per_head"], atol=1e-3, rtol=1e-3).item()
-        )
+        self.assertTrue(paddle.allclose(stats["max_per_head"], ref["max_per_head"], atol=1e-3, rtol=1e-3).item())
 
     def test_attn_sink_lowers_entropy_and_is_folded_into_denominator(self):
         query, kv_full, topk = self._hca_case(seed=11)
@@ -1148,12 +1136,8 @@ class SparseQKKernelComputeTest(unittest.TestCase):
         heads = query.shape[2]
         sink = paddle.full([heads], 5.0, dtype="float32")  # dominant sink logit
 
-        no_sink = self.qk.compute_qk_stats_sparse_paddle(
-            query, kv_full, topk, scale, attn_sink=None, row_stride=1
-        )
-        with_sink = self.qk.compute_qk_stats_sparse_paddle(
-            query, kv_full, topk, scale, attn_sink=sink, row_stride=1
-        )
+        no_sink = self.qk.compute_qk_stats_sparse_paddle(query, kv_full, topk, scale, attn_sink=None, row_stride=1)
+        with_sink = self.qk.compute_qk_stats_sparse_paddle(query, kv_full, topk, scale, attn_sink=sink, row_stride=1)
         ref = self._reference_stats(query, kv_full, topk, scale, sink)
 
         self.assertTrue(
@@ -1166,9 +1150,7 @@ class SparseQKKernelComputeTest(unittest.TestCase):
             float(no_sink["entropy_global"]),
         )
         # The sink is not a real key, so logit max/mean must be unchanged.
-        self.assertTrue(
-            paddle.allclose(with_sink["max_per_head"], no_sink["max_per_head"], atol=1e-6).item()
-        )
+        self.assertTrue(paddle.allclose(with_sink["max_per_head"], no_sink["max_per_head"], atol=1e-6).item())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
纯机械改动，无语义变化：
- ruff-format 合并被手工折行的长语句 / 补类属性后的空行
- ruff --fix 的 SIM114：qk_monitor 里 _is_sparse_layer 与 _learnable_sink 两个 分支体完全相同，合并为 `or`（等价）