### PR TITLE
fix(moe_health): latent_eps_ratio should use the latent norm's own eps

### DIFF
--- a/src/internal_medicine/backends/megatron/moe_monitor.py
+++ b/src/internal_medicine/backends/megatron/moe_monitor.py
@@ -198,15 +198,31 @@ class MoESpecialistMonitor(TorchProbe):
 
     @staticmethod
     def _layernorm_eps_of(moe_layer: nn.Module) -> float | None:
-        """Return ``config.layernorm_epsilon`` for this layer, else ``None``.
+        """Return the eps this layer's latent norm uses, else ``None``.
 
-        This is the eps a latent RMSNorm sitting before ``fc2_latent_proj`` would use
-        (mcore's single knob for every LayerNorm/RMSNorm, ``transformer_config.py:184``,
-        default ``1e-5``). Used only to parameterise ``latent_eps_ratio``; absent config
-        means the ratio is not emitted rather than guessed.
+        ``layernorm_epsilon`` is mcore's single knob for every LayerNorm/RMSNorm
+        (``transformer_config.py:184``, default ``1e-5``), so it is the right answer for
+        a model whose latent norm just inherits the global value. But a model may give
+        the latent norm its OWN eps — normalising ``u`` (natural scale ~1e-3) is a very
+        different regime from normalising a unit-scale hidden state, and moving the
+        global knob would move five other norms with it. When such a field is present it
+        is what that norm actually runs with, so prefer it; ``latent_eps_ratio`` computed
+        from the global value would otherwise describe a norm that does not exist and
+        read identically to the un-modified baseline.
+
+        Used only to parameterise ``latent_eps_ratio``; absent config means the ratio is
+        not emitted rather than guessed. ``None`` in the per-norm field means "not set"
+        and also falls back; any other value, ``0.0`` included, is taken as given —
+        reporting the global eps for a norm that runs at 0.0 would be the same silent
+        mismatch this prefers-the-real-eps rule exists to prevent.
         """
         config = getattr(moe_layer, "config", None)
-        eps = getattr(config, "layernorm_epsilon", None) if config is not None else None
+        if config is None:
+            return None
+        eps = getattr(config, "moe_latent_norm_eps", None)
+        if eps is None:
+            # No per-norm field (every other model) -> the global knob, i.e. unchanged.
+            eps = getattr(config, "layernorm_epsilon", None)
         return float(eps) if isinstance(eps, int | float) else None
 
     def _patch_combine_postprocess(self, layer_idx: int, moe_layer: nn.Module):

--- a/tests/test_megatron_monitors.py
+++ b/tests/test_megatron_monitors.py
@@ -621,6 +621,10 @@ class MegatronMoEMonitorTest(unittest.TestCase):
         layer.config = SimpleNamespace(layernorm_epsilon=eps)
         return layer
 
+    @staticmethod
+    def _latent_eps_layer_resolved_eps(layer):
+        return MoESpecialistMonitor._layernorm_eps_of(layer)
+
     def _run_latent_eps(self, layer, expert_out):
         monitor = MoESpecialistMonitor(log_per_layer=True, log_global=True)
         monitor._find_moe_layers = lambda _model: [(0, layer)]
@@ -704,6 +708,44 @@ class MegatronMoEMonitorTest(unittest.TestCase):
         self.assertNotIn(name, MoESpecialistMonitor.MIN_AGGREGATED)
         self.assertFalse(training_logs._is_max_metric(f"moe_health/layer_0/{name}"))
         self.assertFalse(training_logs._is_min_metric(f"moe_health/layer_0/{name}"))
+
+    def test_latent_eps_ratio_prefers_the_latent_norms_own_eps(self):
+        """A latent norm may carry its own eps; the ratio must use THAT, not the global
+        knob. Normalising u (natural scale ~1e-3) is a different regime from a unit-scale
+        hidden state, and moving layernorm_epsilon would move five other norms with it —
+        so a model that sets moe_latent_norm_eps is running a norm the global value does
+        not describe, and a ratio computed from the global value would read identically
+        to the un-modified baseline."""
+        layer = self._latent_eps_layer(eps=1e-5)
+        layer.config.moe_latent_norm_eps = 1e-8
+        self.assertEqual(self._latent_eps_layer_resolved_eps(layer), 1e-8)
+        latest = self._run_latent_eps(layer, torch.full((4, 2, 4), 1e-3))
+        got = latest["moe_health/layer_0/latent_eps_ratio"]
+        # mean(h**2) == 1e-6, so the eps that is actually in the denominator is decisive:
+        # 1e-8 -> ~0.01 (the norm normalises), 1e-5 -> ~0.91 (eps swamps it).
+        self.assertAlmostEqual(got, 1e-8 / (1e-6 + 1e-8), places=5)
+        self.assertLess(got, 0.02)
+
+    def test_latent_eps_ratio_falls_back_to_the_global_knob(self):
+        """Regression guard: a model WITHOUT the per-norm field must read exactly as
+        before — every model that does not set it is unaffected."""
+        layer = self._latent_eps_layer(eps=1e-5)
+        self.assertFalse(hasattr(layer.config, "moe_latent_norm_eps"))
+        self.assertEqual(self._latent_eps_layer_resolved_eps(layer), 1e-5)
+        latest = self._run_latent_eps(layer, torch.full((4, 2, 4), 1e-3))
+        self.assertAlmostEqual(latest["moe_health/layer_0/latent_eps_ratio"], 1e-5 / (1e-6 + 1e-5), places=5)
+
+        # An explicit None means "not materialised" and must behave like absent.
+        layer_none = self._latent_eps_layer(eps=1e-5)
+        layer_none.config.moe_latent_norm_eps = None
+        self.assertEqual(self._latent_eps_layer_resolved_eps(layer_none), 1e-5)
+
+        # 0.0 is NOT a fallback trigger: a norm running at eps=0 is described by 0, and
+        # reporting the global 1e-5 instead would be the same silent mismatch the
+        # prefers-the-real-eps rule exists to prevent.
+        layer_zero = self._latent_eps_layer(eps=1e-5)
+        layer_zero.config.moe_latent_norm_eps = 0.0
+        self.assertEqual(self._latent_eps_layer_resolved_eps(layer_zero), 0.0)
 
     def test_latent_combine_metrics_measure_combine_postprocess_output(self):
         """The metrics must describe exactly what combine_postprocess returned — the


### PR DESCRIPTION
`_layernorm_eps_of` reads `config.layernorm_epsilon` unconditionally. That is the right
answer for a model whose latent RMSNorm inherits the global knob, but wrong for one that
gives that norm its own epsilon — and the metric then computes a correct formula on the
wrong input, which is worse than not emitting it.

On an arm that lowers only the latent norm's eps to `1e-8` while leaving
`layernorm_epsilon` at `1e-5`, with `S = mean(u**2) ~ 3e-6`:

| | eps used | `latent_eps_ratio` |
|---|---|---|
| truth | 1e-8 | **0.0031** |
| as reported | 1e-5 | **0.7541** |
| unmodified baseline arm | 1e-5 | **0.7541** |

The two curves are indistinguishable: the modified arm reads exactly what the baseline
reads, so the panel says "nothing changed" while the real value differs by **240x**.
Since this metric exists precisely to show whether a run sits in the eps-dominated
regime, that is the one failure mode it must not have.

**Why a per-norm field exists at all.** Normalising the routed latent aggregate `u`
(natural scale ~1e-3) is a different regime from normalising a unit-scale hidden state,
and `layernorm_epsilon` is shared by every other LayerNorm/RMSNorm in the model — moving
it to study one norm moves five others with it, so the experiment would no longer be
single-axis.

**Blast radius is nil for every existing model.** With no such field the resolver falls
back to `layernorm_epsilon`, i.e. today's behaviour bit for bit. Both directions are
pinned by tests (`test_latent_eps_ratio_prefers_the_latent_norms_own_eps` /
`test_latent_eps_ratio_falls_back_to_the_global_knob`).

One deliberate asymmetry: only `None` means "not set". Any other value, `0.0` included,
is taken as given — reporting the global eps for a norm that genuinely runs at `0.0`
would be the same silent mismatch this rule exists to prevent.
