### PR TITLE
refactor(mhc_health): 下线 composite amax-gain 与 amax_gain_bwd（paddlefl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ setup_internal_medicine()
 ```
 
 - `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health`
-- `global_idx`: 考虑 PP (Pipeline Parallelism) 的全局层索引 = `pp_rank × local_layers + local_idx`
+- `global_idx`: 全局层索引。优先取模块自带的 `layer.layer_number`（0-based 全局编号）；取不到时回退到
+  `pp_rank × local_layers + local_idx`。`num_empty_layers_add_in_head > 0` 时所有层号整体偏移该值，看板对号要减掉
 - `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路
 
 ---
@@ -350,7 +351,7 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
 以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。
 只在模型开启 mHC 层时生效——mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
-彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 12 个指标，
+彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 9 个指标，
 指标名以 `attn_` / `mlp_` 前缀区分；除 `branch_residual_share_max` 取极值外，其余按 token/batch 求均值。
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
@@ -363,15 +364,11 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 | 6 | `{c}_h_post_token_std` | `mhc_health/layer_{i}/{c}_h_post_token_std` | `std_t(mean_i h_post)` | 每层+全局 | 门控对输入的区分度，→0 = 退化成常数 |
 | 7 | `{c}_branch_residual_share` | `mhc_health/layer_{i}/{c}_branch_residual_share` | `mean_t(b / (b + r))`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F` | 每层+全局 | **本层是否还在写入残差流**，值域 `[0, 1]`：0.5 = 两项等量 |
 | 8 | `{c}_branch_residual_share_max` | `mhc_health/layer_{i}/{c}_branch_residual_share_max` | 同上取最坏 token | 每层+全局 | 单 token 被分支主导的程度（贴 1 = 存在近零残差 token） |
-| 9 | `{c}_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ij\|)` | 每层+全局 | 单层前向最坏放大 (≈1) |
-| 10 | `{c}_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_amax_gain_bwd` | `mean_t(max_j \|Σ_i h_res_ij\|)` | 每层+全局 | 单层反向最坏放大 (≈1) |
-| 11 | `{c}_composite_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd` | 复合映射 `∏ h_res` 的行和 | 每层+全局 | 跨层累积前向放大 |
-| 12 | `{c}_composite_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd` | 复合映射 `∏ h_res` 的列和 | 每层+全局 | 跨层累积反向放大 |
+| 9 | `{c}_amax_gain_fwd` | `mhc_health/global_{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ij\|)` | **仅全局** | Sinkhorn 收敛哨兵（恒 ≈1，见下） |
 
-`{c}` ∈ `{attn, mlp}`。复合映射为本 pipeline stage / VPP chunk 内 `h_res` 的累乘（每次 forward 在本 stage 首个
-hc 模块处重置）——PP=1 时精确，PP>1 时为 stage 局部近似。
+`{c}` ∈ `{attn, mlp}`。
 
-指标 1~6 与 9~12 来自包裹 `compute_mappings`（`h_pre` 不在 `forward` 返回值里，只能从这里拿到真实映射）；
+指标 1~6 与 9 来自包裹 `compute_mappings`（`h_pre` 不在 `forward` 返回值里，只能从这里拿到真实映射）；
 指标 7~8 需要 sublayer 输出，只有两项合并处才同时可见，故额外包裹 `fused_h_res_h_post_bda`，且指标从**入参**
 推导，因此 fused 快路径与带 dropout 的顺序路径口径一致。两个范数都是精确值但不 materialize 任何
 `[tokens, n, C]` 中间张量：branch 项是外积，`‖h_post_t ⊗ x_t‖_F = ‖h_post_t‖₂·‖x_t‖₂`；residual 项用
@@ -391,7 +388,9 @@ hc 模块处重置）——PP=1 时精确，PP>1 时为 stage 局部近似。
   - `stream_concentration`≈n → **退化为单流**，该层放弃了多流结构，`num_residual_streams` 的开销在这些层上没有
     收益；可考虑逐层配置 n。注意这未必是病：HC 允许不同层使用不同的流组合，需结合「是否总是同一条流」判断。
 - `h_post_token_std`→0 → 门控丢失对 token 的区分度，从动态门退化成常数标量。
-- `amax_gain_fwd/bwd` 偏离 1.0 → Sinkhorn 未收敛或初始化异常；复合映射沿深度偏离 1.0 → 残差流放大/收缩。
+- `amax_gain_fwd` 偏离 1.0 → Sinkhorn 未收敛或初始化异常。它按构造恒 ≈1（实测 0.99999905，动态范围
+  0.0001%），**只当哨兵用，不要拿它做诊断**；也因此只输出 `global_*` 而不占逐层曲线（`Probe.GLOBAL_ONLY`
+  机制：逐层值照常累加、global 从中派生，只是不写日志，所以任一层漂移仍会被全局曲线捕获）。
 
 ---
 

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -47,13 +47,13 @@ internal_medicine_monitors:
 
 ### VRAM 安全（无泄漏）
 
-跨调用状态仅有 `self._composite`（每 chunk 一个小 `[s*b, n, n]` 张量）与固定的 0 维累加器。规则：
+wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则：
 
-- 捕获后立即对 `h_pre/h_post/h_res` `.detach()`，并在 `torch.no_grad()` 下做全部指标/复合计算——否则一个仍带梯度的
+- 捕获后立即对 `h_pre/h_post/h_res` `.detach()`，并在 `no_grad()` 下做全部指标计算——否则一个仍带梯度的
   张量会通过反向把整层 autograd graph 钉住（大泄漏）。
 - wrapper 原样返回 `out`，除 0 维标量外不保留任何对它/其视图的引用。
-- 复合映射 seed 用 `hb.clone()`（而非 `h_res` 的 reshape 视图），使 slot 不会 alias 模型的 `h_res` 存储。
-- `step()` 每步清空 `self._composite`，`remove_hooks()` 一并清空。
+- `remove_hooks()` 恢复原始方法，不残留模块引用。
+
 
 热路径纪律见 `.claude/skills/monitor-hook-perf-rules`：hook 内无 D2H 同步、无集合通信，schema 在 `allocate_buffers`
 前声明。TP 不沿 `n` 切分映射，故无需 hook 内通信；跨 rank 归约在 flush 时由 `gather_and_aggregate` 完成（mean）。
@@ -62,7 +62,7 @@ internal_medicine_monitors:
 
 ## 监控指标
 
-每个 hc 模块产出 12 个指标（megatron 后端 8 个，「结构指标」一节的 4 个为 paddlefleet 独有），指标名以
+每个 hc 模块产出 9 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 8 个），指标名以
 `attn_` / `mlp_` 前缀区分，除 `branch_residual_share_max` 取极值外全部按 token/batch 求均值
 （并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，`{c}` ∈ `{attn, mlp}`；
 对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
@@ -93,42 +93,45 @@ internal_medicine_monitors:
 残差项用 `[tokens, n, n]` 的 Gram/mix 收缩得到，`n = 4` 时开销约为本层投影的 `C/n²` 分之一。
 分支项在 dropout **之前**测量，`hidden_dropout_prob > 0` 的配置会略微高估分支幅度（此处预训练配置为 0）。
 
-### amax-gain（h_res 与复合映射）
+### amax-gain（Sinkhorn 收敛哨兵）
 
-paper 定义的最坏情况增益：矩阵的**最大绝对行和**界定前向传播的最坏放大，**最大绝对列和**界定反向传播的最坏放大。
-对每个 token 的 `n×n` 矩阵计算，再对 token 求均值：
+paper 定义的最坏情况增益：矩阵的**最大绝对行和**界定前向传播的最坏放大。对每个 token 的 `n×n` 矩阵计算，
+再对 token 求均值：
 
 ```
-amax_gain_fwd = mean_t( max_i | Σ_j  M_ij | )      # 行和（forward）
-amax_gain_bwd = mean_t( max_j | Σ_i  M_ij | )      # 列和（backward）
+amax_gain_fwd = mean_t( max_i | Σ_j  h_res_ij | )      # 行和（forward）
 ```
 
-| 指标 | `M` 取值 | 诊断意义 |
-|------|----------|----------|
-| `{c}_amax_gain_fwd` | 本层 `h_res` | 单层前向最坏放大（双随机 → ≈1.0） |
-| `{c}_amax_gain_bwd` | 本层 `h_res` | 单层反向最坏放大（≈1.0） |
-| `{c}_composite_amax_gain_fwd` | 复合映射 `M_k = h_res_k @ M_{k-1}` | 跨层累积前向放大 |
-| `{c}_composite_amax_gain_bwd` | 复合映射 | 跨层累积反向放大 |
+| 指标 | 诊断意义 |
+|------|----------|
+| `{c}_amax_gain_fwd` | Sinkhorn 是否收敛 / 有无 NaN。双随机 → 恒 ≈1.0。**只输出 `global_*`** |
 
-单层 `h_res` 经 Sinkhorn 投影为双随机矩阵（行/列和 ≈ 1），故单层 amax-gain ≈ 1.0；复合映射的增益随深度偏离 1.0，
-正是残差流放大/收缩的信号。
+单层 `h_res` 经 Sinkhorn 投影为双随机矩阵，所以这个值**按构造恒为 1**——实测 0.99999905，动态范围 0.0001%，
+偏离量全部来自 Sinkhorn 的 `eps = 1e-6`。它只能当哨兵，不要拿来做诊断。也正因如此它走 `Probe.GLOBAL_ONLY`：
+逐层值照常累加、`global_*` 从中派生，只是不写进日志——任一层漂移仍会把全局曲线带走，但看板上只有 2 条线
+而不是 13 层 × 2 组件。
 
-### 复合映射（composite mapping）
+### 已下线：amax_gain_bwd 与复合映射
 
-复合映射是本 pipeline stage / VPP chunk 内、按 forward 执行顺序（attn→mlp，逐层递增）对 `h_res` 的累乘，每次 forward
-在本 stage 首个 hc 模块（最低层 attn）处重置。
+- `{c}_amax_gain_bwd`（最大绝对列和）：Sinkhorn 的最后一步是列归一（`hyper_connection.py` 的迭代循环），
+  列和被钉在 1，实测四条 run、每一层都与 `amax_gain_fwd` **逐位相同**。
+- `{c}_composite_amax_gain_fwd` / `_bwd`（`M_k = h_res_k @ M_{k-1}` 的行/列和）：双随机矩阵之积仍是双随机矩阵，
+  复合增益同样恒为 1（实测 0.99999~0.999975）。更糟的是它依赖执行顺序：开 `recompute_granularity: full` 时
+  采集实际发生在反向重放，累乘变成逆序——实测每层累乘因子数为 `1, 25.6, 23.6, …, 2.9`，而正序应为
+  `1, 3, 5, …, 25.8`（关掉 recompute 的对照组给出了后者）。让它与顺序无关需要把每层 `h_res` 在整个 step 内
+  驻留（43 层约 45MB 常驻显存），为一个常数付这个代价不值得。
 
-**局限**：在流水并行（PP>1）下，复合映射只跨越本 stage 局部的层，并非整网的全局累乘；不同 stage/chunk 的逐层键因
-层号不同不会冲突，但自动派生的 `global_*` 复合均值会混合深浅复合值——因此 composite 的**逐层视图**更有意义。PP=1 时精确。
-每 chunk 独立 slot，避免后一 chunk 的层污染前一 chunk 的累乘。
+要真正观测残差流放大，应监控 **Sinkhorn 收敛残差**（行和与 1 的偏差）或 `h_res` 的谱性质，两者都尚未实现。
 
 ---
 
 ## 与 microbatch / 激活重算的交互
 
-- 每个梯度累积 microbatch 都会按序重新调用所有 hc 模块；chunk root 先触发并重置复合映射，故复合映射按 microbatch 正确、
-  不跨 microbatch 泄漏。
-- 整个捕获受 `_should_monitor()` 门控；监控步内所有 wrapper 都触发（root 重置 → 同一 forward 内有序 bmm 累积），故复合
-  状态自洽；非监控步不触发，下一监控步的 root 重置会重新 seed。
-- `_should_monitor()` 要求 grad enabled，故若外层 layer 被整体激活重算，仅 grad-enabled 的那次正向记录；`compute_mappings`
-  本身不被 checkpoint，不会重复触发。
+- 每个梯度累积 microbatch 都会按序重新调用所有 hc 模块，每次调用独立记录一条样本，flush 时对 microbatch 求均值。
+- 整个捕获受 `_should_monitor()` 门控；非监控步只是 `orig(x)` + 一次布尔判断。
+- `_should_monitor()` 要求 grad enabled。这个判据的名字暗示"跳过重算"，**实际语义相反**：recompute 的真前向跑在
+  `no_grad` 下，反向重放才开 grad，所以采集实际发生在反向重放。数值不受影响（重算确定性），但依赖执行顺序的指标
+  会出错——这是复合映射被下线的原因之一。
+- 这个判据留着是因为它顺带保证了"每个模块每 step 只取一条样本"：mHC 的 hyper-connection 在一次前向里会被进入
+  两次（`high_precision_mhc` 打开时 AMP 关闭的 fp32 路径 + bf16 路径），两条都记会稀释所有均值（实测单层
+  `amax_gain` 偏离量减半、门控 std 偏移 1~3%）。详见 README「已知限制：采集口径依赖 grad 判据」。

--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -35,12 +35,14 @@ class PaddleProbe(Probe):
         # global_key → (聚合方式, [对应的 layer keys])，flush 时从 layer 推导 global
         self._layer_metric_groups: dict[str, tuple[str, list[str]]] = {}
         self._layer_metric_keys: set[str] = set()  # 所有 per-layer key，用于 flush 时判断是否输出
+        # GLOBAL_ONLY_METRICS 对应的 per-layer key：仍然累加（global 要从它们推导），
+        # 但不写进日志。给"守门型"指标用——恒定值不值得占 N 层 × M 组件条曲线。
+        self._global_only_layer_keys: set[str] = set()
         self._disabled_keys: set[str] = set()  # log_global=False 时被禁用的 global keys
         self._mtp_layer_ids: set[int] = set()
         self._buffers_allocated = False
 
     def _should_monitor(self) -> bool:
-        # recompute 阶段 grad 被禁用，跳过以避免重复计数和访问已释放的参数
         if not paddle.is_grad_enabled():
             return False
         return super()._should_monitor()
@@ -189,6 +191,8 @@ class PaddleProbe(Probe):
             if layer_key not in all_declared:
                 self.declare_mean(layer_key)
         self._layer_metric_keys.add(layer_key)
+        if metric_name in self.GLOBAL_ONLY:
+            self._global_only_layer_keys.add(layer_key)
         if not self.log_global:
             return
         # 注册 global 分组: flush 时从这些 layer keys 聚合出 global 值
@@ -213,6 +217,12 @@ class PaddleProbe(Probe):
         else:
             self.record_mean(layer_key, val)
 
+    def _emits_layer_key(self, key: str) -> bool:
+        """per-layer key 是否写进日志（global 派生不受此影响）。"""
+        if key not in self._layer_metric_keys:
+            return True  # 显式 declare 的非逐层 key
+        return self.log_per_layer and key not in self._global_only_layer_keys
+
     def _flush_gpu_buffer(self) -> dict[str, float]:
         """单次批量 D2H：收集所有累加器 → 推导 global → stack→cpu→tolist → 重置。"""
         keys: list[str] = []
@@ -223,7 +233,7 @@ class PaddleProbe(Probe):
             cnt = self._gpu_cnt[k]
             if cnt == 0:
                 continue
-            if self.log_per_layer or k not in self._layer_metric_keys:
+            if self._emits_layer_key(k):
                 keys.append(k)
                 tensors.append(self._gpu_acc[k] / cnt)
 
@@ -231,7 +241,7 @@ class PaddleProbe(Probe):
         for k in self._max_keys:
             if self._gpu_cnt[k] == 0:
                 continue
-            if self.log_per_layer or k not in self._layer_metric_keys:
+            if self._emits_layer_key(k):
                 keys.append(k)
                 tensors.append(self._gpu_acc[k].clone())
 
@@ -239,7 +249,7 @@ class PaddleProbe(Probe):
         for k in self._min_keys:
             if self._gpu_cnt[k] == 0:
                 continue
-            if self.log_per_layer or k not in self._layer_metric_keys:
+            if self._emits_layer_key(k):
                 keys.append(k)
                 tensors.append(self._gpu_acc[k].clone())
 

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -7,23 +7,20 @@ per-token mappings of every ``HyperConnectionModule`` in an mHC
 - ``h_pre`` / ``h_post`` — the aggregation / expansion gates: mean and std, plus
   the stream concentration and token sensitivity of ``h_post``.
 - ``h_res``              — the doubly-stochastic residual-mixing matrix: the
-  paper's ``amax_gain`` forward (max-abs row sum) and backward (max-abs column
-  sum), computed both on this layer's ``h_res`` and on the running **composite
-  mapping** (cumulative product of ``h_res`` across the layers local to this
-  pipeline stage / VPP chunk).
+  paper's ``amax_gain`` (max-abs row sum), kept as a NaN / Sinkhorn-divergence
+  sentinel rather than as a diagnostic (see the note below).
 - the **two update terms** of ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``:
   their relative magnitude, i.e. how much this layer still writes into the
   residual streams.
 
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 12
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 9
 series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
     {attn,mlp}_h_post_mean  {attn,mlp}_h_post_std
     {attn,mlp}_h_post_stream_concentration  {attn,mlp}_h_post_token_std
     {attn,mlp}_branch_residual_share  {attn,mlp}_branch_residual_share_max
-    {attn,mlp}_amax_gain_fwd            {attn,mlp}_amax_gain_bwd
-    {attn,mlp}_composite_amax_gain_fwd  {attn,mlp}_composite_amax_gain_bwd
+    {attn,mlp}_amax_gain_fwd
 
 ``h_pre`` is not part of ``HyperConnectionModule.forward``'s return, so we
 cannot use a forward hook. Instead we wrap the module's ``compute_mappings``
@@ -32,6 +29,25 @@ The branch/residual ratio needs the sublayer output too, which only exists where
 the two terms are combined, so ``fused_h_res_h_post_bda`` is wrapped as well.
 Everything is detached and computed under ``no_grad`` (see the VRAM-safety
 notes on the hook).
+
+Retired metrics (do not re-add without a new argument):
+
+- ``composite_amax_gain_fwd`` / ``_bwd`` — the cumulative product of ``h_res``
+  across layers. A product of doubly-stochastic matrices is itself doubly
+  stochastic, so the composite gain is **1 by construction**; measured range was
+  0.99999 ~ 0.999975, i.e. pure Sinkhorn ``eps`` accumulation. Worse, the value
+  is order-dependent: it was built in execution order, which under recompute is
+  the reverse-layer backward replay (measured: per-layer factor counts came out
+  ``1, 25.6, 23.6, ..., 2.9`` instead of ``1, 3, 5, ..., 25.8``). Making it
+  order-proof needs the per-layer ``h_res`` resident for the whole step
+  (~45MB at 43 layers), which is not worth paying for a constant.
+- ``amax_gain_bwd`` (max-abs **column** sum) — Sinkhorn's last step is a column
+  normalization, so columns are pinned to 1 by construction. Measured bit-equal
+  to ``amax_gain_fwd`` on every layer of four runs.
+
+To actually watch for residual-stream amplification, monitor Sinkhorn
+convergence residual (row sums vs 1) or the spectrum of ``h_res`` — neither is
+implemented yet.
 
 The monitor is a hard no-op unless the model actually uses the mHC layer: if
 the mHC classes cannot be imported, or no ``HyperConnectionTransformerLayer``
@@ -74,15 +90,18 @@ _METRIC_NAMES = (
     "branch_residual_share",
     "branch_residual_share_max",
     "amax_gain_fwd",
-    "amax_gain_bwd",
-    "composite_amax_gain_fwd",
-    "composite_amax_gain_bwd",
 )
 
 # Only the worst-token branch ratio keeps extremum semantics across
 # microbatches / layers / ranks; everything else is a mean. The name ends in
 # `_max`, so training_logs' suffix classifier agrees on the full key too.
 _MAX_METRICS = frozenset({"branch_residual_share_max"})
+
+# amax_gain_fwd is 1 by construction (Sinkhorn), so it is a gatekeeper for that
+# invariant rather than a per-layer diagnostic: one global curve per component
+# carries the same signal as 13 layers x 2 components of flat lines. Any layer
+# drifting still moves the global mean.
+_GLOBAL_ONLY_METRICS = frozenset({"amax_gain_fwd"})
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
@@ -95,9 +114,8 @@ def _iter_chunks(model):
     """Yield ``(chunk_id, chunk)`` pairs for VPP-aware discovery.
 
     PaddleFleet exposes VPP model chunks via ``_model_chunks`` on the pipeline
-    layer. When present, each chunk owns its own ``run_function`` and executes
-    in its own forward pass — so the running composite mapping must reset at
-    each chunk's first hc module, and never carry over.
+    layer; each chunk owns its own ``run_function`` and executes in its own
+    forward pass, so discovery has to walk all of them.
 
     Falls back to a single chunk ``(0, model)`` when no VPP chunking is present.
     """
@@ -135,14 +153,13 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         verbose: bool = False,
     ):
         self.MAX_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MAX_METRICS}
+        self.GLOBAL_ONLY = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _GLOBAL_ONLY_METRICS}
         super().__init__(
             log_per_layer=log_per_layer,
             log_global=log_global,
             monitor_interval=monitor_interval,
             verbose=verbose,
         )
-        # chunk_id -> running composite mapping [s*b, n, n], detached (no graph).
-        self._composite: dict[int, paddle.Tensor] = {}
         # (module, attribute name, original bound method) triples, for remove_hooks().
         self._wrapped: list[tuple[nn.Layer, str, object]] = []
 
@@ -150,8 +167,8 @@ class PaddleMHCHealthMonitor(PaddleProbe):
     # Discovery
     # ------------------------------------------------------------------
 
-    def _find_hc_modules(self, chunk, chunk_id: int):
-        """Return ``[(global_idx, comp, hc_module, chunk_id, is_root)]`` for one chunk.
+    def _find_hc_modules(self, chunk):
+        """Return ``[(global_idx, comp, hc_module)]`` for one chunk.
 
         Empty (auto-skip) when the mHC classes are unavailable or the chunk has
         no ``HyperConnectionTransformerLayer``. Uses ``isinstance`` against the
@@ -168,23 +185,17 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             return isinstance(layer, HyperConnectionTransformerLayer)
 
         monitor_layers = iter_monitor_layers(layers, matches, pp_rank=self.pp_rank)
-        entries: list[tuple[int, str, nn.Layer, int, bool]] = []
+        entries: list[tuple[int, str, nn.Layer]] = []
         # is_mtp so we can mark them for `_mtp` suffix in metric keys.
         mtp_layer_ids = [item.idx for item in monitor_layers if item.is_mtp]
         if mtp_layer_ids:
             self.mark_mtp_layers(mtp_layer_ids)
-        first_attn_seen = False
         for item in monitor_layers:
             for comp, attr in _COMPONENTS:
                 mod = getattr(item.layer, attr, None)
                 if not isinstance(mod, HyperConnectionModule):
                     continue
-                # Chunk root = the attn hc of the first monitored layer in this
-                # chunk's execution order; it resets the composite each forward.
-                is_root = comp == "attn" and not first_attn_seen
-                if is_root:
-                    first_attn_seen = True
-                entries.append((item.idx, comp, mod, chunk_id, is_root))
+                entries.append((item.idx, comp, mod))
         return entries
 
     # ------------------------------------------------------------------
@@ -206,12 +217,12 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         every ``declare_layer_metric`` call remains legal.
         """
         self._init_parallel_state()
-        all_targets: list[list[tuple[int, str, nn.Layer, int, bool]]] = []
-        for chunk_id, chunk in _iter_chunks(model):
-            entries = self._find_hc_modules(chunk, chunk_id=chunk_id)
+        all_targets: list[list[tuple[int, str, nn.Layer]]] = []
+        for _chunk_id, chunk in _iter_chunks(model):
+            entries = self._find_hc_modules(chunk)
             if not entries:
                 continue
-            for global_idx, comp, _, _, _ in entries:
+            for global_idx, comp, _ in entries:
                 for name in _METRIC_NAMES:
                     self.declare_layer_metric(global_idx, f"{comp}_{name}")
             all_targets.append(entries)
@@ -219,9 +230,9 @@ class PaddleMHCHealthMonitor(PaddleProbe):
 
     def _attach(self, all_targets):
         for entries in all_targets:
-            for layer_idx, comp, mod, chunk_id, is_root in entries:
+            for layer_idx, comp, mod in entries:
                 orig = mod.compute_mappings
-                mod.compute_mappings = self._make_capture(orig, layer_idx, comp, chunk_id, is_root)
+                mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
                 self._wrapped.append((mod, "compute_mappings", orig))
                 # The branch/residual ratio needs the sublayer output, which only
                 # exists at the point where the two update terms are combined.
@@ -242,50 +253,36 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         self._attach(all_targets)
 
     def remove_hooks(self):
-        # Restore the original bound methods and drop all cross-call state so
-        # the monitor holds no module references or composite tensors after
-        # teardown. ``del mod.<attr>`` removes the instance attribute and falls
-        # back to the class method; if that fails (e.g. slots), we re-bind the
-        # captured original.
+        # Restore the original bound methods so the monitor holds no module
+        # references after teardown. ``del mod.<attr>`` removes the instance
+        # attribute and falls back to the class method; if that fails (e.g.
+        # slots), we re-bind the captured original.
         for mod, attr, orig in self._wrapped:
             try:
                 delattr(mod, attr)
             except AttributeError:
                 setattr(mod, attr, orig)
         self._wrapped = []
-        self._composite.clear()
         super().remove_hooks()
-
-    def step(self):
-        super().step()
-        # Release the running composite between train steps so a [s*b, n, n]
-        # buffer never sits idle in VRAM; the root reseeds it next forward, so
-        # clearing is correctness-neutral.
-        self._composite.clear()
 
     # ------------------------------------------------------------------
     # Capture wrapper (the hot path)
     # ------------------------------------------------------------------
 
-    def _make_capture(self, orig, layer_idx: int, component: str, chunk_id: int, is_root: bool):
+    def _make_capture(self, orig, layer_idx: int, component: str):
         """Wrap ``compute_mappings`` to record metrics from its real return value.
 
         VRAM safety: the mappings arrive attached to the training autograd
-        graph; we ``.detach()`` them and do all metric/composite math under
-        ``no_grad`` so no stored tensor pins the graph through backward. The
-        composite slot holds one detached ``[s*b, n, n]`` tensor per chunk
-        (cloned on seed so it never aliases the model's ``h_res`` storage);
-        ``step()`` clears it.
+        graph; we ``.detach()`` them and do all metric math under ``no_grad`` so
+        no stored tensor pins the graph through backward. The wrapper keeps no
+        state across calls — a deliberate constraint, since a monitored module
+        may be entered more than once per step (recompute replay, and mHC's own
+        fp32 / bf16 paths), and any cross-call accumulator would then depend on
+        execution order.
         """
 
         def wrapped(x):
             out = orig(x)  # the real mappings the model consumes — returned unchanged
-            # Gate the whole capture: metrics are only recorded on monitored
-            # steps, and the composite is reset at the chunk root on each such
-            # step, so gating here keeps the composite self-consistent (root
-            # reset -> ordered bmm builds within one monitored forward).
-            # _should_monitor() also requires grad enabled, selecting the
-            # training (not a no-grad / recompute) forward.
             if not self._should_monitor():
                 return out
             try:
@@ -304,29 +301,9 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                     for name, value in h_post_structure_stats(h_post).items():
                         self.record_layer_metric(layer_idx, f"{component}_{name}", value)
 
+                    # Row sums of a Sinkhorn-projected h_res: 1 by construction,
+                    # so this is a NaN / divergence sentinel, not a diagnostic.
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-1))
-                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, axis=-2))
-
-                    # Composite mapping M_k = h_res_k @ M_{k-1} (per token).
-                    # h_res arrives as [..., n, n]; flatten leading dims to a
-                    # single batch axis for bmm.
-                    shape = h_res.shape
-                    n = shape[-1]
-                    hb = h_res.reshape([-1, n, n])
-                    prev = self._composite.get(chunk_id)
-                    # Reset at the chunk root each forward; also self-heal on
-                    # first fire / shape drift (variable s*b across
-                    # microbatches). identity @ h_res == h_res, so seed with
-                    # h_res; clone() so the slot owns a fresh buffer and never
-                    # pins the model's h_res storage.
-                    if is_root or prev is None or prev.shape != hb.shape:  # noqa: SIM108
-                        M = hb.clone()
-                    else:
-                        M = paddle.bmm(hb, prev)  # fresh tensor, no graph
-                    self._composite[chunk_id] = M
-
-                    self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_fwd", amax_gain(M, axis=-1))
-                    self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_bwd", amax_gain(M, axis=-2))
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMHCMonitor] Error layer {layer_idx}/{component}: {e}")
@@ -396,9 +373,7 @@ def setup_mhc_monitor(
     """Enable the mHC health monitor. No-op on any non-mHC model.
 
     Multi-chunk (VPP / interleaved 1F1B) safe: declares the schema across all
-    chunks before ``allocate_buffers`` locks it, then attaches. Each model
-    chunk gets its own composite slot so a later chunk's layers never
-    contaminate an earlier chunk's running product.
+    chunks before ``allocate_buffers`` locks it, then attaches.
     """
     # No-op guarantee #1: mHC classes unavailable -> touch nothing.
     if HyperConnectionTransformerLayer is None or HyperConnectionModule is None:

--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -28,6 +28,11 @@ class Probe(ABC):
     METRIC_PREFIX: str = ""
     MAX_AGGREGATED: set[str] = set()
     MIN_AGGREGATED: set[str] = set()
+    # Metric names whose per-layer series is accumulated (the global value is
+    # derived from it) but never written to the log. For "gatekeeper" metrics
+    # that are constant by construction and only speak when an invariant breaks:
+    # one global curve carries the same signal as N layers x M components.
+    GLOBAL_ONLY: set[str] = set()
 
     def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
         self.log_per_layer = log_per_layer

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -182,14 +182,14 @@ class MHCMonitorTest(unittest.TestCase):
                 n=n,
                 h_pre=paddle.full([s, b, n], 0.5),
                 h_post=paddle.ones([s, b, n]),
-                h_res=paddle.assign(ident),  # own storage so composite.clone can't alias
+                h_res=paddle.assign(ident),  # own storage, not a view of the shared eye
             )
 
         return FakeLayer(attn=make_hc(), mlp=make_hc())
 
     def _drive(self, targets, x_dim):
         # Fire each wrapped compute_mappings; grad is enabled by default in dygraph.
-        for _, _, mod, _, _ in targets:
+        for _, _, mod in targets:
             mod.compute_mappings(paddle.randn([4, 2, x_dim]))
 
     def _prepare_and_attach(self, monitor, model):
@@ -199,7 +199,7 @@ class MHCMonitorTest(unittest.TestCase):
         # Return a single flat list of entries for convenience.
         return [entry for chunk_entries in all_targets for entry in chunk_entries]
 
-    def test_identity_composite_stays_unit_gain(self):
+    def test_gate_and_amax_metrics_are_recorded(self):
         n, s, b = 4, 2, 3
         layer = self._identity_layer(n, s, b)
         model = _mhc_model([layer])
@@ -213,25 +213,42 @@ class MHCMonitorTest(unittest.TestCase):
 
         latest = training_logs.get_latest(prefix="mhc_health")
         for comp in ("attn", "mlp"):
-            for key in (
-                "h_pre_mean",
-                "h_pre_std",
-                "h_post_mean",
-                "h_post_std",
-                "amax_gain_fwd",
-                "amax_gain_bwd",
-                "composite_amax_gain_fwd",
-                "composite_amax_gain_bwd",
-            ):
+            for key in ("h_pre_mean", "h_pre_std", "h_post_mean", "h_post_std"):
                 self.assertIn(f"mhc_health/layer_0/{comp}_{key}", latest)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_amax_gain_fwd"], 1.0, places=4)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_fwd"], 1.0, places=4)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_bwd"], 1.0, places=4)
             # h_pre == 0.5 everywhere, h_post == 1.0 everywhere.
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_mean"], 0.5, places=5)
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_mean"], 1.0, places=5)
-        # global aggregate is derived too.
-        self.assertIn("mhc_health/global_attn_amax_gain_fwd", latest)
+            # amax_gain_fwd is a gatekeeper: global only, no per-layer series.
+            self.assertNotIn(f"mhc_health/layer_0/{comp}_amax_gain_fwd", latest)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_amax_gain_fwd"], 1.0, places=4)
+        # The retired series must stay gone.
+        for comp in ("attn", "mlp"):
+            for key in ("amax_gain_bwd", "composite_amax_gain_fwd", "composite_amax_gain_bwd"):
+                self.assertNotIn(f"mhc_health/layer_0/{comp}_{key}", latest)
+                self.assertNotIn(f"mhc_health/global_{comp}_{key}", latest)
+
+    def test_amax_gain_fwd_is_the_row_sum(self):
+        # An asymmetric, row-stochastic (but not column-stochastic) h_res pins the
+        # convention: amax_gain_fwd must read the ROW sums (1.0 here), never the
+        # column sums (1.5 here). Identity matrices cannot tell the two apart,
+        # which is how the fwd/bwd label mix-up stayed invisible.
+        n, s, b = 2, 1, 1
+        h_res = paddle.to_tensor([[0.75, 0.25], [0.75, 0.25]]).reshape([1, 1, n, n]).expand([s, b, n, n])
+        hc = FakeHC(
+            n=n,
+            h_pre=paddle.full([s, b, n], 0.5),
+            h_post=paddle.ones([s, b, n]),
+            h_res=paddle.assign(h_res),
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = PaddleMHCHealthMonitor()
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_fwd"], 1.0, places=5)
 
     def test_branch_residual_share_is_recorded_from_bda(self):
         n, s, b, c = 4, 2, 3, 6
@@ -243,7 +260,7 @@ class MHCMonitorTest(unittest.TestCase):
 
         streams = paddle.randn([s, b, n * c])
         x = paddle.randn([s, b, c])
-        for _, _, mod, _, _ in targets:
+        for _, _, mod in targets:
             mod.fused_h_res_h_post_bda(
                 h_res=mod._h_res,
                 original_residual=streams,
@@ -308,7 +325,6 @@ class MHCMonitorTest(unittest.TestCase):
             FakeHC.compute_mappings,
         )
         self.assertEqual(monitor._wrapped, [])
-        self.assertEqual(monitor._composite, {})
 
     def test_no_graph_retention(self):
         n, s, b = 4, 2, 3
@@ -325,14 +341,14 @@ class MHCMonitorTest(unittest.TestCase):
 
         monitor = PaddleMHCHealthMonitor()
         targets = self._prepare_and_attach(monitor, model)
-        for _, _, mod, _, _ in targets:
+        for _, _, mod in targets:
             mod.compute_mappings(paddle.randn([4, 2, n * 8]))
 
-        stored = monitor._composite[0]
-        # detach() sets stop_gradient=True; the composite must not be graph-tracked.
-        self.assertTrue(stored.stop_gradient)
+        # The 0-dim accumulators must not be graph-tracked: if the wrapper forgot
+        # to detach, the graph stays pinned through them until backward.
+        for key, acc in monitor._gpu_acc.items():
+            self.assertTrue(acc.stop_gradient, msg=key)
         monitor.step()
-        self.assertEqual(monitor._composite, {})  # cleared between steps
 
 
 class MHCMonitorNoOpTest(unittest.TestCase):


### PR DESCRIPTION
## 背景

复合映射（composite mapping）系列指标的设计意图是"跨层累乘 h_res 的增益偏离 1.0 = 残差流放大"。这个前提不成立：**双随机矩阵之积仍是双随机矩阵**，所以复合增益按构造恒为 1。
实测区间 0.99999 ~ 0.999975，偏离量全部来自 Sinkhorn 的 `eps = 1e-6`。

更糟的是它依赖执行顺序。`compute_mappings` 的 wrapper 里维护了一个 running product，按调用顺序累乘；而开 `recompute_granularity: full` 时采集实际发生在**反向重放**（真前向跑在 `no_grad` 下被 grad 判据挡掉），于是累乘变成逆序。

## 改动

**删除**（paddlefleet 后端，每模块 12 → 9 个指标）：

- `{c}_composite_amax_gain_fwd` / `_bwd`：恒为 1 且层序不可信。要让它与执行顺序无关，必须把每层 `h_res` 在整个 step 内驻留（43 层约 45MB 常驻显存），并违反`monitor-hook-perf-rules` 里"hook 内不保留张量"的纪律——为一个常数付这个代价不值得。
- `{c}_amax_gain_bwd`：Sinkhorn 的最后一步是列归一，列和按构造钉在 1；实测四条 run、每一层都与 `amax_gain_fwd` **逐位相同**。

**降级为仅全局**：

- `{c}_amax_gain_fwd` 同样恒 ≈1（0.99999905，动态范围 0.0001%），但保留一个不可替代的作用——守住 "`h_res` 是双随机矩阵" 这个前提。`branch_residual_share` 的语义、docs 里"各流等权 / 无放大" 的整套判读都建立在它上面。一旦模型侧改了 Sinkhorn（迭代数、投影方式、低精度化），这条线会立刻偏离，而其它指标只会**静默改变含义**而不报错。

为此在 core 的 `Probe` 新增 `GLOBAL_ONLY`：逐层值照常累加、`global_*` 从中派生，只是不写日志。任一层漂移仍会被全局曲线捕获，而看板占位从 13 层 × 2 组件降到 2 条。默认为空集，未使用它的后端行为不变。

## 影响面

- **megatron 后端不在本次范围**，代码保持原样。那边的 composite 层序与`amax_gain_bwd` 恒等问题同样存在，需另行处理。
- 其余 mHC 指标（门控四项、`stream_concentration`、`token_std`、`branch_residual_share` / `_max`）不受影响。

## 测试

- 删掉 composite 用例；原先用**单位矩阵**的那条改为**非对称行随机矩阵**  `[[0.75, 0.25], [0.75, 0.25]]`（行和 1.0、列和 1.5），钉住 `amax_gain_fwd` 读的是行和而非列和——单位矩阵分不出二者，这正是 fwd/bwd 标签问题一直隐形的原因。
- 新增断言：三条已下线的键（逐层与 global）不再出现；`amax_gain_fwd` 只有 `global_*`。
- `no_graph_retention` 改为直接断言 0 维累加器不带梯度（原来断言的是已删除的 composite slot）。

`pre-commit run` 两 hook Passed；`tests/` 104 passed, 2 skipped。