### PR TITLE
fix(qk_stats): sparse attn patch 透传上游新增关键字参数

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -665,8 +665,8 @@ class PaddleQKStatsMonitor(PaddleProbe):
         monitor = self
         attn_type = item.attn_type
 
-        def wrapped(query, kv_full, attn_sink, topk_idxs, softmax_scale, topk_length=None):
-            out = original(query, kv_full, attn_sink, topk_idxs, softmax_scale, topk_length=topk_length)
+        def wrapped(query, kv_full, attn_sink, topk_idxs, softmax_scale, *args, **kwargs):
+            out = original(query, kv_full, attn_sink, topk_idxs, softmax_scale, *args, **kwargs)
             if core.training and monitor._should_monitor():
                 monitor._record_sparse_stats(layer_idx, attn_type, query, kv_full, attn_sink, topk_idxs, softmax_scale)
             return out


### PR DESCRIPTION
PaddleFleet 的 core_attention.compressed_sparse_attn 新增了 indexer_topk参数，而 _patch_sparse_attn 里的 wrapped 只声明到 topk_length，CSA/HCA 层前向直接 TypeError: unexpected keyword argument 'indexer_topk'。

- paddlefleet/qk_monitor: wrapped 改为 (query, kv_full, attn_sink, topk_idxs, softmax_scale, *args, **kwargs) 原样透传；indexer_topk>0 时返回的 (out, lse_indexer)元组按原样返回。