### PR TITLE
feat(mhc_health): 新增 4 个结构指标，branch/residual 改为有界占比

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,24 +347,51 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 
 > 详细文档: [mhc_health.md](./docs/mhc_health.md)
 
-监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`。
+监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
+以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。
 只在模型开启 mHC 层时生效——mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
-彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 8 个指标，
-指标名以 `attn_` / `mlp_` 前缀区分；全部按 token/batch 求均值。
+彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 12 个指标，
+指标名以 `attn_` / `mlp_` 前缀区分；除 `branch_residual_share_max` 取极值外，其余按 token/batch 求均值。
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
 |---|------|--------|------|------|----------|
 | 1 | `{c}_h_pre_mean` | `mhc_health/layer_{i}/{c}_h_pre_mean` | `mean(h_pre)` | 每层+全局 | 聚合门均值 |
 | 2 | `{c}_h_pre_std` | `mhc_health/layer_{i}/{c}_h_pre_std` | `std(h_pre)` | 每层+全局 | 聚合门离散度 |
 | 3 | `{c}_h_post_mean` | `mhc_health/layer_{i}/{c}_h_post_mean` | `mean(h_post)` | 每层+全局 | 扩展门均值 |
-| 4 | `{c}_h_post_std` | `mhc_health/layer_{i}/{c}_h_post_std` | `std(h_post)` | 每层+全局 | 扩展门离散度 |
-| 5 | `{c}_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ij\|)` | 每层+全局 | 单层前向最坏放大 (≈1) |
-| 6 | `{c}_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_amax_gain_bwd` | `mean_t(max_j \|Σ_i h_res_ij\|)` | 每层+全局 | 单层反向最坏放大 (≈1) |
-| 7 | `{c}_composite_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd` | 复合映射 `∏ h_res` 的行和 | 每层+全局 | 跨层累积前向放大 |
-| 8 | `{c}_composite_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd` | 复合映射 `∏ h_res` 的列和 | 每层+全局 | 跨层累积反向放大 |
+| 4 | `{c}_h_post_std` | `mhc_health/layer_{i}/{c}_h_post_std` | `std(h_post)` | 每层+全局 | 扩展门离散度（token 与 stream 混合） |
+| 5 | `{c}_h_post_stream_concentration` | `mhc_health/layer_{i}/{c}_h_post_stream_concentration` | `mean_t(max_i h_post / mean_i h_post)` | 每层+全局 | stream 集中度，值域 `[1, n]`：1 = 均匀，n = 全压在一条流上 |
+| 6 | `{c}_h_post_token_std` | `mhc_health/layer_{i}/{c}_h_post_token_std` | `std_t(mean_i h_post)` | 每层+全局 | 门控对输入的区分度，→0 = 退化成常数 |
+| 7 | `{c}_branch_residual_share` | `mhc_health/layer_{i}/{c}_branch_residual_share` | `mean_t(b / (b + r))`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F` | 每层+全局 | **本层是否还在写入残差流**，值域 `[0, 1]`：0.5 = 两项等量 |
+| 8 | `{c}_branch_residual_share_max` | `mhc_health/layer_{i}/{c}_branch_residual_share_max` | 同上取最坏 token | 每层+全局 | 单 token 被分支主导的程度（贴 1 = 存在近零残差 token） |
+| 9 | `{c}_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ij\|)` | 每层+全局 | 单层前向最坏放大 (≈1) |
+| 10 | `{c}_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_amax_gain_bwd` | `mean_t(max_j \|Σ_i h_res_ij\|)` | 每层+全局 | 单层反向最坏放大 (≈1) |
+| 11 | `{c}_composite_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd` | 复合映射 `∏ h_res` 的行和 | 每层+全局 | 跨层累积前向放大 |
+| 12 | `{c}_composite_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd` | 复合映射 `∏ h_res` 的列和 | 每层+全局 | 跨层累积反向放大 |
 
 `{c}` ∈ `{attn, mlp}`。复合映射为本 pipeline stage / VPP chunk 内 `h_res` 的累乘（每次 forward 在本 stage 首个
 hc 模块处重置）——PP=1 时精确，PP>1 时为 stage 局部近似。
+
+指标 1~6 与 9~12 来自包裹 `compute_mappings`（`h_pre` 不在 `forward` 返回值里，只能从这里拿到真实映射）；
+指标 7~8 需要 sublayer 输出，只有两项合并处才同时可见，故额外包裹 `fused_h_res_h_post_bda`，且指标从**入参**
+推导，因此 fused 快路径与带 dropout 的顺序路径口径一致。两个范数都是精确值但不 materialize 任何
+`[tokens, n, C]` 中间张量：branch 项是外积，`‖h_post_t ⊗ x_t‖_F = ‖h_post_t‖₂·‖x_t‖₂`；residual 项用
+`‖mixed_t‖²_F = Σ_{j,k} S[t,j,k]·G[t,j,k]`（`S` 为 `h_res` 的自相关、`G` 为 n 条流的 Gram），两者都是
+`[tokens, n, n]`。branch 项在 dropout **之前**测量（本仓库预训练配置 `hidden_dropout_prob = 0`）。
+
+### 健康判读
+
+- `h_post_mean` 趋 0 → 该层 sublayer 输出被门控压掉。注意 `h_post = 2σ(·)` 恒为正，**不存在正负相消**，
+  所以均值小就等于幅度小；但需配合 7 才能确认「贡献」是否真的消失（`F(·)` 的幅度可能同步增大补偿）。
+- `branch_residual_share` 无绝对阈值，看**深度剖面**与趋势。值域 `[0, 1]`：0.5 = 分支与残差等量，趋 0 = 该层退化为
+  纯残差搬运。判读看 `_max` 与均值的差距、以及`_max` 是否长期贴 1。
+- 二者组合定位失效模式：
+  - `h_post_mean`→0、`stream_concentration`≈1、`share` 同步塌 → **整体关闭**。此时 sigmoid 已进饱和区
+    （`h_post = 0.004` 对应 logit ≈ −6.2，`σ′ ≈ 0.002`），靠自身难以恢复，应查门控参数的 lr / weight decay
+    与 `mhc_init_gating_factor`。
+  - `stream_concentration`≈n → **退化为单流**，该层放弃了多流结构，`num_residual_streams` 的开销在这些层上没有
+    收益；可考虑逐层配置 n。注意这未必是病：HC 允许不同层使用不同的流组合，需结合「是否总是同一条流」判断。
+- `h_post_token_std`→0 → 门控丢失对 token 的区分度，从动态门退化成常数标量。
+- `amax_gain_fwd/bwd` 偏离 1.0 → Sinkhorn 未收敛或初始化异常；复合映射沿深度偏离 1.0 → 残差流放大/收缩。
 
 ---
 

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -62,7 +62,8 @@ internal_medicine_monitors:
 
 ## 监控指标
 
-每个 hc 模块产出 8 个指标，指标名以 `attn_` / `mlp_` 前缀区分，全部按 token/batch 求均值
+每个 hc 模块产出 12 个指标（megatron 后端 8 个，「结构指标」一节的 4 个为 paddlefleet 独有），指标名以
+`attn_` / `mlp_` 前缀区分，除 `branch_residual_share_max` 取极值外全部按 token/batch 求均值
 （并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，`{c}` ∈ `{attn, mlp}`；
 对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
 
@@ -74,6 +75,23 @@ internal_medicine_monitors:
 | `{c}_h_pre_std`   | `std(h_pre)`   | 聚合门离散度 |
 | `{c}_h_post_mean` | `mean(h_post)` | 扩展门均值 |
 | `{c}_h_post_std`  | `std(h_post)`  | 扩展门离散度 |
+
+### 结构指标（paddlefleet 独有）
+
+`h_post_mean` / `h_post_std` 把 token 轴和 stream 轴一起池化，因此「n 个流一起变弱」与「n-1 个流死掉、
+剩一个扛全部」在均值上不可分；`branch_residual_share` 则回答 `h_post_mean` 回答不了的问题：门变小可能被
+`F(·)` 变大抵消，只有两项的相对大小能说明该层是否还在写入。
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_h_post_stream_concentration` | `mean_t( max_i h_post[t,i] / mean_i h_post[t,i] )` | 流间集中度，区间 `[1, n]`。1 = 各流等权；趋 `n` = 质量压到单流，该层退化成普通单流残差，`num_residual_streams` 预算未被使用 |
+| `{c}_h_post_token_std` | `std_t( mean_i h_post[t,i] )` | 门对输入的敏感度（`h = r · proj · α + bias`）。→0 = 门不再区分 token，等价于常数标量 |
+| `{c}_branch_residual_share` | `mean_t( b / (b + r) )`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F` | 本层写入量在「写入 + 残差重混」中的占比，区间 `[0, 1]`。0.5 = 两项等量；趋 0 = 该层退化为纯残差搬运。|
+| `{c}_branch_residual_share_max` | `max_t( b / (b + r) )` | 最坏 token 的写入占比；贴 1 表示存在残差近零的 token。唯一按极值跨 microbatch/层/rank 归约的指标 |
+
+两个范数都是精确值，但不物化 `[tokens, n, C]` 中间量：分支项是外积（`‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂·‖xb_t‖₂`），
+残差项用 `[tokens, n, n]` 的 Gram/mix 收缩得到，`n = 4` 时开销约为本层投影的 `C/n²` 分之一。
+分支项在 dropout **之前**测量，`hidden_dropout_prob > 0` 的配置会略微高估分支幅度（此处预训练配置为 0）。
 
 ### amax-gain（h_res 与复合映射）
 

--- a/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
@@ -24,6 +24,8 @@ All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
 
 import paddle
 
+_EPS = 1e-12
+
 
 def amax_gain(mat: paddle.Tensor, axis: int) -> paddle.Tensor:
     """Per-token max-abs {row|col} sum of a batched ``[..., n, n]`` matrix, meaned over tokens.
@@ -46,3 +48,122 @@ def gate_stats(h: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:
     Returns two 0-dim tensors ``(mean, std)``; no host sync.
     """
     return h.mean(), h.std()
+
+
+def h_post_structure_stats(h_post: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Structure of the expansion gate across streams and across tokens.
+
+    ``h_post_mean`` / ``h_post_std`` pool the token axis and the stream axis
+    together, so a shrinking mean cannot tell "all n streams went quiet" apart
+    from "n-1 streams died and one still carries everything". These two split
+    the axes:
+
+    ``h_post_stream_concentration`` — ``mean_t(max_i h_post[t,i] / mean_i h_post[t,i])``.
+    Computed per token *before* averaging, so it is bounded by ``[1, n]``
+    regardless of token-level scale: 1 = all streams weighted equally,
+    ``n`` = all the mass on a single stream (the layer degenerated to a plain
+    single-stream residual and the ``num_residual_streams`` budget is unused).
+
+    ``h_post_token_std`` — std over tokens of the per-token stream mean. The
+    gate is a function of the input (``h = r · proj · α + bias``), so this is
+    its input sensitivity: →0 means the gate stopped discriminating tokens and
+    has effectively become a constant scalar.
+
+    Returns 0-dim GPU tensors; no host sync.
+    """
+    flat = h_post.detach().astype("float32")
+    flat = flat.reshape([-1, flat.shape[-1]])  # [tokens, n]
+
+    per_token_mean = flat.mean(axis=-1)  # [tokens]
+    per_token_max = flat.max(axis=-1)  # [tokens]
+    concentration = (per_token_max / paddle.clip(per_token_mean, min=_EPS)).mean()
+    token_std = per_token_mean.std() if flat.shape[0] > 1 else paddle.zeros(())
+
+    return {
+        "h_post_stream_concentration": concentration,
+        "h_post_token_std": token_std,
+    }
+
+
+def branch_residual_share(
+    h_res: paddle.Tensor,
+    original_residual: paddle.Tensor,
+    h_post: paddle.Tensor,
+    layer_output: paddle.Tensor,
+    bias: paddle.Tensor | None = None,
+) -> dict[str, paddle.Tensor]:
+    """How much of the mHC update this layer wrote itself, per token.
+
+    mHC propagates ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``: the first
+    term only re-mixes what the previous layers wrote, the second is this
+    layer's own contribution. The share
+
+        ``branch_residual_share = b / (b + r)``,
+        ``b = ‖H_postᵀ F(·)‖_F``, ``r = ‖H_resᵀ x_l‖_F``
+
+    is therefore the direct read on "is this layer still writing anything".
+    ``h_post_mean`` alone cannot answer that: a shrinking gate may be offset by
+    a growing ``F(·)``.
+
+    The bounded form is deliberate. The raw ratio ``b / r`` is unbounded and
+    ``r`` really does hit 0 — an all-zero token (padding, or the shifted slot of
+    an MTP layer) has all ``n`` streams at zero, and only ``layer_0`` and MTP
+    layers can see one, since deeper layers always carry earlier writes. Dividing
+    by ``r`` then pinned the value at the epsilon floor (``b / 1e-6 ≈ 1e6``),
+    which blew up the token mean and the derived ``global_*`` series along with
+    it. Here such a token simply reads 1.0, and every token contributes at most
+    1.0 to the mean, so a handful of them can no longer hijack the series.
+
+    Both norms are computed exactly, but without materialising any
+    ``[tokens, n, C]`` intermediate:
+
+    - the branch term is an outer product, so
+      ``‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂ · ‖xb_t‖₂``;
+    - for the residual term, with ``mixed_t[i] = Σ_j h_res[t,j,i] · x_l[t,j]``,
+      ``‖mixed_t‖²_F = Σ_{j,k} S[t,j,k] · G[t,j,k]`` where
+      ``S = Σ_i h_res[t,j,i] h_res[t,k,i]`` and ``G`` is the Gram matrix of the
+      n streams. Both are ``[tokens, n, n]``, i.e. negligible memory, and the
+      cost is ``O(tokens · n² · C)`` — for ``n = 4`` that is ``C/n²`` times
+      cheaper than the layer's own projections.
+
+    Args:
+        h_res: ``[..., n, n]`` Sinkhorn doubly-stochastic mixing matrix.
+        original_residual: ``[..., n*C]`` incoming n-stream hidden states.
+        h_post: ``[..., n]`` expansion gate.
+        layer_output: ``[..., C]`` the sublayer output ``F(·)``.
+        bias: optional ``[C]`` bias added to the sublayer output.
+
+    Returns:
+        ``branch_residual_share`` (token mean) and
+        ``branch_residual_share_max`` (worst token), both in ``[0, 1]``.
+
+    Note:
+        The branch term is measured *before* dropout. Configs that run
+        ``hidden_dropout_prob > 0`` therefore see a slight over-estimate of the
+        branch magnitude at train time; the pretraining configs here use 0.
+    """
+    n = int(h_post.shape[-1])
+    xb = layer_output.detach().astype("float32")
+    if bias is not None:
+        xb = xb + bias.detach().astype("float32").reshape([1] * (xb.ndim - 1) + [-1])
+    xb = xb.reshape([-1, xb.shape[-1]])  # [tokens, C]
+
+    gate = h_post.detach().astype("float32").reshape([-1, n])  # [tokens, n]
+    branch_norm = gate.norm(axis=-1) * xb.norm(axis=-1)  # [tokens]
+
+    streams = original_residual.detach().astype("float32")
+    streams = streams.reshape([-1, n, streams.shape[-1] // n])  # [tokens, n, C]
+    res = h_res.detach().astype("float32").reshape([-1, n, n])  # [tokens, n, n]
+
+    gram = paddle.einsum("tjc,tkc->tjk", streams, streams)  # [tokens, n, n]
+    mix = paddle.einsum("tji,tki->tjk", res, res)  # [tokens, n, n]
+    residual_sq = (gram * mix).sum(axis=[-2, -1])  # [tokens]
+    residual_norm = paddle.sqrt(paddle.clip(residual_sq, min=0.0))
+
+    # eps only guards the both-terms-zero token (share 0); it does not bound the
+    # value, which is why this form is safe where the raw ratio was not.
+    share = branch_norm / paddle.clip(branch_norm + residual_norm, min=_EPS)
+    return {
+        "branch_residual_share": share.mean(),
+        "branch_residual_share_max": share.max(),
+    }

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -4,24 +4,32 @@ Paddle port of ``backends/megatron/mhc_monitor.py``. Monitors the three
 per-token mappings of every ``HyperConnectionModule`` in an mHC
 (Manifold-Constrained Hyper-Connections) model:
 
-- ``h_pre`` / ``h_post`` — the aggregation / expansion gates: mean and std.
+- ``h_pre`` / ``h_post`` — the aggregation / expansion gates: mean and std, plus
+  the stream concentration and token sensitivity of ``h_post``.
 - ``h_res``              — the doubly-stochastic residual-mixing matrix: the
   paper's ``amax_gain`` forward (max-abs row sum) and backward (max-abs column
   sum), computed both on this layer's ``h_res`` and on the running **composite
   mapping** (cumulative product of ``h_res`` across the layers local to this
   pipeline stage / VPP chunk).
+- the **two update terms** of ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``:
+  their relative magnitude, i.e. how much this layer still writes into the
+  residual streams.
 
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 8
-mean-aggregated series, name-prefixed by component:
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 12
+series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
     {attn,mlp}_h_post_mean  {attn,mlp}_h_post_std
+    {attn,mlp}_h_post_stream_concentration  {attn,mlp}_h_post_token_std
+    {attn,mlp}_branch_residual_share  {attn,mlp}_branch_residual_share_max
     {attn,mlp}_amax_gain_fwd            {attn,mlp}_amax_gain_bwd
     {attn,mlp}_composite_amax_gain_fwd  {attn,mlp}_composite_amax_gain_bwd
 
 ``h_pre`` is not part of ``HyperConnectionModule.forward``'s return, so we
 cannot use a forward hook. Instead we wrap the module's ``compute_mappings``
 bound method to capture its real ``(h_pre, h_post, h_res)`` — no recompute.
+The branch/residual ratio needs the sublayer output too, which only exists where
+the two terms are combined, so ``fused_h_res_h_post_bda`` is wrapped as well.
 Everything is detached and computed under ``no_grad`` (see the VRAM-safety
 notes on the hook).
 
@@ -40,7 +48,7 @@ import paddle.nn as nn
 
 from .base import PaddleProbe
 from .layer_discovery import get_decoder_layers, iter_monitor_layers
-from .mhc_metrics import amax_gain, gate_stats
+from .mhc_metrics import amax_gain, branch_residual_share, gate_stats, h_post_structure_stats
 
 logger = logging.getLogger(__name__)
 
@@ -61,11 +69,20 @@ _METRIC_NAMES = (
     "h_pre_std",
     "h_post_mean",
     "h_post_std",
+    "h_post_stream_concentration",
+    "h_post_token_std",
+    "branch_residual_share",
+    "branch_residual_share_max",
     "amax_gain_fwd",
     "amax_gain_bwd",
     "composite_amax_gain_fwd",
     "composite_amax_gain_bwd",
 )
+
+# Only the worst-token branch ratio keeps extremum semantics across
+# microbatches / layers / ranks; everything else is a mean. The name ends in
+# `_max`, so training_logs' suffix classifier agrees on the full key too.
+_MAX_METRICS = frozenset({"branch_residual_share_max"})
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
@@ -103,10 +120,10 @@ class PaddleMHCHealthMonitor(PaddleProbe):
     """Monitor the h_pre / h_post / h_res mappings of mHC hyper-connection layers."""
 
     METRIC_PREFIX = "mhc_health"
-    # Every metric is a mean over tokens/batch (and over microbatches/ranks at
-    # flush). No max/min series, so both classification sets stay empty. The
-    # metric names end in _mean/_std/_fwd/_bwd — never a `_max`/`_min` boundary —
-    # so training_logs' suffix classifier also keeps them as "mean".
+    # All metrics but one are means over tokens/batch (and over microbatches /
+    # ranks at flush); `branch_residual_share_max` is the single extremum series.
+    # Component-prefixed names are registered in __init__, because
+    # record_layer_metric classifies on the name it is handed.
     MAX_AGGREGATED: set[str] = set()
     MIN_AGGREGATED: set[str] = set()
 
@@ -117,6 +134,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         monitor_interval: int = 1,
         verbose: bool = False,
     ):
+        self.MAX_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MAX_METRICS}
         super().__init__(
             log_per_layer=log_per_layer,
             log_global=log_global,
@@ -125,8 +143,8 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         )
         # chunk_id -> running composite mapping [s*b, n, n], detached (no graph).
         self._composite: dict[int, paddle.Tensor] = {}
-        # (module, original_compute_mappings) pairs, for remove_hooks() restoration.
-        self._wrapped: list[tuple[nn.Layer, object]] = []
+        # (module, attribute name, original bound method) triples, for remove_hooks().
+        self._wrapped: list[tuple[nn.Layer, str, object]] = []
 
     # ------------------------------------------------------------------
     # Discovery
@@ -204,8 +222,15 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             for layer_idx, comp, mod, chunk_id, is_root in entries:
                 orig = mod.compute_mappings
                 mod.compute_mappings = self._make_capture(orig, layer_idx, comp, chunk_id, is_root)
-                self._wrapped.append((mod, orig))
-        logger.info(f"[PaddleMHCMonitor] Wrapped {len(self._wrapped)} hyper-connection modules.")
+                self._wrapped.append((mod, "compute_mappings", orig))
+                # The branch/residual ratio needs the sublayer output, which only
+                # exists at the point where the two update terms are combined.
+                orig_bda = getattr(mod, "fused_h_res_h_post_bda", None)
+                if orig_bda is None:
+                    continue
+                mod.fused_h_res_h_post_bda = self._make_bda_capture(orig_bda, layer_idx, comp)
+                self._wrapped.append((mod, "fused_h_res_h_post_bda", orig_bda))
+        logger.info(f"[PaddleMHCMonitor] Wrapped {len(self._wrapped)} hyper-connection methods.")
 
     def register_hooks(self, model):
         """Discover, declare, allocate, and attach — the whole three-phase setup."""
@@ -219,14 +244,14 @@ class PaddleMHCHealthMonitor(PaddleProbe):
     def remove_hooks(self):
         # Restore the original bound methods and drop all cross-call state so
         # the monitor holds no module references or composite tensors after
-        # teardown. ``del mod.compute_mappings`` removes the instance attribute
-        # and falls back to the class method; if that fails (e.g. slots), we
-        # re-bind the captured original.
-        for mod, orig in self._wrapped:
+        # teardown. ``del mod.<attr>`` removes the instance attribute and falls
+        # back to the class method; if that fails (e.g. slots), we re-bind the
+        # captured original.
+        for mod, attr, orig in self._wrapped:
             try:
-                del mod.compute_mappings
+                delattr(mod, attr)
             except AttributeError:
-                mod.compute_mappings = orig
+                setattr(mod, attr, orig)
         self._wrapped = []
         self._composite.clear()
         super().remove_hooks()
@@ -276,6 +301,8 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                     self.record_layer_metric(layer_idx, f"{component}_h_pre_std", pre_std)
                     self.record_layer_metric(layer_idx, f"{component}_h_post_mean", post_mean)
                     self.record_layer_metric(layer_idx, f"{component}_h_post_std", post_std)
+                    for name, value in h_post_structure_stats(h_post).items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
 
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-1))
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, axis=-2))
@@ -303,6 +330,56 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMHCMonitor] Error layer {layer_idx}/{component}: {e}")
+            return out
+
+        return wrapped
+
+    def _make_bda_capture(self, orig, layer_idx: int, component: str):
+        """Wrap ``fused_h_res_h_post_bda`` to record the branch/residual ratio.
+
+        This is the only place where both terms of the mHC update are available:
+        the call receives ``h_res`` + ``original_residual`` (the residual term's
+        inputs) and ``layer_output_with_bias`` (the branch term's input). Metrics
+        are derived from the **arguments**, so both the fused fast path and the
+        sequential dropout path are covered identically, and the call itself is
+        forwarded untouched.
+
+        Arguments are read by keyword with a positional fallback: PaddleFleet's
+        transformer layer calls this with keywords today, but relying on that
+        alone would silently stop recording if it ever switched.
+        """
+
+        def wrapped(*args, **kwargs):
+            out = orig(*args, **kwargs)
+            if not self._should_monitor():
+                return out
+            try:
+
+                def pick(name, pos):
+                    if name in kwargs:
+                        return kwargs[name]
+                    return args[pos] if len(args) > pos else None
+
+                h_res = pick("h_res", 0)
+                original_residual = pick("original_residual", 1)
+                h_post = pick("h_post", 2)
+                layer_output_with_bias = pick("layer_output_with_bias", 3)
+                if h_res is None or original_residual is None or h_post is None:
+                    return out
+                if isinstance(layer_output_with_bias, tuple):
+                    layer_output, bias = layer_output_with_bias
+                else:
+                    layer_output, bias = layer_output_with_bias, None
+                if layer_output is None:
+                    return out
+
+                with paddle.no_grad():
+                    stats = branch_residual_share(h_res, original_residual, h_post, layer_output, bias)
+                    for name, value in stats.items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[PaddleMHCMonitor] Error bda layer {layer_idx}/{component}: {e}")
             return out
 
         return wrapped

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -35,6 +35,27 @@ class FakeHC(nn.Layer):
     def compute_mappings(self, x):
         return self._h_pre, self._h_post, self._h_res
 
+    def fused_h_res_h_post_bda(
+        self,
+        h_res,
+        original_residual,
+        h_post,
+        layer_output_with_bias,
+        dropout_prob=0.0,
+        training=True,
+        fused=False,
+    ):
+        x, bias = layer_output_with_bias
+        n = self.n
+        leading = original_residual.shape[:-1]
+        C = original_residual.shape[-1] // n
+        mixed = paddle.bmm(
+            h_res.reshape([-1, n, n]).transpose([0, 2, 1]),
+            original_residual.reshape([-1, n, C]),
+        ).reshape([*leading, n, C])
+        xb = x if bias is None else x + bias
+        return (h_post.unsqueeze(-1) * xb.unsqueeze(-2) + mixed).reshape([*leading, n * C])
+
     def forward(self, hidden_states):  # pragma: no cover - unused
         return hidden_states, self._h_res, self._h_post
 
@@ -70,6 +91,73 @@ class MHCMetricsTest(unittest.TestCase):
         mean, std = mhc_metrics.gate_stats(h)
         self.assertAlmostEqual(float(mean), 1.5, places=5)
         self.assertAlmostEqual(float(std), float(h.std()), places=5)
+
+    def test_stream_concentration_bounds(self):
+        # Uniform across streams -> 1 (lower bound); all mass on one stream -> n.
+        uniform = paddle.full([3, 4], 0.7)
+        one_hot = paddle.to_tensor([[1.0, 0.0, 0.0, 0.0]] * 3, dtype="float32")
+        self.assertAlmostEqual(
+            float(mhc_metrics.h_post_structure_stats(uniform)["h_post_stream_concentration"]),
+            1.0,
+            places=5,
+        )
+        self.assertAlmostEqual(
+            float(mhc_metrics.h_post_structure_stats(one_hot)["h_post_stream_concentration"]),
+            4.0,
+            places=5,
+        )
+
+    def test_token_std_zero_when_gate_is_constant(self):
+        const = paddle.full([8, 4], 1.0)
+        varying = paddle.to_tensor([[0.2] * 4, [1.8] * 4], dtype="float32")
+        self.assertAlmostEqual(float(mhc_metrics.h_post_structure_stats(const)["h_post_token_std"]), 0.0, places=6)
+        self.assertGreater(float(mhc_metrics.h_post_structure_stats(varying)["h_post_token_std"]), 0.5)
+
+    def test_branch_residual_share_against_explicit_terms(self):
+        # h_res = identity -> residual term is exactly the incoming streams, so
+        # the share reduces to b / (b + ‖x_l‖_F) with b = ‖h_post‖₂·‖x‖₂.
+        n, c = 2, 3
+        h_res = paddle.eye(n).reshape([1, n, n])
+        streams = paddle.to_tensor([[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]], dtype="float32")
+        h_post = paddle.to_tensor([[3.0, 4.0]], dtype="float32")  # ‖·‖₂ = 5
+        x = paddle.to_tensor([[0.0, 0.0, 2.0]], dtype="float32")  # ‖·‖₂ = 2
+        stats = mhc_metrics.branch_residual_share(h_res, streams.reshape([1, n * c]), h_post, x)
+        branch = 5.0 * 2.0
+        residual = float(paddle.sqrt(paddle.to_tensor(5.0)))  # ‖streams‖_F = √5
+        expected = branch / (branch + residual)
+        self.assertAlmostEqual(float(stats["branch_residual_share"]), expected, places=4)
+        self.assertAlmostEqual(float(stats["branch_residual_share_max"]), expected, places=4)
+
+    def test_branch_residual_share_zero_gate_kills_branch(self):
+        n, c = 4, 5
+        h_res = paddle.eye(n).reshape([1, n, n])
+        streams = paddle.randn([1, n * c])
+        x = paddle.randn([1, c])
+        stats = mhc_metrics.branch_residual_share(h_res, streams, paddle.zeros([1, n]), x)
+        self.assertAlmostEqual(float(stats["branch_residual_share"]), 0.0, places=6)
+
+    def test_branch_residual_share_zero_residual_token_stays_bounded(self):
+        # An all-zero token (padding, or an MTP layer's shifted slot) drives the
+        # residual norm to 0. The raw ratio hit the epsilon floor and returned
+        # ~1e6, hijacking the token mean; the bounded share must read 1.0 and
+        # leave the mean dominated by the healthy token.
+        n, c = 2, 3
+        h_res = paddle.eye(n).reshape([1, n, n]).expand([2, n, n])
+        streams = paddle.concat([paddle.ones([1, n * c]), paddle.zeros([1, n * c])])
+        h_post = paddle.ones([2, n])
+        x = paddle.ones([2, c])
+        stats = mhc_metrics.branch_residual_share(h_res, streams, h_post, x)
+        self.assertAlmostEqual(float(stats["branch_residual_share_max"]), 1.0, places=6)
+        self.assertLessEqual(float(stats["branch_residual_share"]), 1.0)
+        self.assertGreater(float(stats["branch_residual_share"]), 0.5)
+
+    def test_branch_residual_share_all_zero_token_is_zero(self):
+        # Both terms zero must not divide by zero; the eps guard makes it 0.
+        n, c = 2, 3
+        stats = mhc_metrics.branch_residual_share(
+            paddle.zeros([1, n, n]), paddle.zeros([1, n * c]), paddle.zeros([1, n]), paddle.zeros([1, c])
+        )
+        self.assertAlmostEqual(float(stats["branch_residual_share"]), 0.0, places=6)
 
 
 class MHCMonitorTest(unittest.TestCase):
@@ -144,6 +232,66 @@ class MHCMonitorTest(unittest.TestCase):
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_mean"], 1.0, places=5)
         # global aggregate is derived too.
         self.assertIn("mhc_health/global_attn_amax_gain_fwd", latest)
+
+    def test_branch_residual_share_is_recorded_from_bda(self):
+        n, s, b, c = 4, 2, 3, 6
+        layer = self._identity_layer(n, s, b)
+        model = _mhc_model([layer])
+
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        streams = paddle.randn([s, b, n * c])
+        x = paddle.randn([s, b, c])
+        for _, _, mod, _, _ in targets:
+            mod.fused_h_res_h_post_bda(
+                h_res=mod._h_res,
+                original_residual=streams,
+                h_post=mod._h_post,
+                layer_output_with_bias=(x, None),
+                dropout_prob=0.0,
+                training=True,
+                fused=False,
+            )
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for key in ("branch_residual_share", "branch_residual_share_max"):
+                self.assertIn(f"mhc_health/layer_0/{comp}_{key}", latest)
+            # h_post == 1 everywhere so the branch norm is √n·‖x‖ and h_res is the
+            # identity, hence the share must sit strictly inside (0, 1].
+            share = latest[f"mhc_health/layer_0/{comp}_branch_residual_share"]
+            self.assertGreater(share, 0.0)
+            self.assertLessEqual(share, 1.0)
+            self.assertGreaterEqual(latest[f"mhc_health/layer_0/{comp}_branch_residual_share_max"], share)
+
+    def test_h_post_structure_keys_recorded(self):
+        n, s, b = 4, 2, 3
+        layer = self._identity_layer(n, s, b)
+        model = _mhc_model([layer])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            # h_post is constant 1.0 -> equal across streams and across tokens.
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_stream_concentration"], 1.0, places=4)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_token_std"], 0.0, places=5)
+
+    def test_remove_hooks_restores_both_wrapped_methods(self):
+        n, s, b = 4, 2, 3
+        layer = self._identity_layer(n, s, b)
+        model = _mhc_model([layer])
+        monitor = PaddleMHCHealthMonitor()
+        hc = layer.self_attention_hyper_connection
+        self._prepare_and_attach(monitor, model)
+        self.assertIn("fused_h_res_h_post_bda", vars(hc))
+        monitor.remove_hooks()
+        self.assertNotIn("fused_h_res_h_post_bda", vars(hc))
+        self.assertEqual(hc.fused_h_res_h_post_bda.__func__, FakeHC.fused_h_res_h_post_bda)
 
     def test_remove_hooks_restores_compute_mappings(self):
         n, s, b = 4, 2, 3


### PR DESCRIPTION
## 背景

原有 8 个指标有两个盲区：

1. `h_post_mean` / `h_post_std` 把 token 轴与 stream 轴一起池化，「n 条流一起变弱」
   与「n-1 条流死掉、剩一条扛全部」在均值上不可分；
2. 无法回答「这层还在不在写入残差流」——门变小可能被 `F(·)` 变大抵消，两者存在
   尺度冗余。

## 新增指标（paddlefleet 后端，每个 hc 模块 8 → 12 个）

- `{c}_h_post_stream_concentration` = `mean_t(max_i h_post / mean_i h_post)`，逐 token 先算再平均，区间 `[1, n]`。1 = 各流等权，趋 `n` = 退化成单流残差
- `{c}_h_post_token_std` = `std_t(mean_i h_post)`，门对输入的敏感度，→0 = 退化成常数标量
- `{c}_branch_residual_share` = `mean_t(b / (b + r))`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F`，本层写入量占比，区间 `[0, 1]`，0.5 = 两项等量
- `{c}_branch_residual_share_max` = 最坏 token 的写入占比

## 实现要点

- 两个范数都是精确值，但不物化任何 `[tokens, n, C]` 中间量：分支项是外积（`‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂·‖xb_t‖₂`），残差项用 `[tokens, n, n]` 的 Gram/mix 收缩，`n = 4` 时开销约为本层投影的 `C/n²` 分之一
- 采集点在 `fused_h_res_h_post_bda`（两项唯一同时可见处），指标从**入参**推导，故 fused 快路径与带 dropout 的顺序路径口径一致
- 热路径无 D2H 同步、无集合通信，schema 仍在 `allocate_buffers` 前声明
- `branch_residual_share_max` 是唯一按极值跨 microbatch / 层 / rank 归约的指标，名字以 `_max` 结尾，training_logs 的后缀分类器与 monitor 判定一致