### PR TITLE
fix(qk_stats): megatron QK 监控折叠 learnable sink logit + moe   负载均衡熵 + qk THD packed

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ setup_internal_medicine()
 | 9 | `sink_nonsink_gap` | `qk_stats/.../sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | 每层+全局 | Sink/非Sink 分化度 |
 | 10 | `attn_sink_logit` | `qk_stats/.../attn_sink_logit` | `mean(sink_logit)` | 每层+全局 | learned sink logit 量级漂移；稀疏层取 `attn_sink`，full 层取 `softmax_offset` |
 
+> **learnable / off-by-one softmax 的 sink 折叠**：当 `core_attention.softmax_offset`
+> 存在时（`softmax_type` 为 `learnable` / `off-by-one`），`entropy_avg` / `sink` 会把这个
+> per-head sink logit 作为一列额外的无 key 列折进 softmax 分母，使统计与模型真实分布一致
+> （`sink` 分子与 `max` / `mean` 仍只统计真实 key）。vanilla softmax（无 offset）行为不变。
+> megatron 与 paddlefleet 两个后端语义一致。
+
 ### 混合注意力栈的层类型标签 (attn_type)
 
 指标键会带上层类型前缀，避免不同注意力类型的统计混在同一张图里。

--- a/README.md
+++ b/README.md
@@ -158,8 +158,10 @@ setup_internal_medicine()
 | 14 | `load_max_min_ratio` | `moe_health/.../load_max_min_ratio` | `max(tokens) / min(tokens)` | 每层+全局 | 最忙/最闲专家 token 数比值 |
 | 15 | `load_max_median_ratio` | `moe_health/.../load_max_median_ratio` | `max(tokens) / median(tokens)` | 每层+全局 | 最忙/中位专家 token 数比值 |
 | 16 | `load_cv` | `moe_health/.../load_cv` | `std(tokens) / mean(tokens)` | 每层+全局 | 专家负载变异系数 (均衡=0) |
+| 17 | `load_balance_entropy_norm` | `moe_health/.../load_balance_entropy_norm` | `H(p) / log(E)` | 每层+全局 | 归一化负载熵 (均衡=1, 坍缩=0) |
+| 18 | `load_effective_experts` | `moe_health/.../load_effective_experts` | `exp(H)` | 每层+全局 | 有效专家数 (均衡=E, 坍缩=1) |
 
-> **注**: 指标 14-16 (`load_*`) 在满足以下**任一**条件时输出, 优先使用前者:
+> **注**: 指标 14-18 (`load_*`) 在满足以下**任一**条件时输出, 优先使用前者:
 > 1. `global_aux_loss` 已开启 (`get_aux_loss_coeff("global_aux_loss") > 0`): 复用
 >    router 的 `global_tokens_per_expert` 缓冲区 (已跨 TPxDPxCP all-reduce 并在
 >    global batch 内累加)。该缓冲区在 `finalize_model_grads` →
@@ -387,6 +389,8 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **MoE** | `load_max_min_ratio` | `max/min(tokens)` | mean | 越接近 1 越均衡 (global_aux_loss 或 expert_bias) |
 | **MoE** | `load_max_median_ratio` | `max/median(tokens)` | mean | 越接近 1 越均衡 (global_aux_loss 或 expert_bias) |
 | **MoE** | `load_cv` | `std/mean(tokens)` | mean | 越接近 0 越均衡 (global_aux_loss 或 expert_bias) |
+| **MoE** | `load_balance_entropy_norm` | `H(p)/log(E)` | mean | 越接近 1 越均衡 (global_aux_loss 或 expert_bias) |
+| **MoE** | `load_effective_experts` | `exp(H)` | mean | 越接近专家数 E 越均衡 (global_aux_loss 或 expert_bias) |
 | **QK** | `max` | `max(QK^T/√d)` | max | 不应暴增 |
 | **QK** | `mean` | `mean(logits)` | mean | 稳定 |
 | **QK** | `entropy_avg` | `-Σ(p log p)` avg | mean | 适中 |

--- a/docs/qk_logits.md
+++ b/docs/qk_logits.md
@@ -219,6 +219,17 @@ sink    = s_i / d_i
 
 默认启用因果 mask (`causal=True`)，适用于 GPT 类自回归模型。注意力矩阵中 `query_pos < key_pos` 的位置被设为 `-1e10`。
 
+### THD Packed 序列
+
+当一个 batch 内多条变长序列被打包成单条 `[T, H, D]` 张量（THD 布局，`total_tokens = ΣLᵢ`）时，`core_attention` 通过 `packed_seq_params.cu_seqlens_q`（回退 `cu_seqlens_q_padded`）携带各序列边界。此时 QK monitor 走 **packed 专用路径** `compute_qk_stats_packed` → `qk_stats_packed_kernel`（split-M，grid `(num_heads, num_m_blocks)`）：
+
+- **逐序列边界**：`_cu_seqlens_to_token_arrays` 用 `torch.searchsorted` 在 GPU 上把 `cu_seqlens` 展开成每 token 的 `seq_start`/`seq_end`（int32），全程无 `.item()`/`.cpu()`/`.tolist()`，可安全在 forward hook 内调用而不破坏 compute/comm overlap。kernel 内用 `same_seq = seq_start[m] ≤ n < seq_end[m]` 屏蔽跨序列注意力，**不会跨序列泄露**。
+- **逐序列 sink**：sink token 是每条序列自己的首 token（`seq_start[m]` 列），而非全局 token-0。因此每条 packed 序列各自独立统计 attention sink。
+- **padding 安全**：当张量的 `T` 维大于 `cu_seqlens[-1]`（padding slot）时，这些 token 的 `seq_start == seq_end == 0`，`same_seq` 使其有效范围为空，不贡献任何统计，也不会越界读取。
+- **mean 语义**：与 dense split-M kernel 一致，采用 **row-first 均值**（先算每行均值，再对全体有效行取平均），而非按有效位置计数加权。
+
+> 注：packed 路径当前不支持 SWA / 滑动窗口与 CP（`q_row_offset` / 非对称 Q/K 长度）的组合；如需叠加，须同时补充对应的正确性测试。
+
 ---
 
 ## 使用方式
@@ -299,9 +310,9 @@ qk_stats/global_sink_nonsink_gap
 
 | Hook 位置 | 类型 | 捕获内容 | 产出指标 |
 |-----------|------|----------|----------|
-| `attention.core_attention` | forward **pre**-hook | `args[0]` = Query, `args[1]` = Key | 全部 9 个指标 |
+| `attention.core_attention` | forward **pre**-hook | `args[0]` = Query, `args[1]` = Key；`kwargs["packed_seq_params"]` = packed 边界（若有） | 全部 9 个指标 |
 
-注意: 使用 `forward_pre_hook` 而非 `forward_hook`，直接拦截送入 `core_attention` 的 Q/K 张量。
+注意: 使用 `forward_pre_hook` 而非 `forward_hook`，直接拦截送入 `core_attention` 的 Q/K 张量。hook 以 `with_kwargs=True` 注册，以便读取 `packed_seq_params`：当 Q 为 3 维（`[T, H, D]`）且带 `cu_seqlens_q` 时走 THD packed 路径（见上文「THD Packed 序列」），否则走常规 dense 路径。
 
 ---
 

--- a/src/internal_medicine/backends/megatron/moe_metrics.py
+++ b/src/internal_medicine/backends/megatron/moe_metrics.py
@@ -111,10 +111,20 @@ def compute_load_balance_ratios(tokens_per_expert: torch.Tensor) -> dict[str, to
       - load_max_min_ratio    = #tokens(most-routed) / #tokens(least-routed)
       - load_max_median_ratio = #tokens(most-routed) / #tokens(median expert)
       - load_cv               = std(counts) / mean(counts)  (变异系数, 完全均衡=0)
+      - load_balance_entropy_norm = H(p) / log(E)  (归一化负载熵, 完全均衡=1, 坍缩到
+        单专家=0). p_e = count_e / sum(count) 是本 batch 的专家负载分布, H = -sum(p log p).
+      - load_effective_experts = exp(H)  (有效专家数 / perplexity, 完全均衡=E, 坍缩=1).
+        比裸熵更好读: "256 个专家实际只有效用到了 40 个".
+
+    熵与 CV 在接近均衡区间数学上近似 (H/log(E) ≈ 1 - CV²/(2 log E)), 但熵有界 [0,1],
+    可跨专家数配置比较, 且 exp(H) 直接给出"有效专家数". 熵对分布做全体求和, 不像
+    max/min 比值被单个死专家主导, 更平滑. 三者都 scale-invariant (与总 token 数无关),
+    因此无需除 ga_steps.
 
     median 用 torch.median (偶数个专家时取下中位, 即某个真实专家的计数, 不做插值).
     极值比值分母 clamp(min=1.0) 防止死专家 (count=0) 产生 inf/NaN. CV 用 population
-    std (unbiased=False) 除以 mean, mean clamp(min=1.0) 防止空批次除零. 全程 GPU
+    std (unbiased=False) 除以 mean, mean clamp(min=1.0) 防止空批次除零. 熵用 p*log(p)
+    并对 p clamp(min=1e-12) 防止 0*log0 的 NaN (死专家贡献 0, 是熵的正确极限). 全程 GPU
     tensor, 不在 hot path 上运行 (调用点在 finalize_model_grads, forward hook 之外).
 
     Args:
@@ -139,10 +149,22 @@ def compute_load_balance_ratios(tokens_per_expert: torch.Tensor) -> dict[str, to
     mean_count = counts.mean(dim=-1)
     std_count = counts.std(dim=-1, unbiased=False)
 
+    # Load distribution p_e = count_e / sum(count), then Shannon entropy per layer.
+    # clamp the total (not per-expert) to avoid divide-by-zero on an empty batch;
+    # clamp p only inside log to make dead experts (p=0) contribute 0*log(~0)->0,
+    # the correct 0*log0 limit, without NaN. num_experts drives the log(E) norm.
+    num_experts = counts.shape[-1]
+    total_count = counts.sum(dim=-1, keepdim=True).clamp(min=1.0)
+    probs = counts / total_count
+    entropy = -(probs * probs.clamp(min=1e-12).log()).sum(dim=-1)  # [num_layers]
+    log_e = torch.log(torch.tensor(float(num_experts), device=counts.device))
+
     return {
         "load_max_min_ratio": max_count / min_count.clamp(min=1.0),
         "load_max_median_ratio": max_count / median_count.clamp(min=1.0),
         "load_cv": std_count / mean_count.clamp(min=1.0),
+        "load_balance_entropy_norm": entropy / log_e,
+        "load_effective_experts": torch.exp(entropy),
     }
 
 

--- a/src/internal_medicine/backends/megatron/moe_monitor.py
+++ b/src/internal_medicine/backends/megatron/moe_monitor.py
@@ -56,6 +56,8 @@ _LOAD_BALANCE_METRICS = (
     "load_max_min_ratio",
     "load_max_median_ratio",
     "load_cv",
+    "load_balance_entropy_norm",
+    "load_effective_experts",
 )
 
 _EXPERT_METRICS = (
@@ -285,14 +287,11 @@ class MoESpecialistMonitor(TorchProbe):
         ratios = compute_load_balance_ratios(tokens_per_expert)
         if ratios is None:
             return
-        max_min = ratios["load_max_min_ratio"]
-        max_median = ratios["load_max_median_ratio"]
-        load_cv = ratios["load_cv"]
-        n = min(max_min.shape[0], len(layer_order))
+        # Every metric shares the same leading (layer) dim; align to layer_order.
+        n = min(next(iter(ratios.values())).shape[0], len(layer_order))
         for row, layer_idx in zip(range(n), layer_order[:n], strict=False):
-            self.record_layer_metric(layer_idx, "load_max_min_ratio", max_min[row])
-            self.record_layer_metric(layer_idx, "load_max_median_ratio", max_median[row])
-            self.record_layer_metric(layer_idx, "load_cv", load_cv[row])
+            for name in _LOAD_BALANCE_METRICS:
+                self.record_layer_metric(layer_idx, name, ratios[name][row])
 
     def _patch_router_cache(self, router):
         if not hasattr(router, "_apply_aux_loss"):

--- a/src/internal_medicine/backends/megatron/qk_monitor.py
+++ b/src/internal_medicine/backends/megatron/qk_monitor.py
@@ -150,10 +150,21 @@ class QKStatsMonitor(TorchProbe):
 
                 is_thd = query.dim() == 3
 
+                # Learned per-head sink logit (learnable/off-by-one softmax);
+                # None for vanilla. `module` is core_attention. Keep on-device.
+                attn_sink = getattr(module, "softmax_offset", None)
+                if attn_sink is not None:
+                    attn_sink = attn_sink.detach()
+
                 with torch.no_grad():
                     if is_thd and cu_seqlens is not None:
                         stats = compute_qk_stats_packed(
-                            query, key, cu_seqlens.detach(), causal=self.causal, use_triton=self.use_triton
+                            query,
+                            key,
+                            cu_seqlens.detach(),
+                            causal=self.causal,
+                            use_triton=self.use_triton,
+                            attn_sink=attn_sink,
                         )
                     else:
                         if is_thd:
@@ -162,7 +173,9 @@ class QKStatsMonitor(TorchProbe):
                         seq_len = query.shape[0]
                         if seq_len > _MAX_SEQ_LEN_FOR_QK and not self.use_triton:
                             return
-                        stats = compute_qk_stats(query, key, causal=self.causal, use_triton=self.use_triton)
+                        stats = compute_qk_stats(
+                            query, key, causal=self.causal, use_triton=self.use_triton, attn_sink=attn_sink
+                        )
 
                 # NOTE: TP cross-rank aggregation is intentionally NOT done here.
                 # gather_and_aggregate() at flush time pools across all ranks

--- a/src/internal_medicine/backends/megatron/qk_monitor.py
+++ b/src/internal_medicine/backends/megatron/qk_monitor.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 from .base import TorchProbe
 from .sink_head_metrics import compute_sink_head_classification
-from .triton_kernels import compute_qk_stats
+from .triton_kernels import compute_qk_stats, compute_qk_stats_packed
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,8 @@ class QKStatsMonitor(TorchProbe):
         for layer_idx, attention_module in targets:
             if hasattr(attention_module, "core_attention"):
                 hook = attention_module.core_attention.register_forward_pre_hook(
-                    self.timed_hook("compute", self._make_compute_hook(layer_idx))
+                    self.timed_hook("compute", self._make_compute_hook(layer_idx)),
+                    with_kwargs=True,
                 )
                 self.hooks.append(hook)
         logger.info(f"[QKMonitor] Registered {len(self.hooks)} hooks.")
@@ -129,19 +130,39 @@ class QKStatsMonitor(TorchProbe):
         return attention_layers
 
     def _make_compute_hook(self, layer_idx: int):
-        def hook_fn(module, args):
+        def hook_fn(module, args, kwargs=None):
             if not self._should_monitor():
                 return
             try:
-                query, key = args[0].detach(), args[1].detach()
-                if query.dim() == 3:
-                    query = query.unsqueeze(1)
-                    key = key.unsqueeze(1)
-                seq_len = query.shape[0]
-                if seq_len > _MAX_SEQ_LEN_FOR_QK and not self.use_triton:
+                if len(args) < 2:
                     return
+                query, key = args[0].detach(), args[1].detach()
+
+                # Packed (THD) sequences carry cu_seqlens via packed_seq_params;
+                # honor per-sequence boundaries instead of treating the whole
+                # packed row as one giant sequence.
+                cu_seqlens = None
+                psp = (kwargs or {}).get("packed_seq_params")
+                if psp is not None:
+                    cu_seqlens = getattr(psp, "cu_seqlens_q", None)
+                    if cu_seqlens is None:
+                        cu_seqlens = getattr(psp, "cu_seqlens_q_padded", None)
+
+                is_thd = query.dim() == 3
+
                 with torch.no_grad():
-                    stats = compute_qk_stats(query, key, causal=self.causal, use_triton=self.use_triton)
+                    if is_thd and cu_seqlens is not None:
+                        stats = compute_qk_stats_packed(
+                            query, key, cu_seqlens.detach(), causal=self.causal, use_triton=self.use_triton
+                        )
+                    else:
+                        if is_thd:
+                            query = query.unsqueeze(1)
+                            key = key.unsqueeze(1)
+                        seq_len = query.shape[0]
+                        if seq_len > _MAX_SEQ_LEN_FOR_QK and not self.use_triton:
+                            return
+                        stats = compute_qk_stats(query, key, causal=self.causal, use_triton=self.use_triton)
 
                 # NOTE: TP cross-rank aggregation is intentionally NOT done here.
                 # gather_and_aggregate() at flush time pools across all ranks

--- a/src/internal_medicine/backends/megatron/triton_kernels.py
+++ b/src/internal_medicine/backends/megatron/triton_kernels.py
@@ -7,7 +7,7 @@ import logging
 
 import torch
 
-from ...core.triton_qk_kernel import qk_stats_kernel
+from ...core.triton_qk_kernel import qk_stats_kernel, qk_stats_packed_kernel
 
 logger = logging.getLogger(__name__)
 
@@ -159,3 +159,244 @@ def compute_qk_stats(q: torch.Tensor, k: torch.Tensor, causal: bool = True, use_
         return compute_qk_stats_triton(q, k, causal)
 
     return compute_qk_stats_pytorch(q, k, causal)
+
+
+def _cu_seqlens_to_token_arrays(cu_seqlens: torch.Tensor, total_tokens: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map ``cu_seqlens`` to per-token sequence boundaries, entirely on-device.
+
+    Given ``cu_seqlens = [0, l0, l0+l1, ...]`` (the packed cumulative sequence
+    lengths), returns two int32 tensors of shape ``[total_tokens]``:
+      * ``seq_start[t]`` = start token index of the sequence containing token t
+      * ``seq_end[t]``   = end (exclusive) token index of that sequence
+
+    Padding tokens (``t >= cu_seqlens[-1]``) get an empty ``[0, 0)`` range so
+    the kernel's ``same_seq`` mask discards them.
+
+    Sync-free: built from ``torch.searchsorted`` + ``torch.where`` with NO
+    ``.item()`` / ``.cpu()`` / ``.tolist()``, so it is safe to call from a
+    forward hook without breaking compute/comm overlap.
+    """
+    device = cu_seqlens.device
+    cu = cu_seqlens.to(torch.int64)
+    num_seqs = cu.numel() - 1
+    token_ids = torch.arange(total_tokens, device=device, dtype=torch.int64)
+
+    # seq_idx: i such that cu[i] <= t < cu[i+1]
+    seq_idx = torch.searchsorted(cu, token_ids, right=True) - 1
+    seq_idx = seq_idx.clamp(0, max(num_seqs - 1, 0))
+
+    seq_start = cu[seq_idx]
+    seq_end = cu[seq_idx + 1]
+
+    # Padding tokens beyond the last real token -> empty range.
+    last = cu[-1]
+    is_pad = token_ids >= last
+    zero = torch.zeros((), device=device, dtype=torch.int64)
+    seq_start = torch.where(is_pad, zero, seq_start)
+    seq_end = torch.where(is_pad, zero, seq_end)
+
+    return seq_start.to(torch.int32).contiguous(), seq_end.to(torch.int32).contiguous()
+
+
+def compute_qk_stats_triton_packed(
+    q: torch.Tensor, k: torch.Tensor, cu_seqlens: torch.Tensor, causal: bool = True
+) -> dict:
+    """Packed (THD) QK statistics via the split-M Triton kernel.
+
+    Input: [H, T, D] (GQA already repeat_interleave-expanded, batch flattened).
+    Reduces the per-M-block partial buffers into per-head stats using row-first
+    mean semantics (mean over valid rows of each row's mean logit), matching
+    the dense ``qk_stats_partial_kernel`` reduction.
+    """
+    num_heads, total_tokens, head_dim = q.shape
+    scale = 1.0 / (head_dim**0.5)
+
+    seq_start, seq_end = _cu_seqlens_to_token_arrays(cu_seqlens, total_tokens)
+
+    BLOCK_M = 64
+    BLOCK_N = 64
+    BLOCK_K = 64
+    if head_dim > 64:
+        BLOCK_K = 128
+
+    num_m_blocks = (total_tokens + BLOCK_M - 1) // BLOCK_M
+
+    def _buf():
+        return torch.empty((num_heads, num_m_blocks), device=q.device, dtype=torch.float32)
+
+    p_max = _buf()
+    p_sum_logit = _buf()
+    p_sum_row_mean = _buf()
+    p_count = _buf()
+    p_sum_entropy = _buf()
+    p_sum_sink = _buf()
+    p_valid_rows = _buf()
+
+    grid = (num_heads, num_m_blocks)
+
+    qk_stats_packed_kernel[grid](
+        q,
+        k,
+        seq_start,
+        seq_end,
+        p_max,
+        p_sum_logit,
+        p_sum_row_mean,
+        p_count,
+        p_sum_entropy,
+        p_sum_sink,
+        p_valid_rows,
+        num_heads,
+        total_tokens,
+        head_dim,
+        num_m_blocks,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        p_max.stride(0),
+        p_max.stride(1),
+        scale=scale,
+        apply_causal_mask=causal,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+    )
+
+    # Reduce partials over the M-block dim -> per-head [H].
+    valid_rows = p_valid_rows.sum(dim=1)
+    safe_rows = valid_rows.clamp(min=1)
+
+    max_per_head = p_max.max(dim=1).values
+    mean_per_head = p_sum_row_mean.sum(dim=1) / safe_rows
+    entropy_per_head = p_sum_entropy.sum(dim=1) / safe_rows
+    sink_per_head = p_sum_sink.sum(dim=1) / safe_rows
+
+    # Shape [1, H] to match the dense [B, H] convention consumed by the hook.
+    max_per_head = max_per_head.unsqueeze(0)
+    mean_per_head = mean_per_head.unsqueeze(0)
+    entropy_per_head = entropy_per_head.unsqueeze(0)
+    sink_per_head = sink_per_head.unsqueeze(0)
+
+    return {
+        "max_per_head": max_per_head,
+        "mean_per_head": mean_per_head,
+        "entropy_per_head": entropy_per_head,
+        "sink_per_head": sink_per_head,
+        "max_global": max_per_head.max(),
+        "mean_global": mean_per_head.mean(),
+        "entropy_global": entropy_per_head.mean(),
+        "sink_global": sink_per_head.mean(),
+    }
+
+
+def compute_qk_stats_pytorch_packed(
+    q: torch.Tensor, k: torch.Tensor, cu_seqlens: torch.Tensor, causal: bool = True
+) -> dict:
+    """Reference packed QK statistics. Input: [H, T, D].
+
+    Slices each packed sequence and accumulates row-first statistics so the
+    result matches ``compute_qk_stats_triton_packed`` exactly (mean is the
+    average over valid rows of each row's mean logit — NOT a count-weighted
+    position mean). This is the reference/fallback path; ``cu_seqlens.tolist()``
+    incurs a D2H sync and is acceptable here (not the Triton hot path).
+    """
+    num_heads, total_tokens, head_dim = q.shape
+    scale = 1.0 / (head_dim**0.5)
+    device = q.device
+
+    bounds = cu_seqlens.to(torch.int64).tolist()
+
+    sum_row_mean = torch.zeros(num_heads, device=device)
+    sum_entropy = torch.zeros(num_heads, device=device)
+    sum_sink = torch.zeros(num_heads, device=device)
+    valid_rows = torch.zeros(num_heads, device=device)
+    max_per_head = torch.full((num_heads,), -1e10, device=device)
+
+    for i in range(len(bounds) - 1):
+        s, e = bounds[i], bounds[i + 1]
+        length = e - s
+        if length <= 0:
+            continue
+
+        q_seq = q[:, s:e, :]  # [H, L, D]
+        k_seq = k[:, s:e, :]
+        logits = torch.matmul(q_seq, k_seq.transpose(-2, -1)) * scale  # [H, L, L]
+
+        if causal:
+            causal_mask = torch.triu(torch.ones(length, length, device=device, dtype=torch.bool), diagonal=1)
+            logits = logits.masked_fill(causal_mask, float("-inf"))
+
+        valid_mask = logits > -1e9  # [H, L, L]
+        row_count = valid_mask.sum(dim=-1)  # [H, L]
+
+        # max over all valid positions in this sequence
+        seq_max = torch.where(valid_mask, logits, torch.full_like(logits, -1e10)).amax(dim=(-2, -1))
+        max_per_head = torch.maximum(max_per_head, seq_max)
+
+        # row-first mean
+        row_sum = torch.where(valid_mask, logits, torch.zeros_like(logits)).sum(dim=-1)  # [H, L]
+        row_mean = row_sum / row_count.clamp(min=1)  # [H, L]
+        sum_row_mean += row_mean.sum(dim=-1)
+
+        # entropy per row
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log_softmax(logits, dim=-1)
+        ent_map = -(probs * log_probs)
+        ent_map = torch.where(valid_mask, ent_map, torch.zeros_like(ent_map))
+        sum_entropy += ent_map.sum(dim=-1).sum(dim=-1)
+
+        # sink = prob of each row's own sequence-start (local column 0)
+        sum_sink += probs[..., 0].sum(dim=-1)
+
+        valid_rows += (row_count > 0).sum(dim=-1).to(valid_rows.dtype)
+
+    safe_rows = valid_rows.clamp(min=1)
+    mean_per_head = (sum_row_mean / safe_rows).unsqueeze(0)
+    entropy_per_head = (sum_entropy / safe_rows).unsqueeze(0)
+    sink_per_head = (sum_sink / safe_rows).unsqueeze(0)
+    max_per_head = max_per_head.unsqueeze(0)
+
+    return {
+        "max_per_head": max_per_head,
+        "mean_per_head": mean_per_head,
+        "entropy_per_head": entropy_per_head,
+        "sink_per_head": sink_per_head,
+        "max_global": max_per_head.max(),
+        "mean_global": mean_per_head.mean(),
+        "entropy_global": entropy_per_head.mean(),
+        "sink_global": sink_per_head.mean(),
+    }
+
+
+def compute_qk_stats_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    causal: bool = True,
+    use_triton: bool = True,
+) -> dict:
+    """Unified packed (THD) entry point. Input layout: [T, H, D].
+
+    Respects per-sequence boundaries from ``cu_seqlens`` so no attention
+    leaks across packed sequences and each sequence's sink is its own first
+    token. GQA is expanded on the host (matching ``compute_qk_stats``), then
+    the tensors are permuted to [H, T, D] before dispatch.
+    """
+    total_tokens, num_q_heads, head_dim = q.shape
+    _, num_k_heads, _ = k.shape
+
+    if num_q_heads != num_k_heads:
+        heads_per_group = num_q_heads // num_k_heads
+        k = k.repeat_interleave(heads_per_group, dim=1)
+
+    # [T, H, D] -> [H, T, D]
+    q = q.permute(1, 0, 2).contiguous()
+    k = k.permute(1, 0, 2).contiguous()
+
+    if use_triton:
+        return compute_qk_stats_triton_packed(q, k, cu_seqlens, causal)
+
+    return compute_qk_stats_pytorch_packed(q, k, cu_seqlens, causal)

--- a/src/internal_medicine/backends/megatron/triton_kernels.py
+++ b/src/internal_medicine/backends/megatron/triton_kernels.py
@@ -12,11 +12,16 @@ from ...core.triton_qk_kernel import qk_stats_kernel, qk_stats_packed_kernel
 logger = logging.getLogger(__name__)
 
 
-def compute_qk_stats_triton(q: torch.Tensor, k: torch.Tensor, causal: bool = True) -> dict:
+def compute_qk_stats_triton(
+    q: torch.Tensor, k: torch.Tensor, causal: bool = True, attn_sink: torch.Tensor | None = None
+) -> dict:
     """
     Compute QK statistics using optimized Triton kernel.
     Input: [B, H, S, D] (already permuted by compute_qk_stats).
     Returns: Max Logits, Mean Logits, Entropy, Sink Weights.
+
+    ``attn_sink``: optional per-query-head sink logit ``[H]`` folded into the
+    softmax denominator (``None`` = vanilla, real-key-only).
     """
     batch, num_heads, seq_len, head_dim = q.shape
     scale = 1.0 / (head_dim**0.5)
@@ -37,9 +42,14 @@ def compute_qk_stats_triton(q: torch.Tensor, k: torch.Tensor, causal: bool = Tru
     if head_dim > 64:
         BLOCK_K = 128
 
+    # None is not a valid kernel pointer: pass a dummy zero buffer, gate on HAS_SINK.
+    sink_present = attn_sink is not None
+    sink_buf = attn_sink if sink_present else torch.zeros(num_heads, device=q.device, dtype=torch.float32)
+
     qk_stats_kernel[grid](
         q,
         k,
+        sink_buf,
         max_logits,
         mean_logits,
         entropy,
@@ -64,6 +74,7 @@ def compute_qk_stats_triton(q: torch.Tensor, k: torch.Tensor, causal: bool = Tru
         max_logits.stride(1),
         scale=scale,
         apply_causal_mask=causal,
+        HAS_SINK=sink_present,
         ROW_STRIDE=1,  # full-sequence (exact) behavior, unchanged
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
@@ -82,10 +93,15 @@ def compute_qk_stats_triton(q: torch.Tensor, k: torch.Tensor, causal: bool = Tru
     }
 
 
-def compute_qk_stats_pytorch(q: torch.Tensor, k: torch.Tensor, causal: bool = True) -> dict:
+def compute_qk_stats_pytorch(
+    q: torch.Tensor, k: torch.Tensor, causal: bool = True, attn_sink: torch.Tensor | None = None
+) -> dict:
     """
     Reference PyTorch implementation including Entropy and Sink.
     Input: [B, H, S, D] (already permuted by compute_qk_stats).
+
+    ``attn_sink``: optional per-query-head sink logit ``[H]`` folded in as one
+    extra key-less softmax column (excluded from max/mean and the sink numerator).
     """
     batch, num_heads, seq_len, head_dim = q.shape
     scale = 1.0 / (head_dim**0.5)
@@ -109,21 +125,25 @@ def compute_qk_stats_pytorch(q: torch.Tensor, k: torch.Tensor, causal: bool = Tr
     mean_per_head = sum_logits / count.clamp(min=1)
 
     # 3. Softmax & Entropy & Sink
-    # Softmax along last dim (keys)
-    probs = torch.softmax(logits, dim=-1)  # [B, H, S, S]
+    # Fold the sink logit in as one extra key-less column: it enters the softmax
+    # denominator and entropy (it's part of the model's distribution), but not
+    # max/mean or the token-0 sink numerator (those describe real keys).
+    if attn_sink is not None:
+        sink_col = attn_sink.reshape(1, num_heads, 1, 1).expand(batch, num_heads, seq_len, 1).to(logits.dtype)
+        ext_logits = torch.cat([logits, sink_col], dim=-1)  # [B, H, S, S+1]
+        ext_valid = torch.cat([valid_mask, torch.ones_like(sink_col, dtype=torch.bool)], dim=-1)
+    else:
+        ext_logits = logits
+        ext_valid = valid_mask
 
-    # Entropy: -sum(p * log(p))
-    # Note: masked positions have p=0, 0*log0=0 (handled by where)
-    log_probs = torch.log_softmax(logits, dim=-1)
+    probs = torch.softmax(ext_logits, dim=-1)  # [B, H, S, S(+1)]
+    log_probs = torch.log_softmax(ext_logits, dim=-1)
     entropy_map = -(probs * log_probs)
-    # Mask out invalid (causal) entries which might be NaN
-    entropy_map = torch.where(valid_mask, entropy_map, torch.tensor(0.0, device=q.device))
+    entropy_map = torch.where(ext_valid, entropy_map, torch.tensor(0.0, device=q.device))
     row_entropy = entropy_map.sum(dim=-1)  # [B, H, S]
-    # Average entropy over valid queries (rows)
-    # For causal, first row has 1 valid, second 2...
     avg_entropy = row_entropy.mean(dim=-1)  # [B, H]
 
-    # Sink: Probability of token 0
+    # Sink: probability of real token 0 (never the appended sink column)
     sink_probs = probs[..., 0]  # [B, H, S]
     avg_sink = sink_probs.mean(dim=-1)  # [B, H]
 
@@ -139,10 +159,18 @@ def compute_qk_stats_pytorch(q: torch.Tensor, k: torch.Tensor, causal: bool = Tr
     }
 
 
-def compute_qk_stats(q: torch.Tensor, k: torch.Tensor, causal: bool = True, use_triton: bool = True) -> dict:
+def compute_qk_stats(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    causal: bool = True,
+    use_triton: bool = True,
+    attn_sink: torch.Tensor | None = None,
+) -> dict:
     """
     Unified entry point. Input layout: [S, B, H, D] (Megatron core_attention convention).
     Permutes to [B, H, S, D] before dispatching to backend.
+
+    ``attn_sink``: optional per-query-head sink logit ``[H]`` (softmax_offset).
     """
     seq_len, batch, num_q_heads, head_dim = q.shape
     _, _, num_k_heads, _ = k.shape
@@ -156,9 +184,9 @@ def compute_qk_stats(q: torch.Tensor, k: torch.Tensor, causal: bool = True, use_
     k = k.permute(1, 2, 0, 3).contiguous()
 
     if use_triton:
-        return compute_qk_stats_triton(q, k, causal)
+        return compute_qk_stats_triton(q, k, causal, attn_sink=attn_sink)
 
-    return compute_qk_stats_pytorch(q, k, causal)
+    return compute_qk_stats_pytorch(q, k, causal, attn_sink=attn_sink)
 
 
 def _cu_seqlens_to_token_arrays(cu_seqlens: torch.Tensor, total_tokens: int) -> tuple[torch.Tensor, torch.Tensor]:
@@ -199,7 +227,11 @@ def _cu_seqlens_to_token_arrays(cu_seqlens: torch.Tensor, total_tokens: int) -> 
 
 
 def compute_qk_stats_triton_packed(
-    q: torch.Tensor, k: torch.Tensor, cu_seqlens: torch.Tensor, causal: bool = True
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    causal: bool = True,
+    attn_sink: torch.Tensor | None = None,
 ) -> dict:
     """Packed (THD) QK statistics via the split-M Triton kernel.
 
@@ -207,6 +239,9 @@ def compute_qk_stats_triton_packed(
     Reduces the per-M-block partial buffers into per-head stats using row-first
     mean semantics (mean over valid rows of each row's mean logit), matching
     the dense ``qk_stats_partial_kernel`` reduction.
+
+    ``attn_sink``: optional per-query-head sink logit ``[H]`` folded into the
+    softmax denominator on top of the per-sequence sink column.
     """
     num_heads, total_tokens, head_dim = q.shape
     scale = 1.0 / (head_dim**0.5)
@@ -234,9 +269,14 @@ def compute_qk_stats_triton_packed(
 
     grid = (num_heads, num_m_blocks)
 
+    # None is not a valid kernel pointer: pass a dummy zero buffer, gate on HAS_SINK.
+    sink_present = attn_sink is not None
+    sink_buf = attn_sink if sink_present else torch.zeros(num_heads, device=q.device, dtype=torch.float32)
+
     qk_stats_packed_kernel[grid](
         q,
         k,
+        sink_buf,
         seq_start,
         seq_end,
         p_max,
@@ -260,6 +300,7 @@ def compute_qk_stats_triton_packed(
         p_max.stride(1),
         scale=scale,
         apply_causal_mask=causal,
+        HAS_SINK=sink_present,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
@@ -293,7 +334,11 @@ def compute_qk_stats_triton_packed(
 
 
 def compute_qk_stats_pytorch_packed(
-    q: torch.Tensor, k: torch.Tensor, cu_seqlens: torch.Tensor, causal: bool = True
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    causal: bool = True,
+    attn_sink: torch.Tensor | None = None,
 ) -> dict:
     """Reference packed QK statistics. Input: [H, T, D].
 
@@ -302,6 +347,9 @@ def compute_qk_stats_pytorch_packed(
     average over valid rows of each row's mean logit — NOT a count-weighted
     position mean). This is the reference/fallback path; ``cu_seqlens.tolist()``
     incurs a D2H sync and is acceptable here (not the Triton hot path).
+
+    ``attn_sink``: optional per-query-head sink logit ``[H]`` folded in as one
+    extra key-less softmax column per sequence, matching the kernel.
     """
     num_heads, total_tokens, head_dim = q.shape
     scale = 1.0 / (head_dim**0.5)
@@ -341,11 +389,21 @@ def compute_qk_stats_pytorch_packed(
         row_mean = row_sum / row_count.clamp(min=1)  # [H, L]
         sum_row_mean += row_mean.sum(dim=-1)
 
-        # entropy per row
-        probs = torch.softmax(logits, dim=-1)
-        log_probs = torch.log_softmax(logits, dim=-1)
+        # entropy per row. Fold the sink logit in as an extra key-less column:
+        # it enters the softmax denominator and entropy, but not max/mean or the
+        # seq-start sink numerator (those describe real keys).
+        if attn_sink is not None:
+            sink_col = attn_sink.reshape(num_heads, 1, 1).expand(num_heads, length, 1).to(logits.dtype)
+            ext_logits = torch.cat([logits, sink_col], dim=-1)
+            ext_valid = torch.cat([valid_mask, torch.ones_like(sink_col, dtype=torch.bool)], dim=-1)
+        else:
+            ext_logits = logits
+            ext_valid = valid_mask
+
+        probs = torch.softmax(ext_logits, dim=-1)
+        log_probs = torch.log_softmax(ext_logits, dim=-1)
         ent_map = -(probs * log_probs)
-        ent_map = torch.where(valid_mask, ent_map, torch.zeros_like(ent_map))
+        ent_map = torch.where(ext_valid, ent_map, torch.zeros_like(ent_map))
         sum_entropy += ent_map.sum(dim=-1).sum(dim=-1)
 
         # sink = prob of each row's own sequence-start (local column 0)
@@ -377,6 +435,7 @@ def compute_qk_stats_packed(
     cu_seqlens: torch.Tensor,
     causal: bool = True,
     use_triton: bool = True,
+    attn_sink: torch.Tensor | None = None,
 ) -> dict:
     """Unified packed (THD) entry point. Input layout: [T, H, D].
 
@@ -384,6 +443,8 @@ def compute_qk_stats_packed(
     leaks across packed sequences and each sequence's sink is its own first
     token. GQA is expanded on the host (matching ``compute_qk_stats``), then
     the tensors are permuted to [H, T, D] before dispatch.
+
+    ``attn_sink``: optional per-query-head sink logit ``[H]`` (softmax_offset).
     """
     total_tokens, num_q_heads, head_dim = q.shape
     _, num_k_heads, _ = k.shape
@@ -397,6 +458,6 @@ def compute_qk_stats_packed(
     k = k.permute(1, 0, 2).contiguous()
 
     if use_triton:
-        return compute_qk_stats_triton_packed(q, k, cu_seqlens, causal)
+        return compute_qk_stats_triton_packed(q, k, cu_seqlens, causal, attn_sink=attn_sink)
 
-    return compute_qk_stats_pytorch_packed(q, k, cu_seqlens, causal)
+    return compute_qk_stats_pytorch_packed(q, k, cu_seqlens, causal, attn_sink=attn_sink)

--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -32,6 +32,7 @@ def qk_stats_kernel(
     # Pointers
     Q_ptr,
     K_ptr,
+    attn_sink_ptr,
     max_logits_ptr,
     mean_logits_ptr,
     entropy_ptr,
@@ -61,6 +62,7 @@ def qk_stats_kernel(
     # Configs
     scale: tl.constexpr,
     apply_causal_mask: tl.constexpr,
+    HAS_SINK: tl.constexpr,
     ROW_STRIDE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -189,6 +191,21 @@ def qk_stats_kernel(
             d_i = d_new
             h_i = h_new
             s_i = s_new
+
+        # Fold the per-head sink logit as an extra key-less column: it enters
+        # the denominator (and entropy) but not max/mean or the sink numerator.
+        # h uses the OLD d_i before d_i is rescaled (see partial kernel).
+        if HAS_SINK:
+            sink_logit = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+            m_new = tl.maximum(m_i, sink_logit)
+            alpha_prev = tl.exp(m_i - m_new)
+            h_i = (h_i + (m_i - m_new) * d_i) * alpha_prev
+            d_i = d_i * alpha_prev
+            s_i = s_i * alpha_prev
+            sink_w = tl.exp(sink_logit - m_new)
+            d_i = d_i + sink_w
+            h_i = h_i + sink_w * (sink_logit - m_new)
+            m_i = m_new
 
         # Finalize block rows
         log_d = tl.log(d_i)
@@ -741,6 +758,7 @@ def qk_stats_packed_kernel(
     # Pointers
     Q_ptr,
     K_ptr,
+    attn_sink_ptr,
     token_seq_start_ptr,  # [total_tokens] int32: start token index of each token's sequence
     token_seq_end_ptr,  # [total_tokens] int32: end (exclusive) token index of each token's sequence
     partial_max_ptr,
@@ -768,6 +786,7 @@ def qk_stats_packed_kernel(
     # Configs
     scale: tl.constexpr,
     apply_causal_mask: tl.constexpr,
+    HAS_SINK: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -889,6 +908,21 @@ def qk_stats_packed_kernel(
         d_i = d_new
         h_i = h_new
         s_i = s_new
+
+    # Fold the per-head sink logit as an extra key-less column on top of the
+    # per-sequence sink column: it enters the denominator (and entropy) but not
+    # max/mean or the sink numerator. h uses the OLD d_i before d_i is rescaled.
+    if HAS_SINK:
+        sink_logit = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+        m_new = tl.maximum(m_i, sink_logit)
+        alpha_prev = tl.exp(m_i - m_new)
+        h_i = (h_i + (m_i - m_new) * d_i) * alpha_prev
+        d_i = d_i * alpha_prev
+        s_i = s_i * alpha_prev
+        sink_w = tl.exp(sink_logit - m_new)
+        d_i = d_i + sink_w
+        h_i = h_i + sink_w * (sink_logit - m_new)
+        m_i = m_new
 
     # Finalize per-row stats for this M-block
     safe_d = tl.where(d_i > 0, d_i, 1.0)

--- a/src/internal_medicine/core/triton_qk_kernel.py
+++ b/src/internal_medicine/core/triton_qk_kernel.py
@@ -8,7 +8,7 @@ each CP rank keeps its local Q shard (``seq_len_q = S/CP``) but sees the
 full-sequence K (``seq_len_k = S``) after an all_gather. Passing
 ``q_row_offset = cp_rank * seq_len_q`` restores correct causal masking.
 
-Two families of kernels live here:
+Three families of kernels live here:
 
 * ``qk_stats_kernel`` / ``qk_stats_partial_kernel`` — dense causal attention.
 * ``qk_stats_sparse_partial_kernel`` — two-segment sparse attention, used for
@@ -16,6 +16,11 @@ Two families of kernels live here:
   attends to a sliding window over the original KV plus a contiguous run of
   compressed KV entries, under a single softmax that also includes a learned
   per-head sink logit.
+* ``qk_stats_packed_kernel`` — packed (THD) variant of the partial kernel: when
+  multiple variable-length sequences are packed into one ``[H, T, D]`` tensor,
+  per-token ``seq_start``/``seq_end`` boundaries confine each query to its own
+  sequence (no cross-sequence leakage) and the sink column is each row's own
+  sequence start rather than global token 0.
 """
 
 import triton
@@ -721,6 +726,189 @@ def qk_stats_sparse_partial_kernel(
     block_valid_rows = tl.sum(valid_mask.to(tl.float32))
 
     out_offset = batch_idx * stride_p_batch + head_idx * stride_p_head + pid_m * stride_p_m
+
+    tl.store(partial_max_ptr + out_offset, block_max_logit)
+    tl.store(partial_sum_logit_ptr + out_offset, block_sum_logit)
+    tl.store(partial_sum_row_mean_ptr + out_offset, block_sum_row_mean)
+    tl.store(partial_count_ptr + out_offset, block_count)
+    tl.store(partial_sum_entropy_ptr + out_offset, block_sum_entropy)
+    tl.store(partial_sum_sink_ptr + out_offset, block_sum_sink)
+    tl.store(partial_valid_rows_ptr + out_offset, block_valid_rows)
+
+
+@triton.jit
+def qk_stats_packed_kernel(
+    # Pointers
+    Q_ptr,
+    K_ptr,
+    token_seq_start_ptr,  # [total_tokens] int32: start token index of each token's sequence
+    token_seq_end_ptr,  # [total_tokens] int32: end (exclusive) token index of each token's sequence
+    partial_max_ptr,
+    partial_sum_logit_ptr,
+    partial_sum_row_mean_ptr,
+    partial_count_ptr,
+    partial_sum_entropy_ptr,
+    partial_sum_sink_ptr,
+    partial_valid_rows_ptr,
+    # Shapes
+    num_heads,
+    total_tokens,
+    head_dim,
+    num_m_blocks,
+    # Strides for Q/K (THD layout [H, T, D]; batch is always 1 for packed)
+    stride_q_head,
+    stride_q_seq,
+    stride_q_dim,
+    stride_k_head,
+    stride_k_seq,
+    stride_k_dim,
+    # Strides for partial buffers (layout [H, num_m_blocks])
+    stride_p_head,
+    stride_p_m,
+    # Configs
+    scale: tl.constexpr,
+    apply_causal_mask: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Packed (THD) variant of ``qk_stats_partial_kernel``.
+
+    Grid: (num_heads, num_m_blocks). Input layout: [H, T, D] where T is the
+    total packed-token count across all sequences (batch dim is always 1).
+
+    Per-sequence semantics via ``token_seq_start``/``token_seq_end`` (built on
+    the host from ``cu_seqlens`` — see ``_cu_seqlens_to_token_arrays``):
+      * a query row m only attends to key columns n with
+        ``seq_start[m] <= n < seq_end[m]`` (no cross-sequence leakage), and
+      * the attention-sink column for row m is that row's own sequence start
+        ``seq_start[m]`` — NOT global token 0.
+    Padding tokens carry ``seq_start == seq_end == 0`` so ``same_seq`` masks
+    them out (empty valid range) and they contribute nothing.
+
+    NOTE: CP (``q_row_offset`` / asymmetric seq lens) and ``ROW_STRIDE``
+    subsampling are intentionally unsupported here — packed monitoring does not
+    yet compose with either. Add them only alongside a correctness test.
+    """
+    pid_head = tl.program_id(0)
+    pid_m = tl.program_id(1)
+
+    head_idx = pid_head
+    q_base = Q_ptr + head_idx * stride_q_head
+    # GQA is expanded on the host (repeat_interleave), so K shares Q's head idx.
+    k_base = K_ptr + head_idx * stride_k_head
+
+    m_start = pid_m * BLOCK_M
+    m_offsets = m_start + tl.arange(0, BLOCK_M)
+    m_mask = m_offsets < total_tokens
+
+    # Per-row sequence boundaries (int32). Padding rows -> [0, 0) empty range.
+    seq_start = tl.load(token_seq_start_ptr + m_offsets, mask=m_mask, other=0)
+    seq_end = tl.load(token_seq_end_ptr + m_offsets, mask=m_mask, other=0)
+
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - 1e10
+    d_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    h_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    s_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    row_max_logit_raw = tl.zeros([BLOCK_M], dtype=tl.float32) - 1e10
+    row_sum_logit_raw = tl.zeros([BLOCK_M], dtype=tl.float32)
+    row_count_raw = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # Bound the key scan to the columns any row in this block can actually see:
+    # lower = smallest sequence start among valid rows (skip fully-masked
+    # earlier sequences); upper = causal cap (n <= max m) or max sequence end.
+    n_lo = tl.min(tl.where(m_mask, seq_start, total_tokens))
+    n_start_init = (n_lo // BLOCK_N) * BLOCK_N
+    if apply_causal_mask:
+        n_stop = tl.minimum(m_start + BLOCK_M, total_tokens)
+    else:
+        n_stop = tl.minimum(tl.max(tl.where(m_mask, seq_end, 0)), total_tokens)
+
+    for n_start in range(n_start_init, n_stop, BLOCK_N):
+        n_offsets = n_start + tl.arange(0, BLOCK_N)
+        n_mask = n_offsets < total_tokens
+
+        acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+        for k_start in range(0, head_dim, BLOCK_K):
+            k_offsets = k_start + tl.arange(0, BLOCK_K)
+            k_mask = k_offsets < head_dim
+
+            q_ptr = q_base + m_offsets[:, None] * stride_q_seq + k_offsets[None, :] * stride_q_dim
+            q = tl.load(q_ptr, mask=m_mask[:, None] & k_mask[None, :], other=0.0)
+
+            k_ptr = k_base + n_offsets[:, None] * stride_k_seq + k_offsets[None, :] * stride_k_dim
+            k = tl.load(k_ptr, mask=n_mask[:, None] & k_mask[None, :], other=0.0)
+
+            acc += tl.dot(q, tl.trans(k))
+
+        logits = acc * scale
+
+        # Same-sequence mask: n in [seq_start[m], seq_end[m]). Global offsets are
+        # used directly — same_seq already prevents any cross-sequence leakage.
+        same_seq = (n_offsets[None, :] >= seq_start[:, None]) & (n_offsets[None, :] < seq_end[:, None])
+        mask_val = n_mask[None, :] & m_mask[:, None] & same_seq
+        if apply_causal_mask:
+            causal = m_offsets[:, None] >= n_offsets[None, :]
+            mask_val = mask_val & causal
+
+        logits = tl.where(mask_val, logits, -1e10)
+
+        block_max = tl.max(logits, 1)
+        row_max_logit_raw = tl.maximum(row_max_logit_raw, block_max)
+
+        logits_zeroed = tl.where(mask_val, logits, 0.0)
+        row_sum_logit_raw += tl.sum(logits_zeroed, 1)
+        row_count_raw += tl.sum(mask_val.to(tl.float32), 1)
+
+        # Online softmax update
+        m_curr = block_max
+        m_new = tl.maximum(m_i, m_curr)
+
+        alpha_prev = tl.exp(m_i - m_new)
+        alpha_curr = tl.exp(logits - m_new[:, None])
+        alpha_curr = tl.where(mask_val, alpha_curr, 0.0)
+
+        d_curr = tl.sum(alpha_curr, 1)
+        d_new = d_i * alpha_prev + d_curr
+
+        h_term_prev = h_i * alpha_prev + (m_i - m_new) * d_i * alpha_prev
+        logits_diff = logits - m_new[:, None]
+        h_term_curr = tl.sum(tl.where(mask_val, logits_diff * alpha_curr, 0.0), 1)
+        h_new = h_term_prev + h_term_curr
+
+        # Sink = per-row sequence start column. Unlike the dense kernel this is
+        # not confined to n_start==0, since each row's sink lives at seq_start[m]
+        # which can fall in any key block.
+        is_sink_col = n_offsets[None, :] == seq_start[:, None]
+        sink_contrib = tl.sum(tl.where(mask_val & is_sink_col, alpha_curr, 0.0), 1)
+        s_new = s_i * alpha_prev + sink_contrib
+
+        m_i = m_new
+        d_i = d_new
+        h_i = h_new
+        s_i = s_new
+
+    # Finalize per-row stats for this M-block
+    safe_d = tl.where(d_i > 0, d_i, 1.0)
+    row_entropy = tl.log(safe_d) - (h_i / safe_d)
+    row_sink = s_i / safe_d
+
+    row_has_data = row_count_raw > 0
+    valid_mask = row_has_data & m_mask
+
+    block_max_logit = tl.max(tl.where(m_mask, row_max_logit_raw, -1e10))
+    block_sum_logit = tl.sum(tl.where(valid_mask, row_sum_logit_raw, 0.0))
+    safe_row_count = tl.where(row_count_raw > 0, row_count_raw, 1.0)
+    row_mean_logit = row_sum_logit_raw / safe_row_count
+    block_sum_row_mean = tl.sum(tl.where(valid_mask, row_mean_logit, 0.0))
+    block_count = tl.sum(tl.where(m_mask, row_count_raw, 0.0))
+    block_sum_entropy = tl.sum(tl.where(valid_mask, row_entropy, 0.0))
+    block_sum_sink = tl.sum(tl.where(valid_mask, row_sink, 0.0))
+    block_valid_rows = tl.sum(valid_mask.to(tl.float32))
+
+    out_offset = head_idx * stride_p_head + pid_m * stride_p_m
 
     tl.store(partial_max_ptr + out_offset, block_max_logit)
     tl.store(partial_sum_logit_ptr + out_offset, block_sum_logit)

--- a/tests/test_megatron_monitors.py
+++ b/tests/test_megatron_monitors.py
@@ -181,8 +181,15 @@ class MegatronMoEMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["moe_health/layer_1/load_max_median_ratio"], 2.5, places=5)
         # CV = population std / mean. layer 0 mean=3, std=sqrt(((2)+(0)+(1)+(1))/4)=sqrt(1.5)
         self.assertAlmostEqual(latest["moe_health/layer_0/load_cv"], (1.5**0.5) / 3.0, places=5)
+        # Normalized load entropy H(p)/log(E) and effective experts exp(H).
+        self.assertAlmostEqual(latest["moe_health/layer_0/load_balance_entropy_norm"], 0.943959, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_1/load_balance_entropy_norm"], 0.742738, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_0/load_effective_experts"], 3.701009, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_1/load_effective_experts"], 2.800094, places=5)
         self.assertIn("moe_health/global_load_max_min_ratio", latest)
         self.assertIn("moe_health/global_load_cv", latest)
+        self.assertIn("moe_health/global_load_balance_entropy_norm", latest)
+        self.assertIn("moe_health/global_load_effective_experts", latest)
 
     def test_load_balance_metrics_absent_without_any_source(self):
         # When no router exposes global_tokens_per_expert and none has expert-bias

--- a/tests/test_triton_qk_kernel.py
+++ b/tests/test_triton_qk_kernel.py
@@ -30,6 +30,8 @@ _kernels = importlib.import_module("internal_medicine.backends.megatron.triton_k
 compute_qk_stats_triton_packed = _kernels.compute_qk_stats_triton_packed
 compute_qk_stats_pytorch_packed = _kernels.compute_qk_stats_pytorch_packed
 compute_qk_stats_packed = _kernels.compute_qk_stats_packed
+compute_qk_stats_triton = _kernels.compute_qk_stats_triton
+compute_qk_stats_pytorch = _kernels.compute_qk_stats_pytorch
 _cu_seqlens_to_token_arrays = _kernels._cu_seqlens_to_token_arrays
 
 
@@ -217,6 +219,88 @@ class CuSeqlensTokenArraysTest(unittest.TestCase):
         self.assertEqual(s.shape[0], 64)
         self.assertTrue((s == 0).all(), f"unexpected seq_start: {s[:8].tolist()}")
         self.assertTrue((e == 64).all(), f"unexpected seq_end: {e[:8].tolist()}")
+
+
+class DenseSinkFoldTest(unittest.TestCase):
+    """Fold the per-head sink logit into the dense QK stats vs a materialized ref."""
+
+    ATOL = 2e-2
+    RTOL = 2e-2
+
+    def _bhsd(self, seq_len=96, num_heads=4, head_dim=64, seed=3):
+        torch.manual_seed(seed)
+        q = torch.randn(1, num_heads, seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(1, num_heads, seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+        return q, k
+
+    def _reference(self, q, k, sink):
+        _, num_heads, seq_len, head_dim = q.shape
+        logits = torch.matmul(q.float(), k.float().transpose(-2, -1)) / head_dim**0.5
+        logits = logits.masked_fill(
+            torch.triu(torch.ones(seq_len, seq_len, device=q.device, dtype=torch.bool), 1), float("-inf")
+        )
+        sink_col = sink.reshape(1, num_heads, 1, 1).expand(1, num_heads, seq_len, 1).float()
+        ext = torch.cat([logits, sink_col], dim=-1)
+        probs = torch.softmax(ext, dim=-1)
+        ent = -(probs * torch.log_softmax(ext, dim=-1))
+        ent = torch.where(torch.isfinite(ext), ent, torch.zeros_like(ent))
+        return ent.sum(-1).mean(-1).flatten(), probs[..., 0].mean(-1).flatten()
+
+    def test_fold_matches_materialized_reference(self):
+        q, k = self._bhsd()
+        sink = torch.tensor([0.5, -1.0, 2.0, 0.0], device="cuda")
+        out = compute_qk_stats_triton(q.contiguous(), k.contiguous(), causal=True, attn_sink=sink)
+        ref_ent, ref_sink = self._reference(q, k, sink)
+        for h in range(ref_ent.numel()):
+            self.assertAlmostEqual(
+                out["entropy_per_head"].float().flatten()[h].item(),
+                ref_ent[h].item(),
+                delta=self.ATOL + self.RTOL * abs(ref_ent[h].item()),
+            )
+            self.assertAlmostEqual(
+                out["sink_per_head"].float().flatten()[h].item(),
+                ref_sink[h].item(),
+                delta=self.ATOL + self.RTOL * abs(ref_sink[h].item()),
+            )
+
+    def test_none_sink_matches_baseline(self):
+        q, k = self._bhsd()
+        out = compute_qk_stats_triton(q.contiguous(), k.contiguous(), causal=True, attn_sink=None)
+        ref = compute_qk_stats_pytorch(q.contiguous(), k.contiguous(), causal=True, attn_sink=None)
+        self.assertAlmostEqual(out["entropy_global"].item(), ref["entropy_global"].item(), delta=self.ATOL)
+
+    def test_large_sink_collapses_entropy(self):
+        q, k = self._bhsd()
+        big = torch.full((4,), 50.0, device="cuda")
+        out = compute_qk_stats_triton(q.contiguous(), k.contiguous(), causal=True, attn_sink=big)
+        self.assertLess(out["entropy_global"].item(), 1e-2)
+        self.assertLess(out["sink_global"].item(), 1e-2)
+
+
+class PackedSinkFoldTest(unittest.TestCase):
+    """Fold the sink logit into the packed (THD) QK stats vs the pytorch reference."""
+
+    ATOL = 2e-2
+    RTOL = 2e-2
+
+    def _qk(self, seed=5):
+        q, k, cu = _make_packed_qk([48, 80, 64], num_heads=4, head_dim=64, seed=seed)
+        return (*_to_htd(q, k), cu)
+
+    def test_fold_matches_reference(self):
+        qh, kh, cu = self._qk()
+        for sink in (torch.tensor([0.5, -1.0, 2.0, 0.0], device="cuda"), None):
+            tri = compute_qk_stats_triton_packed(qh, kh, cu, causal=True, attn_sink=sink)
+            ref = compute_qk_stats_pytorch_packed(qh, kh, cu, causal=True, attn_sink=sink)
+            for key in ("entropy_global", "sink_global"):
+                t, r = tri[key].float().item(), ref[key].float().item()
+                self.assertAlmostEqual(t, r, delta=self.ATOL + self.RTOL * abs(r), msg=f"{key}: {t} vs {r}")
+
+    def test_large_sink_collapses_entropy(self):
+        qh, kh, cu = self._qk()
+        tri = compute_qk_stats_triton_packed(qh, kh, cu, causal=True, attn_sink=torch.full((4,), 50.0, device="cuda"))
+        self.assertLess(tri["entropy_global"].item(), 1e-2)
+        self.assertLess(tri["sink_global"].item(), 1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_triton_qk_kernel.py
+++ b/tests/test_triton_qk_kernel.py
@@ -1,0 +1,223 @@
+"""Correctness tests for the packed (THD) QK-stats Triton kernel.
+
+Compares ``qk_stats_packed_kernel`` (via ``compute_qk_stats_triton_packed``)
+against a row-first PyTorch reference, and unit-tests the sync-free
+``_cu_seqlens_to_token_arrays`` helper.
+
+Mean uses row-first semantics (mean over valid rows of each row's mean logit)
+on BOTH the Triton and PyTorch packed paths, so ``mean_global`` is asserted
+directly — no need to skip it.
+"""
+
+import importlib
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+try:
+    import torch
+
+    triton = importlib.import_module("triton")
+except Exception as exc:
+    raise unittest.SkipTest(f"torch or triton unavailable: {exc}") from exc
+
+if not torch.cuda.is_available():
+    raise unittest.SkipTest("CUDA required for Triton kernel tests")
+
+_kernels = importlib.import_module("internal_medicine.backends.megatron.triton_kernels")
+compute_qk_stats_triton_packed = _kernels.compute_qk_stats_triton_packed
+compute_qk_stats_pytorch_packed = _kernels.compute_qk_stats_pytorch_packed
+compute_qk_stats_packed = _kernels.compute_qk_stats_packed
+_cu_seqlens_to_token_arrays = _kernels._cu_seqlens_to_token_arrays
+
+
+def _make_packed_qk(seq_lengths, num_heads, head_dim, dtype=torch.bfloat16, device="cuda", seed=1):
+    """Build packed [T, H, D] q/k and int32 cu_seqlens from a list of seq lengths."""
+    torch.manual_seed(seed)
+    total = sum(seq_lengths)
+    q = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device)
+    offsets = [0] + list(torch.tensor(seq_lengths).cumsum(0).tolist())
+    cu_seqlens = torch.tensor(offsets, dtype=torch.int32, device=device)
+    return q, k, cu_seqlens
+
+
+def _to_htd(q, k):
+    return q.permute(1, 0, 2).contiguous(), k.permute(1, 0, 2).contiguous()
+
+
+class TritonPackedKernelCorrectnessTest(unittest.TestCase):
+    ATOL = 1e-2
+    RTOL = 1e-2
+
+    def _assert_close(self, triton_out, ref_out, keys, tag=""):
+        for key in keys:
+            t = triton_out[key].float().item()
+            r = ref_out[key].float().item()
+            self.assertAlmostEqual(
+                t,
+                r,
+                delta=self.ATOL + self.RTOL * abs(r),
+                msg=f"{tag} {key}: triton={t:.6f} ref={r:.6f}",
+            )
+
+    _ALL = ("max_global", "mean_global", "entropy_global", "sink_global")
+
+    def test_uniform_sequences_causal(self):
+        q, k, cu = _make_packed_qk([64, 64, 64], num_heads=4, head_dim=64)
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=True),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=True),
+            self._ALL,
+            tag="3x64_causal",
+        )
+
+    def test_variable_length_sequences(self):
+        q, k, cu = _make_packed_qk([32, 80, 48], num_heads=4, head_dim=64)
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=True),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=True),
+            self._ALL,
+            tag="var_len_causal",
+        )
+
+    def test_head_dim_128(self):
+        q, k, cu = _make_packed_qk([48, 80], num_heads=4, head_dim=128)
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=True),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=True),
+            self._ALL,
+            tag="head_dim_128",
+        )
+
+    def test_single_sequence_causal(self):
+        # A single packed sequence: packed-triton must match its row-first
+        # PyTorch reference (this also exercises the no-boundary fast path).
+        seq_len, num_heads, head_dim = 128, 4, 64
+        torch.manual_seed(2)
+        q = torch.randn(seq_len, num_heads, head_dim, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(seq_len, num_heads, head_dim, dtype=torch.bfloat16, device="cuda")
+        cu = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=True),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=True),
+            self._ALL,
+            tag="single_seq_causal",
+        )
+
+    def test_block_boundary_straddle(self):
+        # A sequence boundary that falls inside a BLOCK_M=64 block: seq 1 ends
+        # at token 50, seq 2 starts at 50 — both live in block [0:64].
+        q, k, cu = _make_packed_qk([50, 78], num_heads=4, head_dim=64)
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=True),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=True),
+            self._ALL,
+            tag="boundary_straddle",
+        )
+
+    def test_non_causal(self):
+        q, k, cu = _make_packed_qk([64, 64], num_heads=4, head_dim=64)
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=False),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=False),
+            self._ALL,
+            tag="non_causal",
+        )
+
+    def test_non_causal_unequal_lengths(self):
+        # Unequal sequence lengths, non-causal: row counts differ across rows so
+        # row-first mean is a non-trivial average — a good stress for the reduce.
+        q, k, cu = _make_packed_qk([32, 96], num_heads=4, head_dim=64)
+        qh, kh = _to_htd(q, k)
+        self._assert_close(
+            compute_qk_stats_triton_packed(qh, kh, cu, causal=False),
+            compute_qk_stats_pytorch_packed(qh, kh, cu, causal=False),
+            self._ALL,
+            tag="non_causal_unequal",
+        )
+
+    def test_padded_total_tokens(self):
+        # total_tokens (tensor T dim) > cu_seqlens[-1]: padding tokens must not
+        # contribute to any accumulator and must not cause OOB reads.
+        seq_lengths = [48, 64]
+        real_T = sum(seq_lengths)  # 112
+        padded_T = 128  # next multiple of BLOCK_M=64
+        torch.manual_seed(5)
+        q = torch.randn(padded_T, 4, 64, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(padded_T, 4, 64, dtype=torch.bfloat16, device="cuda")
+        cu = torch.tensor([0, 48, 112], dtype=torch.int32, device="cuda")
+
+        # Reference uses only real tokens; triton sees the padded tensor.
+        ref_q, ref_k = _to_htd(q[:real_T], k[:real_T])
+        ref_out = compute_qk_stats_pytorch_packed(ref_q, ref_k, cu, causal=True)
+
+        qh, kh = _to_htd(q, k)
+        triton_out = compute_qk_stats_triton_packed(qh, kh, cu, causal=True)
+        self._assert_close(triton_out, ref_out, self._ALL, tag="padded_T")
+
+    def test_gqa_packed_entry_point(self):
+        # GQA via the entry point: num_q_heads=8, num_k_heads=2 (repeat_interleave).
+        q_thd, _, cu = _make_packed_qk([48, 80], num_heads=8, head_dim=64)
+        torch.manual_seed(8)
+        k_gqa = torch.randn(q_thd.shape[0], 2, 64, dtype=torch.bfloat16, device="cuda")
+        out_triton = compute_qk_stats_packed(q_thd, k_gqa, cu, causal=True, use_triton=True)
+        out_ref = compute_qk_stats_packed(q_thd, k_gqa, cu, causal=True, use_triton=False)
+        self._assert_close(out_triton, out_ref, self._ALL, tag="gqa_packed")
+
+
+class CuSeqlensTokenArraysTest(unittest.TestCase):
+    """Unit tests for _cu_seqlens_to_token_arrays (GPU-only, no kernel launch)."""
+
+    def test_no_padding_single_sequence(self):
+        cu = torch.tensor([0, 64], dtype=torch.int32, device="cuda")
+        s, e = _cu_seqlens_to_token_arrays(cu, 64)
+        self.assertEqual(s.shape[0], 64)
+        self.assertTrue((s == 0).all(), "all seq_start should be 0")
+        self.assertTrue((e == 64).all(), "all seq_end should be 64")
+
+    def test_no_padding_multiple_sequences(self):
+        cu = torch.tensor([0, 32, 80, 128], dtype=torch.int32, device="cuda")
+        s, e = _cu_seqlens_to_token_arrays(cu, 128)
+        self.assertEqual(s.shape[0], 128)
+        self.assertTrue((s[:32] == 0).all())
+        self.assertTrue((e[:32] == 32).all())
+        self.assertTrue((s[32:80] == 32).all())
+        self.assertTrue((e[32:80] == 80).all())
+        self.assertTrue((s[80:] == 80).all())
+        self.assertTrue((e[80:] == 128).all())
+        pad_mask = (s == 0) & (e == 0)
+        self.assertFalse(pad_mask.any(), "no tokens should be zeroed when total_tokens==cu[-1]")
+
+    def test_padded_tokens_are_zeroed(self):
+        # real_tokens=112, total_tokens=128 — 16 padding slots.
+        cu = torch.tensor([0, 48, 112], dtype=torch.int32, device="cuda")
+        s, e = _cu_seqlens_to_token_arrays(cu, 128)
+        self.assertEqual(s.shape[0], 128)
+        self.assertTrue((s[:48] == 0).all())
+        self.assertTrue((e[:48] == 48).all())
+        self.assertTrue((s[48:112] == 48).all())
+        self.assertTrue((e[48:112] == 112).all())
+        self.assertTrue((s[112:] == 0).all(), f"padding seq_start not zero: {s[112:].tolist()}")
+        self.assertTrue((e[112:] == 0).all(), f"padding seq_end not zero: {e[112:].tolist()}")
+
+    def test_zero_length_sequence_skipped(self):
+        # cu = [0, 0, 64] — zero-length first sequence must not pollute seq 1.
+        cu = torch.tensor([0, 0, 64], dtype=torch.int32, device="cuda")
+        s, e = _cu_seqlens_to_token_arrays(cu, 64)
+        self.assertEqual(s.shape[0], 64)
+        self.assertTrue((s == 0).all(), f"unexpected seq_start: {s[:8].tolist()}")
+        self.assertTrue((e == 64).all(), f"unexpected seq_end: {e[:8].tolist()}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ---
  ## 概述

  本 MR 收拢三块 internal_medicine 监控改动，均已本地验证 + 单测覆盖：
  
  1. **moe 负载均衡熵**（`758cf9e`）—— 新增 `load_balance_entropy_norm` =
  H(p)/log(E)
     与 `load_effective_experts` = exp(H)，比 max/min
  比值更平滑、不被单个死专家主导。
  2. **qk THD packed 支持**（`ec4ab24`）—— packed(THD) 序列按 `cu_seqlens`
  尊重每条
     文档边界算 QK 统计，不再把整条打包行当一个序列；sink 列取每序列自己的
  start。
  3. **qk learnable sink 折叠**（`d174747`，本次修复）—— 见下。
  
  ## 问题（本次 fix）
  
  `softmax_type=learnable`/`off-by-one` 的模型每层 attention 有一个可学习
  per-head
  sink 列 `core_attention.softmax_offset`，它是 softmax 分母的一部分。但
  megatron 后端
  此前算 entropy/sink 时只对真实 key 归一化，**没算这个 sink 
  列**，导致该配方（如
  recipe_0806）下上报的 entropy/sink 
  相对模型真实分布有系统性偏差。paddlefleet 后端
  已修（`a0b3f90`/`b1dec28`），megatron 未跟上。
  
  ## 改动
  
  - **core kernel**：`qk_stats_kernel`(稠密) 与 
  `qk_stats_packed_kernel`(THD) 加
    `attn_sink_ptr` + `HAS_SINK`，复用 partial kernel 已验证的在线 softmax
  折叠数学
    （h 用旧 d_i 迁移，只改分母/熵，不动 max/mean/sink 分子）。
  - **megatron/triton_kernels**：`compute_qk_stats(_packed)` 及
  triton/pytorch 分支
    串接 `attn_sink`；None-fallback 传零 buffer + `HAS_SINK=False`。
  - **megatron/qk_monitor**：hook 读 
  `module.softmax_offset`（`.detach()`，无 D2H sync），
    传入 compute。
  - 补 dense/packed sink-fold 对照测试；README 指标表补 sink 折叠说明。

  ## 影响面
  
  - 只影响 megatron 后端 learnable/off-by-one softmax 模型的 qk 
  entropy/sink 数值；
    **vanilla softmax（offset=None）行为完全不变**。
  - 不改 metric schema、无 hook 内 collective、无 D2H sync（符合 
  monitor-hook-perf-rules）。
  - paddlefleet 后端零接触（用的是另外两个 kernel，未被改动）。
  
  ## 验证
  
  - 子仓单测全绿：ruff/pre-commit Passed；qk kernel + megatron + core 
  套件通过，
    新增 sink-fold 用例（triton vs 物化 reference，含 none/large-sink 
  边界）。
  - 端到端 smoke：l12 + recipe_0806，8×H800，FusedAttention，0 OOM/0 
  报错；
    修复后同层 sink 一致性下降（分母含 sink 列），符合预期。
  - 数值自洽：moe `effective_experts ≈ exp(entropy_norm·ln512)` 误差 
  <0.1。
  
  ---