### PR TITLE
add mhc new feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
-- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 8 指标；仅在开启 mHC 层时生效)
+- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 
 ---
@@ -359,8 +359,9 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
 以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。
 只在模型开启 mHC 层时生效——mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
-彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 9 个指标，
-指标名以 `attn_` / `mlp_` 前缀区分；除 `branch_residual_share_max` 取极值外，其余按 token/batch 求均值。
+彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 14 个指标，
+指标名以 `attn_` / `mlp_` 前缀区分；除 `branch_residual_share_max`、`h_res_softmax_max`、
+`composite_amax_gain_{fwd,bwd}_max` 取极大值与 `h_res_softmax_min` 取极小值外，其余按 token/batch 求均值。
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
 |---|------|--------|------|------|----------|
@@ -372,11 +373,26 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 | 6 | `{c}_h_post_token_std` | `mhc_health/layer_{i}/{c}_h_post_token_std` | `std_t(mean_i h_post)` | 每层+全局 | 门控对输入的区分度，→0 = 退化成常数 |
 | 7 | `{c}_branch_residual_share` | `mhc_health/layer_{i}/{c}_branch_residual_share` | `mean_t(b / (b + r))`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F` | 每层+全局 | **本层是否还在写入残差流**，值域 `[0, 1]`：0.5 = 两项等量 |
 | 8 | `{c}_branch_residual_share_max` | `mhc_health/layer_{i}/{c}_branch_residual_share_max` | 同上取最坏 token | 每层+全局 | 单 token 被分支主导的程度（贴 1 = 存在近零残差 token） |
-| 9 | `{c}_amax_gain_fwd` | `mhc_health/global_{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ij\|)` | **仅全局** | Sinkhorn 收敛哨兵（恒 ≈1，见下） |
+| 9 | `{c}_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ji\|)`（`h_res` 的列和 = `h_resᵀ` 的行和） | 每层+全局 | 单层前向最坏放大。列和被 Sinkhorn 最后一步钉死为 1，故这条是不变量守卫（见下） |
+| 10 | `{c}_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_amax_gain_bwd` | `mean_t(max_j \|Σ_i h_res_ji\|)`（`h_res` 的行和） | 每层+全局 | 单层反向最坏放大。承载 Sinkhorn 截断迭代的收敛残差 |
+| 11 | `{c}_h_res_softmax_min` | `mhc_health/layer_{i}/{c}_h_res_softmax_min` | `min_t min_{i,j} softmax(z)`，`z` = Sinkhorn 之前的 `h_res` logits | 每层+全局 | **饱和哨兵**，值域 `(0, 1/n]`：`1/n` = 行内均匀，趋 0 = 该行退化成 one-hot。阈值 `1.18e-38`（fp32 最小正规数），越线即模型自己的 `softmax` 已下溢。按 **min** 归约 |
+| 12 | `{c}_h_res_softmax_max` | `mhc_health/layer_{i}/{c}_h_res_softmax_max` | `max_t max_{i,j} softmax(z)` | 每层+全局 | 单个最大混合权重，值域 `[1/n, 1]`。行内跨度约 18 之后在 fp32 里精确等于 1.0 且不再变化，故只能当"是否已饱和"的开关，不反映饱和深度。按 **max** 归约 |
+| 13 | `{c}_composite_amax_gain_fwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd_max` | `max_i \|Σ_j A_{k,i,j}\|`，`A_k = h_res_kᵀ @ A_{k-1}` 按层序累乘（`h_res_kᵀ` 才是 `apply_h_res` 实际作用的算子） | 每层+全局 | 从首层到本层累计的前向最坏放大。按 **max** 归约 |
+| 14 | `{c}_composite_amax_gain_bwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd_max` | `max_j \|Σ_i A_{k,i,j}\|` | 每层+全局 | 同上取列和。按 **max** 归约 |
 
 `{c}` ∈ `{attn, mlp}`。
 
-指标 1~6 与 9 来自包裹 `compute_mappings`（`h_pre` 不在 `forward` 返回值里，只能从这里拿到真实映射）；
+**哪个轴带信息**：`apply_h_res` 与 fused cuTile kernel 都按 `out_i = Σ_j h_res_ji · x_j` 混流，即真正作用在流
+向量上的算子是 `h_resᵀ`，所以前向增益是 `h_res` 的列和、反向增益是行和（单层与复合同口径）。我们的
+`_sinkhorn_normalize` 最后一步是**列**归一，所以 `_fwd` 被钉死为 1 充当不变量守卫，`_bwd` 才承载截断迭代的残差；
+论文 Eq. (9) 最后一步是行归一，它 Fig 7 里会动的是 forward 那条，**两边曲线不可直接对比**。
+
+指标 1~6 与 9~10 来自包裹 `compute_mappings`（`h_pre` 不在 `forward` 返回值里，只能从这里拿到真实映射）；
+指标 11~12 需要 Sinkhorn **之前**的 `h_res` logits，故额外包裹 `_compute_h`（顺带绕开 `use_fused_mhc` 分叉）；
+指标 13~14 在 **flush 时**按 `layer_idx` 排序累乘（hook 内只存 token 平均并**转置**后的 `n×n` 快照，
+转置是因为 `apply_h_res` 实际作用的算子是 `h_resᵀ`），因此与 hook 触发顺序无关——而该顺序在 recompute 下是
+反向重放的逆序，正是它当初被下线的原因。MTP 层不在主干链上，累乘时跳过。作用域是本 rank 持有的层，
+当前配置（`sharding: stage1`，无 PP）下即全部 43 层；开 PP 后会退化为 stage 内语义，详见 docs。
 指标 7~8 需要 sublayer 输出，只有两项合并处才同时可见，故额外包裹 `fused_h_res_h_post_bda`，且指标从**入参**
 推导，因此 fused 快路径与带 dropout 的顺序路径口径一致。两个范数都是精确值但不 materialize 任何
 `[tokens, n, C]` 中间张量：branch 项是外积，`‖h_post_t ⊗ x_t‖_F = ‖h_post_t‖₂·‖x_t‖₂`；residual 项用
@@ -396,9 +412,15 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
   - `stream_concentration`≈n → **退化为单流**，该层放弃了多流结构，`num_residual_streams` 的开销在这些层上没有
     收益；可考虑逐层配置 n。注意这未必是病：HC 允许不同层使用不同的流组合，需结合「是否总是同一条流」判断。
 - `h_post_token_std`→0 → 门控丢失对 token 的区分度，从动态门退化成常数标量。
-- `amax_gain_fwd` 偏离 1.0 → Sinkhorn 未收敛或初始化异常。它按构造恒 ≈1（实测 0.99999905，动态范围
-  0.0001%），**只当哨兵用，不要拿它做诊断**；也因此只输出 `global_*` 而不占逐层曲线（`Probe.GLOBAL_ONLY`
-  机制：逐层值照常累加、global 从中派生，只是不写日志，所以任一层漂移仍会被全局曲线捕获）。
+- `amax_gain_bwd` 偏离 1.0 → Sinkhorn 未收敛或初始化异常。它承载截断迭代的残差，量级很小，
+  **只当哨兵用，不要拿它做诊断**。`amax_gain_fwd` 读 `h_res` 的列和，而列和被 Sinkhorn 最后一步钉死为 1，
+  所以它是不变量守卫：一旦它偏离 1，说明归一化本身出了问题（数值异常或实现改动），比 `_bwd` 更严重。
+- `composite_amax_gain_{fwd,bwd}_max` → 从首层累计到本层的最坏放大，逐层输出构成剖面曲线（论文 Fig 7b 的拱形
+  只有复合能显示，单层看不出）。与单层同口径：`_fwd` 被钉死，会动的是 `_bwd`。
+- `h_res_softmax_min` 下降 → 该层 `h_res` 的 logits 正在饱和，**梯度冻结**。饱和行的 softmax Jacobian
+  `diag(p) − ppᵀ ≈ 0`，`mapping_proj.weight` / `alpha_res` 收不到梯度，该层 `h_res` 冻在当前形态且不可自愈。
+  阈值 `1.18e-38`（fp32 最小正规数），越线即模型自己的 `softmax` 已下溢、行内比例不可逆丢失。健康值 `1/n`。
+  这条曲线是唯一的观测窗口——成品 `h_res` 的行和列和被 Sinkhorn 归一化钉在 1，其余指标全读健康。
 
 ---
 

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -38,6 +38,7 @@ internal_medicine_monitors:
 
 `h_pre` 不在 `HyperConnectionModule.forward` 的返回中，普通 forward hook 看不到它。因此本 monitor **包裹
 （wrap）每个 mHC 模块的 `compute_mappings` 绑定方法**，直接捕获其真实返回的 `(h_pre, h_post, h_res)` —— 不重算。
+另外包 `_compute_h`（拿 Sinkhorn 之前的 `h_res` logits）和 `fused_h_res_h_post_bda`（拿子层输出，算分支/残差占比）。
 
 - `compute_mappings` 是普通 Python 方法（仅 `@nvtx_decorator`，非 `@torch.compile`），在 `_forward_normal` 中以
   `self.compute_mappings(...)` 调用，且**不被 checkpoint**，因此在 grad-enabled 的正向中恰好执行一次；实例属性
@@ -62,10 +63,11 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 
 ## 监控指标
 
-每个 hc 模块产出 9 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 8 个），指标名以
-`attn_` / `mlp_` 前缀区分，除 `branch_residual_share_max` 取极值外全部按 token/batch 求均值
-（并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，`{c}` ∈ `{attn, mlp}`；
-对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
+每个 hc 模块产出 14 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 8 个），指标名以
+`attn_` / `mlp_` 前缀区分，除 `branch_residual_share_max`、`h_res_softmax_max`、
+`composite_amax_gain_{fwd,bwd}_max` 取极大值与 `h_res_softmax_min` 取极小值外全部按 token/batch 求均值
+（并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，
+`{c}` ∈ `{attn, mlp}`；对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
 
 ### 门控统计（h_pre / h_post）
 
@@ -95,33 +97,87 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 
 ### amax-gain（Sinkhorn 收敛哨兵）
 
-paper 定义的最坏情况增益：矩阵的**最大绝对行和**界定前向传播的最坏放大。对每个 token 的 `n×n` 矩阵计算，
-再对 token 求均值：
+paper 定义的最坏情况增益：算子的**最大绝对行和**界定前向传播的最坏放大。这里的算子不是 `h_res` 本身——
+`apply_h_res` 与 fused cuTile kernel 都按 `out_i = Σ_j h_res_ji · x_j` 混流，即真正作用在流向量上的是 `h_resᵀ`
+（见 `hyper_connection.py:466-471`、`fused_mhc_kernels.py:367-373`）。所以前向增益是 `h_res` 的**列**和、
+反向增益是**行**和。对每个 token 的 `n×n` 矩阵计算，再对 token 求均值：
 
 ```
-amax_gain_fwd = mean_t( max_i | Σ_j  h_res_ij | )      # 行和（forward）
+amax_gain_fwd = mean_t( max_i | Σ_j  h_res_ji | )      # h_res 的列和 = h_resᵀ 的行和（forward）
+amax_gain_bwd = mean_t( max_j | Σ_i  h_res_ji | )      # h_res 的行和（backward）
 ```
 
 | 指标 | 诊断意义 |
 |------|----------|
-| `{c}_amax_gain_fwd` | Sinkhorn 是否收敛 / 有无 NaN。双随机 → 恒 ≈1.0。**只输出 `global_*`** |
+| `{c}_amax_gain_fwd` | 单层前向最坏放大。列和被 Sinkhorn 最后一步归一钉死，是不变量守卫 |
+| `{c}_amax_gain_bwd` | 单层反向最坏放大。承载 Sinkhorn 截断迭代的收敛残差 |
 
-单层 `h_res` 经 Sinkhorn 投影为双随机矩阵，所以这个值**按构造恒为 1**——实测 0.99999905，动态范围 0.0001%，
-偏离量全部来自 Sinkhorn 的 `eps = 1e-6`。它只能当哨兵，不要拿来做诊断。也正因如此它走 `Probe.GLOBAL_ONLY`：
-逐层值照常累加、`global_*` 从中派生，只是不写进日志——任一层漂移仍会把全局曲线带走，但看板上只有 2 条线
-而不是 13 层 × 2 组件。
+**哪个轴带信息**：我们的 `_sinkhorn_normalize` 最后一步是**列**归一，所以列和按构造恒为 1，行和才承载截断迭代的
+残差（偏离量来自 `eps = 1e-6`，量级很小）。所以 `_bwd` 只能当哨兵、不要做诊断；`_fwd` 一旦偏离 1 反而更严重，
+说明归一化本身出了问题（数值异常或实现改动）。
 
-### 已下线：amax_gain_bwd 与复合映射
+注意论文 Eq. (9) 最后一步是**行**归一，所以它 Fig 7 里会动的是 forward 那条，而我们会动的是 `_bwd`——
+**两边曲线不可直接对比。**
 
-- `{c}_amax_gain_bwd`（最大绝对列和）：Sinkhorn 的最后一步是列归一（`hyper_connection.py` 的迭代循环），
-  列和被钉在 1，实测四条 run、每一层都与 `amax_gain_fwd` **逐位相同**。
-- `{c}_composite_amax_gain_fwd` / `_bwd`（`M_k = h_res_k @ M_{k-1}` 的行/列和）：双随机矩阵之积仍是双随机矩阵，
-  复合增益同样恒为 1（实测 0.99999~0.999975）。更糟的是它依赖执行顺序：开 `recompute_granularity: full` 时
-  采集实际发生在反向重放，累乘变成逆序——实测每层累乘因子数为 `1, 25.6, 23.6, …, 2.9`，而正序应为
-  `1, 3, 5, …, 25.8`（关掉 recompute 的对照组给出了后者）。让它与顺序无关需要把每层 `h_res` 在整个 step 内
-  驻留（43 层约 45MB 常驻显存），为一个常数付这个代价不值得。
+### logits 饱和哨兵（迭代前的行内跨度）
 
-要真正观测残差流放大，应监控 **Sinkhorn 收敛残差**（行和与 1 的偏差）或 `h_res` 的谱性质，两者都尚未实现。
+`softmax` 在行内**平移不变**，所以决定 `h_res` 有多尖的唯一量是行内跨度 `max_j z_j − min_j z_j`。跨度直接决定
+softmax 的最小输出：`min ≈ exp(−跨度)`，于是阈值由 dtype 给出，不需要拍：
+
+- `exp(-87) ≈ 1.2e-38` —— fp32 最小正规数
+- `exp(-103) ≈ 1.4e-45` —— fp32 最小 denormal，再往下就是 0
+
+跨度超过 ~87，模型自己的 `softmax` 就开始下溢：行内相对比例被摧毁，紧随其后的 Sinkhorn 把残存比例按最多
+`1/eps` 放大。
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_h_res_softmax_min` | `min_t min_{i,j} softmax(z)_{t,i,j}` | 最小混合权重。值域 `(0, 1/n]`，`1/n` = 行内均匀，趋 0 = 该行退化成 one-hot。按 **min** 归约 |
+| `{c}_h_res_softmax_max` | `max_t max_{i,j} softmax(z)_{t,i,j}` | 单个最大混合权重。值域 `[1/n, 1]`，跨度到约 18 之后在 fp32 里精确等于 1.0 并保持不变，所以只能当"是否已经饱和"的开关看，不反映饱和深度。按 **max** 归约 |
+
+### 复合映射（composite_amax_gain_{fwd,bwd}_max）
+
+`apply_h_res` 的实际运算是 `mixed = h_resᵀ @ residual`，所以
+**真正作用在流向量上的算子是 `h_resᵀ`**。从首层到第 k 层的复合算子是
+
+```
+A_k = h_res_kᵀ @ ⋯ @ h_res_0ᵀ
+```
+
+逐层记录它的最大绝对行和（`_fwd`，前向信号增益）与最大绝对列和（`_bwd`，反向梯度增益）。这条曲线对应论文
+Figure 7(b)：单层指标看不出的拱形（中间层高、两端低）只有复合能显示。
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_composite_amax_gain_fwd_max` | `max_i \|Σ_j A_{k,i,j}\|` | 从首层到本层累计的前向最坏放大。逐层输出形成剖面曲线；global 按 **max** 归约给出峰值 |
+| `{c}_composite_amax_gain_bwd_max` | `max_j \|Σ_i A_{k,i,j}\|` | 同上取列和 |
+
+四个实现要点：
+
+1. **累乘的是转置。** 直接对 `h_res` 累乘既不是前向链也不是反向链——`h_res_k ⋯ h_res_0` 与真实算子
+   `A_k = (h_res_0 ⋯ h_res_k)ᵀ` 是不同的矩阵。快照里存的就是 `h_resᵀ`。单层的 `amax_gain_{fwd,bwd}` 同样按
+   `h_resᵀ` 口径计算（只是没有显式转置，直接换了求和轴），所以两组指标的 `_fwd`/`_bwd` 语义一致、可以对着读。
+2. **先对 token 求平均再累乘**（论文 Fig 7/8 同口径），所以每层每组件只存一个 `n×n` fp32 快照，而不是把 per-token
+   `h_res` 在整个 step 内驻留。这是它当初被下线的第一条理由，现在不成立。
+3. **累乘发生在 flush 时、按 `layer_idx` 排序**，不在 hook 里增量累乘。所以结果与 hook 触发顺序无关——而触发顺序
+   在 recompute 下是反向重放的逆序，那正是它当初被下线的第二条理由。`_record_composite` 有对应的回归测试
+   （故意逆序触发 hook，断言结果仍等于正序累乘）。
+4. **MTP 层被排除。** MTP 层不在主干传播路径上，乘进链条没有物理意义。
+
+作用域限制：复合只覆盖**本 rank 持有的层**。当前配置（`sharding: stage1`，无 PP）下每张卡都持有全部 43 层，所以
+就是全网语义。真开 PP 后它会退化成 stage 内语义，而我们既检测不到也修不了——`get_pipeline_model_parallel_rank`
+和 `get_pipeline_model_parallel_world_size` 在 PaddleFleet 里目前是 stub（无条件返回 0 / 1，
+`parallel_state.py:229`、`:246`）。要支持 PP 需要先等这两个函数实现，再补一次 flush 时的 all-gather；届时
+**collective 必须放在所有 per-layer `try/except` 之外**，否则单个 rank 吞异常会让整个 job 挂死而不是报错。
+
+### 曾经下线、现已恢复
+
+- `{c}_amax_gain_bwd`：曾因读数与 `amax_gain_fwd` 一致而下线。这个结果本身是预期的（`_fwd` 读的列和被 Sinkhorn
+  最后一步钉死为 1），两条现在都保留：`_fwd` 当不变量守卫，`_bwd` 才是承载收敛残差的那条。
+- `{c}_composite_amax_gain_{fwd,bwd}_max`：曾因两条理由下线，现在都不成立——per-token `h_res` 全 step 驻留的开销
+  （改成先对 token 求平均后只剩一个 `n×n` 快照），以及依赖执行顺序（改成按 `layer_idx` 排序、flush 时累乘后无关）。
+
+
 
 ---
 
@@ -131,7 +187,7 @@ amax_gain_fwd = mean_t( max_i | Σ_j  h_res_ij | )      # 行和（forward）
 - 整个捕获受 `_should_monitor()` 门控；非监控步只是 `orig(x)` + 一次布尔判断。
 - `_should_monitor()` 要求 grad enabled。这个判据的名字暗示"跳过重算"，**实际语义相反**：recompute 的真前向跑在
   `no_grad` 下，反向重放才开 grad，所以采集实际发生在反向重放。数值不受影响（重算确定性），但依赖执行顺序的指标
-  会出错——这是复合映射被下线的原因之一。
+  会出错——这曾经让复合映射下线，现在复合改成按 `layer_idx` 排序、在 flush 时累乘，不再受影响。
 - 这个判据留着是因为它顺带保证了"每个模块每 step 只取一条样本"：mHC 的 hyper-connection 在一次前向里会被进入
-  两次（`high_precision_mhc` 打开时 AMP 关闭的 fp32 路径 + bf16 路径），两条都记会稀释所有均值（实测单层
-  `amax_gain` 偏离量减半、门控 std 偏移 1~3%）。详见 README「已知限制：采集口径依赖 grad 判据」。
+  两次（`high_precision_mhc` 打开时 AMP 关闭的 fp32 路径 + bf16 路径），两条都记会稀释所有均值。详见 README
+  「已知限制：采集口径依赖 grad 判据」。

--- a/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
@@ -1,24 +1,15 @@
 """mHC (Manifold-Constrained Hyper-Connections) metric compute functions.
 
 Paddle port of ``backends/megatron/mhc_metrics.py``. Pure, stateless tensor
-helpers for the ``mhc_health`` monitor. They operate on the three mappings a
-``HyperConnectionModule`` produces per token:
+helpers for the ``mhc_health`` monitor, operating on the three mappings a
+``HyperConnectionModule`` produces per token (``n = num_residual_streams``):
 
 - ``h_pre``  [..., n]     — stream aggregation gate (sigmoid)
 - ``h_post`` [..., n]     — stream expansion gate (2 * sigmoid)
 - ``h_res``  [..., n, n]  — Sinkhorn doubly-stochastic residual-mixing matrix
 
-``n = num_residual_streams``.
-
-The ``amax_gain`` diagnostic follows the mHC paper: the max-abs **row** sum of a
-mixing matrix bounds the worst-case forward-pass expansion, and the max-abs
-**column** sum bounds the backward-pass expansion. For a single doubly-stochastic
-``h_res`` both sit at ~1.0; on the *composite* mapping (cumulative product of
-``h_res`` across layers) they drift away from 1.0 with depth, flagging
-residual-stream amplification.
-
 All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
-``.cpu()``), so they are safe to call from a forward hot path. See
+``.cpu()``), so they are safe on a forward hot path. See
 ``.claude/skills/monitor-hook-perf-rules``.
 """
 
@@ -30,16 +21,54 @@ _EPS = 1e-12
 def amax_gain(mat: paddle.Tensor, axis: int) -> paddle.Tensor:
     """Per-token max-abs {row|col} sum of a batched ``[..., n, n]`` matrix, meaned over tokens.
 
-    ``axis=-1`` sums over columns -> per-row sums (forward gain); ``axis=-2``
-    sums over rows -> per-column sums (backward gain). ``sum(axis)`` collapses
-    one ``n``-axis to ``[..., n]``; ``abs().max(axis=-1)`` takes the worst
-    stream per token; ``mean()`` averages over all tokens.
-
-    Returns a 0-dim tensor on ``mat``'s device/dtype (fp32 from
-    ``compute_mappings``).
+    The paper's worst-case gain bound. Which axis is "forward" depends on the
+    matrix passed in: streams mix as ``out = h_res^T @ x``, so on ``h_res`` as
+    stored ``axis=-2`` (column sums) is the forward gain and ``axis=-1`` the
+    backward one; on an already-transposed matrix the two swap. Returns a 0-dim
+    tensor.
     """
     sums = mat.sum(axis=axis)  # [..., n]
     return sums.abs().max(axis=-1).mean()  # 0-dim
+
+
+def h_res_softmax_extrema(h_res_logits: paddle.Tensor, n: int) -> dict[str, paddle.Tensor]:
+    """Extreme mixing weights of the row-wise softmax, before Sinkhorn.
+
+    Saturation sentinel. ``min`` is the informative half: bounded by ``(0, 1/n]``
+    with ``1/n`` = uniform row, falling as the row peaks, and it crosses fp32's
+    smallest normal (``1.18e-38``) exactly when the model's own ``softmax``
+    underflows and the within-row proportions are lost. ``max`` is capped at 1 by
+    the row sum and pins at exactly 1.0 in fp32 from a within-row logit spread of
+    ~18 onwards, so it only answers "saturated yes/no", not how far.
+
+    What it diagnoses is **gradient freezing**, not NaN: a saturated row's softmax
+    Jacobian ``diag(p) - p pᵀ`` is ~0, so ``mapping_proj`` / ``alpha_res`` stop
+    receiving gradient and that layer's ``h_res`` freezes, while the finished
+    ``h_res`` still reports row/column sums of ~1 and every other metric
+    here reads healthy. (NaN was ruled out separately: both the native and cuTile
+    Sinkhorn paths stay finite in fp32 even on ``-inf`` logits, because the
+    ``eps`` in the normalization denominators caps amplification at ``1/eps``.)
+
+    The softmax deliberately omits the model's ``+ eps`` (``_sinkhorn_normalize``
+    in ``hyper_connection.py``), which would floor every entry at 1e-6 and clamp
+    ``min`` there. The trade is that ``min`` reads exactly 0 past a spread of
+    ~103 — past the alarm, and the model cannot tell 0 from 1e-44 either.
+
+    Args:
+        h_res_logits: ``[..., n*n]`` raw mixing logits, i.e. ``_compute_h``'s
+            third return value — before the reshape and Sinkhorn projection.
+        n: ``num_residual_streams``.
+
+    Returns:
+        ``h_res_softmax_min`` / ``h_res_softmax_max`` over every row of every
+        token, as 0-dim tensors; one softmax serves both. No host sync.
+    """
+    logits = h_res_logits.detach().astype("float32").reshape([-1, n, n])
+    weights = paddle.nn.functional.softmax(logits, axis=-1)
+    return {
+        "h_res_softmax_min": weights.min(),
+        "h_res_softmax_max": weights.max(),
+    }
 
 
 def gate_stats(h: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:
@@ -53,21 +82,18 @@ def gate_stats(h: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:
 def h_post_structure_stats(h_post: paddle.Tensor) -> dict[str, paddle.Tensor]:
     """Structure of the expansion gate across streams and across tokens.
 
-    ``h_post_mean`` / ``h_post_std`` pool the token axis and the stream axis
-    together, so a shrinking mean cannot tell "all n streams went quiet" apart
-    from "n-1 streams died and one still carries everything". These two split
-    the axes:
+    ``h_post_mean`` / ``h_post_std`` pool the token and stream axes together, so
+    a shrinking mean cannot tell "all n streams went quiet" from "n-1 died and
+    one carries everything". These two split the axes:
 
-    ``h_post_stream_concentration`` — ``mean_t(max_i h_post[t,i] / mean_i h_post[t,i])``.
-    Computed per token *before* averaging, so it is bounded by ``[1, n]``
-    regardless of token-level scale: 1 = all streams weighted equally,
-    ``n`` = all the mass on a single stream (the layer degenerated to a plain
-    single-stream residual and the ``num_residual_streams`` budget is unused).
+    ``h_post_stream_concentration`` — ``mean_t(max_i h_post / mean_i h_post)``,
+    taken per token *before* averaging so it stays bounded by ``[1, n]``
+    regardless of token-level scale: 1 = streams equally weighted, ``n`` = all
+    mass on one stream (the ``num_residual_streams`` budget is unused).
 
-    ``h_post_token_std`` — std over tokens of the per-token stream mean. The
-    gate is a function of the input (``h = r · proj · α + bias``), so this is
-    its input sensitivity: →0 means the gate stopped discriminating tokens and
-    has effectively become a constant scalar.
+    ``h_post_token_std`` — std over tokens of the per-token stream mean. The gate
+    is a function of the input (``h = r · proj · α + bias``), so →0 means it
+    stopped discriminating tokens and is effectively a constant scalar.
 
     Returns 0-dim GPU tensors; no host sync.
     """
@@ -94,37 +120,28 @@ def branch_residual_share(
 ) -> dict[str, paddle.Tensor]:
     """How much of the mHC update this layer wrote itself, per token.
 
-    mHC propagates ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``: the first
-    term only re-mixes what the previous layers wrote, the second is this
-    layer's own contribution. The share
+    mHC propagates ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``: the first term
+    only re-mixes what earlier layers wrote, the second is this layer's own
+    contribution. The share
 
         ``branch_residual_share = b / (b + r)``,
         ``b = ‖H_postᵀ F(·)‖_F``, ``r = ‖H_resᵀ x_l‖_F``
 
-    is therefore the direct read on "is this layer still writing anything".
-    ``h_post_mean`` alone cannot answer that: a shrinking gate may be offset by
-    a growing ``F(·)``.
+    reads "is this layer still writing anything" — which ``h_post_mean`` cannot,
+    since a shrinking gate may be offset by a growing ``F(·)``.
 
-    The bounded form is deliberate. The raw ratio ``b / r`` is unbounded and
-    ``r`` really does hit 0 — an all-zero token (padding, or the shifted slot of
-    an MTP layer) has all ``n`` streams at zero, and only ``layer_0`` and MTP
-    layers can see one, since deeper layers always carry earlier writes. Dividing
-    by ``r`` then pinned the value at the epsilon floor (``b / 1e-6 ≈ 1e6``),
-    which blew up the token mean and the derived ``global_*`` series along with
-    it. Here such a token simply reads 1.0, and every token contributes at most
-    1.0 to the mean, so a handful of them can no longer hijack the series.
+    The bounded form is deliberate: ``r`` really does hit 0 (an all-zero token in
+    ``layer_0`` or an MTP layer's shifted slot), and the raw ratio ``b / r`` then
+    pinned at the epsilon floor ``b / 1e-6 ≈ 1e6`` and hijacked the token mean
+    and the derived ``global_*`` series. Here such a token reads 1.0 and every
+    token contributes at most 1.0.
 
-    Both norms are computed exactly, but without materialising any
-    ``[tokens, n, C]`` intermediate:
-
-    - the branch term is an outer product, so
-      ``‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂ · ‖xb_t‖₂``;
-    - for the residual term, with ``mixed_t[i] = Σ_j h_res[t,j,i] · x_l[t,j]``,
-      ``‖mixed_t‖²_F = Σ_{j,k} S[t,j,k] · G[t,j,k]`` where
-      ``S = Σ_i h_res[t,j,i] h_res[t,k,i]`` and ``G`` is the Gram matrix of the
-      n streams. Both are ``[tokens, n, n]``, i.e. negligible memory, and the
-      cost is ``O(tokens · n² · C)`` — for ``n = 4`` that is ``C/n²`` times
-      cheaper than the layer's own projections.
+    Both norms are exact but materialise no ``[tokens, n, C]`` intermediate: the
+    branch term is an outer product (``‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂·‖xb_t‖₂``)
+    and the residual term contracts two ``[tokens, n, n]`` matrices —
+    ``‖mixed_t‖²_F = Σ_{j,k} S[t,j,k]·G[t,j,k]`` with ``S`` the ``h_res``
+    autocorrelation and ``G`` the Gram matrix of the n streams. Cost is
+    ``C/n²`` times cheaper than the layer's own projections.
 
     Args:
         h_res: ``[..., n, n]`` Sinkhorn doubly-stochastic mixing matrix.
@@ -138,9 +155,9 @@ def branch_residual_share(
         ``branch_residual_share_max`` (worst token), both in ``[0, 1]``.
 
     Note:
-        The branch term is measured *before* dropout. Configs that run
-        ``hidden_dropout_prob > 0`` therefore see a slight over-estimate of the
-        branch magnitude at train time; the pretraining configs here use 0.
+        The branch term is measured *before* dropout, so configs with
+        ``hidden_dropout_prob > 0`` slightly over-estimate it; the pretraining
+        configs here use 0.
     """
     n = int(h_post.shape[-1])
     xb = layer_output.detach().astype("float32")

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -1,57 +1,60 @@
 """mHC Health Monitor for PaddleFleet.
 
-Paddle port of ``backends/megatron/mhc_monitor.py``. Monitors the three
-per-token mappings of every ``HyperConnectionModule`` in an mHC
-(Manifold-Constrained Hyper-Connections) model:
+Paddle port of ``backends/megatron/mhc_monitor.py``. Monitors the three per-token
+mappings of every ``HyperConnectionModule`` in an mHC (Manifold-Constrained
+Hyper-Connections) model, plus the relative magnitude of the two update terms of
+``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)`` (i.e. how much this layer still
+writes into the residual streams).
 
-- ``h_pre`` / ``h_post`` — the aggregation / expansion gates: mean and std, plus
-  the stream concentration and token sensitivity of ``h_post``.
-- ``h_res``              — the doubly-stochastic residual-mixing matrix: the
-  paper's ``amax_gain`` (max-abs row sum), kept as a NaN / Sinkhorn-divergence
-  sentinel rather than as a diagnostic (see the note below).
-- the **two update terms** of ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``:
-  their relative magnitude, i.e. how much this layer still writes into the
-  residual streams.
-
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 9
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 14
 series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
     {attn,mlp}_h_post_mean  {attn,mlp}_h_post_std
     {attn,mlp}_h_post_stream_concentration  {attn,mlp}_h_post_token_std
     {attn,mlp}_branch_residual_share  {attn,mlp}_branch_residual_share_max
-    {attn,mlp}_amax_gain_fwd
+    {attn,mlp}_amax_gain_fwd  {attn,mlp}_amax_gain_bwd
+    {attn,mlp}_h_res_softmax_min  {attn,mlp}_h_res_softmax_max
+    {attn,mlp}_composite_amax_gain_fwd_max  {attn,mlp}_composite_amax_gain_bwd_max
 
-``h_pre`` is not part of ``HyperConnectionModule.forward``'s return, so we
-cannot use a forward hook. Instead we wrap the module's ``compute_mappings``
-bound method to capture its real ``(h_pre, h_post, h_res)`` — no recompute.
-The branch/residual ratio needs the sublayer output too, which only exists where
-the two terms are combined, so ``fused_h_res_h_post_bda`` is wrapped as well.
-Everything is detached and computed under ``no_grad`` (see the VRAM-safety
-notes on the hook).
+Forward hooks are not enough, so three bound methods are wrapped instead (see
+``mhc_metrics`` for what each metric means):
 
-Retired metrics (do not re-add without a new argument):
+- ``compute_mappings`` — ``h_pre`` is not in ``forward``'s return value.
+- ``_compute_h``       — the mixing logits only exist before the Sinkhorn
+  projection, and wrapping here also sidesteps the ``use_fused_mhc`` fork.
+- ``fused_h_res_h_post_bda`` — the only point where both update terms are
+  visible.
 
-- ``composite_amax_gain_fwd`` / ``_bwd`` — the cumulative product of ``h_res``
-  across layers. A product of doubly-stochastic matrices is itself doubly
-  stochastic, so the composite gain is **1 by construction**; measured range was
-  0.99999 ~ 0.999975, i.e. pure Sinkhorn ``eps`` accumulation. Worse, the value
-  is order-dependent: it was built in execution order, which under recompute is
-  the reverse-layer backward replay (measured: per-layer factor counts came out
-  ``1, 25.6, 23.6, ..., 2.9`` instead of ``1, 3, 5, ..., 25.8``). Making it
-  order-proof needs the per-layer ``h_res`` resident for the whole step
-  (~45MB at 43 layers), which is not worth paying for a constant.
-- ``amax_gain_bwd`` (max-abs **column** sum) — Sinkhorn's last step is a column
-  normalization, so columns are pinned to 1 by construction. Measured bit-equal
-  to ``amax_gain_fwd`` on every layer of four runs.
+Everything is detached and computed under ``no_grad`` (see the VRAM-safety notes
+on the hook).
 
-To actually watch for residual-stream amplification, monitor Sinkhorn
-convergence residual (row sums vs 1) or the spectrum of ``h_res`` — neither is
-implemented yet.
+Which axis carries signal: both the single-layer and the composite gains are
+computed on the operator that really acts on the stream vector, ``h_res^T``
+(``apply_h_res`` and the fused cuTile kernel both contract over ``h_res``'s first
+index). ``_fwd`` is therefore a column sum of ``h_res`` and ``_bwd`` a row sum.
+Our ``_sinkhorn_normalize`` ends on a **column** normalization, so ``_fwd`` is
+pinned to 1 by construction and ``_bwd`` carries the truncated-iteration
+residual. The paper's Eq. (9) ends on a row normalization, so its Fig. 7 plots
+the mirror image — the curve that moves there is its forward gain, ours is
+``_bwd``. Both directions are emitted anyway so the pinned side acts as a guard.
 
-The monitor is a hard no-op unless the model actually uses the mHC layer: if
-the mHC classes cannot be imported, or no ``HyperConnectionTransformerLayer``
-is found, ``setup_mhc_monitor`` attaches nothing and registers no metrics.
+``composite_amax_gain_*`` and ``amax_gain_bwd`` were all retired once and are
+back. The composite objections were the cost of keeping a per-token ``h_res``
+resident for the whole step and order-dependence under recompute: averaging over
+tokens first shrinks the snapshot to one ``n x n`` matrix per layer, and keying
+snapshots by ``layer_idx`` instead of accumulating in call order removes the
+order-dependence (see ``_record_composite`` for the remaining scope caveat).
+``amax_gain_bwd`` was dropped for reading equal to ``amax_gain_fwd``, which is
+expected given the pinned axis above; it is kept now as the explicit invariant
+guard.
+
+Residual-stream amplification itself is still unmonitored; the candidates are the
+Sinkhorn convergence residual (row sums vs 1) and the spectrum of ``h_res``.
+
+The monitor is a hard no-op unless the model actually uses the mHC layer: if the
+mHC classes cannot be imported, or no ``HyperConnectionTransformerLayer`` is
+found, ``setup_mhc_monitor`` attaches nothing and registers no metrics.
 
 Hot-path discipline (no D2H sync, no hook-time collectives, schema fixed at
 registration): see ``.claude/skills/monitor-hook-perf-rules``.
@@ -64,7 +67,13 @@ import paddle.nn as nn
 
 from .base import PaddleProbe
 from .layer_discovery import get_decoder_layers, iter_monitor_layers
-from .mhc_metrics import amax_gain, branch_residual_share, gate_stats, h_post_structure_stats
+from .mhc_metrics import (
+    amax_gain,
+    branch_residual_share,
+    gate_stats,
+    h_post_structure_stats,
+    h_res_softmax_extrema,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -90,18 +99,30 @@ _METRIC_NAMES = (
     "branch_residual_share",
     "branch_residual_share_max",
     "amax_gain_fwd",
+    "amax_gain_bwd",
+    "h_res_softmax_min",
+    "h_res_softmax_max",
+    "composite_amax_gain_fwd_max",
+    "composite_amax_gain_bwd_max",
 )
 
-# Only the worst-token branch ratio keeps extremum semantics across
-# microbatches / layers / ranks; everything else is a mean. The name ends in
-# `_max`, so training_logs' suffix classifier agrees on the full key too.
-_MAX_METRICS = frozenset({"branch_residual_share_max"})
+# Extrema, not means: a worst case that a mean over 43 layers would bury. The
+# `_max` / `_min` suffixes keep training_logs' classifier in agreement on the
+# full key too.
+_MAX_METRICS = frozenset(
+    {
+        "branch_residual_share_max",
+        "h_res_softmax_max",
+        "composite_amax_gain_fwd_max",
+        "composite_amax_gain_bwd_max",
+    }
+)
+_MIN_METRICS = frozenset({"h_res_softmax_min"})
 
-# amax_gain_fwd is 1 by construction (Sinkhorn), so it is a gatekeeper for that
-# invariant rather than a per-layer diagnostic: one global curve per component
-# carries the same signal as 13 layers x 2 components of flat lines. Any layer
-# drifting still moves the global mean.
-_GLOBAL_ONLY_METRICS = frozenset({"amax_gain_fwd"})
+# Nothing is global-only: the single-layer amax gains used to be, on the grounds
+# that they are 1 by construction, but the per-layer profile is wanted alongside
+# the composite one.
+_GLOBAL_ONLY_METRICS: frozenset[str] = frozenset()
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
@@ -138,9 +159,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
     """Monitor the h_pre / h_post / h_res mappings of mHC hyper-connection layers."""
 
     METRIC_PREFIX = "mhc_health"
-    # All metrics but one are means over tokens/batch (and over microbatches /
-    # ranks at flush); `branch_residual_share_max` is the single extremum series.
-    # Component-prefixed names are registered in __init__, because
+    # Populated in __init__ with component-prefixed names, because
     # record_layer_metric classifies on the name it is handed.
     MAX_AGGREGATED: set[str] = set()
     MIN_AGGREGATED: set[str] = set()
@@ -153,6 +172,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         verbose: bool = False,
     ):
         self.MAX_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MAX_METRICS}
+        self.MIN_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MIN_METRICS}
         self.GLOBAL_ONLY = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _GLOBAL_ONLY_METRICS}
         super().__init__(
             log_per_layer=log_per_layer,
@@ -162,6 +182,12 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         )
         # (module, attribute name, original bound method) triples, for remove_hooks().
         self._wrapped: list[tuple[nn.Layer, str, object]] = []
+        # (layer_idx, component) -> token-mean of the *operator* h_res^T [n, n],
+        # for the composite product. Keyed rather than appended so the product is
+        # built in layer order, not call order (see _record_composite).
+        self._h_res_snapshot: dict[tuple[int, str], paddle.Tensor] = {}
+        # MTP layers are off the main trunk and must not enter the product.
+        self._mtp_layer_ids: set[int] = set()
 
     # ------------------------------------------------------------------
     # Discovery
@@ -190,6 +216,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         mtp_layer_ids = [item.idx for item in monitor_layers if item.is_mtp]
         if mtp_layer_ids:
             self.mark_mtp_layers(mtp_layer_ids)
+            self._mtp_layer_ids.update(mtp_layer_ids)
         for item in monitor_layers:
             for comp, attr in _COMPONENTS:
                 mod = getattr(item.layer, attr, None)
@@ -234,8 +261,14 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                 orig = mod.compute_mappings
                 mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
                 self._wrapped.append((mod, "compute_mappings", orig))
-                # The branch/residual ratio needs the sublayer output, which only
-                # exists at the point where the two update terms are combined.
+                # Wrapping `_compute_h` also sidesteps the `use_fused_mhc` fork:
+                # the fused path swaps `_sinkhorn_op` for a cuTile kernel whose
+                # intermediates are unreachable, but `_compute_h` is plain paddle
+                # either way.
+                orig_h = getattr(mod, "_compute_h", None)
+                if orig_h is not None:
+                    mod._compute_h = self._make_logits_capture(orig_h, layer_idx, comp)
+                    self._wrapped.append((mod, "_compute_h", orig_h))
                 orig_bda = getattr(mod, "fused_h_res_h_post_bda", None)
                 if orig_bda is None:
                     continue
@@ -263,7 +296,63 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             except AttributeError:
                 setattr(mod, attr, orig)
         self._wrapped = []
+        self._h_res_snapshot.clear()
         super().remove_hooks()
+
+    # ------------------------------------------------------------------
+    # Composite product (flush time, not hot path)
+    # ------------------------------------------------------------------
+
+    def _record_composite(self) -> None:
+        """Record the gains of the layer-ordered cumulative product of h_res^T.
+
+        The snapshots hold ``h_res^T``, i.e. the matrix ``apply_h_res`` actually
+        applies to the stream vector (``mixed = h_res^T @ residual``), so the
+        product ``A_k = h_res_k^T ... h_res_0^T`` is the real composite operator
+        from the first layer up to layer ``k``. ``_fwd`` is its max-abs row sum
+        (worst forward signal gain), ``_bwd`` its max-abs column sum.
+
+        Built from snapshots sorted by ``layer_idx``, so the result does not
+        depend on the order the hooks fired in — under recompute that order is
+        the reverse-layer backward replay, which is what retired the previous
+        composite metric. MTP layers are skipped: they are off the main trunk, so
+        multiplying them into the chain has no physical meaning.
+
+        Scope is the layers this rank owns: the whole model under sharding (every
+        rank holds all layers), but one stage under real pipeline parallelism,
+        which we can neither detect nor correct while
+        ``get_pipeline_model_parallel_{rank,world_size}`` are stubs in PaddleFleet
+        (they return 0 / 1 unconditionally).
+        """
+        for comp, _ in _COMPONENTS:
+            chain = sorted(
+                (
+                    (idx, mat)
+                    for (idx, c), mat in self._h_res_snapshot.items()
+                    if c == comp and idx not in self._mtp_layer_ids
+                ),
+                key=lambda item: item[0],
+            )
+            composite = None
+            for layer_idx, mat in chain:
+                composite = mat if composite is None else paddle.matmul(mat, composite)
+                self.record_layer_metric(
+                    layer_idx, f"{comp}_composite_amax_gain_fwd_max", amax_gain(composite, axis=-1)
+                )
+                self.record_layer_metric(
+                    layer_idx, f"{comp}_composite_amax_gain_bwd_max", amax_gain(composite, axis=-2)
+                )
+
+    def _flush_buffers(self) -> None:
+        if self._h_res_snapshot:
+            try:
+                with paddle.no_grad():
+                    self._record_composite()
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[PaddleMHCMonitor] Error composite: {e}")
+            self._h_res_snapshot.clear()
+        super()._flush_buffers()
 
     # ------------------------------------------------------------------
     # Capture wrapper (the hot path)
@@ -272,13 +361,12 @@ class PaddleMHCHealthMonitor(PaddleProbe):
     def _make_capture(self, orig, layer_idx: int, component: str):
         """Wrap ``compute_mappings`` to record metrics from its real return value.
 
-        VRAM safety: the mappings arrive attached to the training autograd
-        graph; we ``.detach()`` them and do all metric math under ``no_grad`` so
-        no stored tensor pins the graph through backward. The wrapper keeps no
-        state across calls — a deliberate constraint, since a monitored module
-        may be entered more than once per step (recompute replay, and mHC's own
-        fp32 / bf16 paths), and any cross-call accumulator would then depend on
-        execution order.
+        VRAM safety: the mappings arrive attached to the training autograd graph,
+        so they are detached and all metric math runs under ``no_grad`` — nothing
+        stored may pin the graph through backward. The wrapper also keeps no state
+        across calls, since a monitored module can be entered more than once per
+        step (recompute replay, and mHC's own fp32 / bf16 paths) and any
+        cross-call accumulator would depend on execution order.
         """
 
         def wrapped(x):
@@ -301,9 +389,28 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                     for name, value in h_post_structure_stats(h_post).items():
                         self.record_layer_metric(layer_idx, f"{component}_{name}", value)
 
-                    # Row sums of a Sinkhorn-projected h_res: 1 by construction,
-                    # so this is a NaN / divergence sentinel, not a diagnostic.
-                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-1))
+                    # Gains of the *operator*, not of `h_res` as written: streams
+                    # mix as `out_i = Σ_j h_res[j, i] · x_j`, so stream i's
+                    # forward gain is a **column** sum of `h_res` and its
+                    # backward gain a row sum. Columns are pinned to 1 by
+                    # construction (the Sinkhorn iteration ends on a column
+                    # normalization), so `_fwd` is a flat invariant guard while
+                    # `_bwd` carries the convergence residual.
+                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-2))
+                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, axis=-1))
+
+                    # Token-mean snapshot of the *operator* for the composite
+                    # product. `apply_h_res` mixes streams as
+                    # `mixed = h_res^T @ residual`, so the matrix that actually
+                    # acts on the stream vector is the transpose — composing
+                    # `h_res` itself would give neither the forward nor the
+                    # backward chain. Paper Fig 7b averages over tokens too, so
+                    # this holds one n x n matrix per layer/component. Last write
+                    # wins if the module is entered more than once per step.
+                    n = int(h_res.shape[-1])
+                    self._h_res_snapshot[(layer_idx, component)] = (
+                        h_res.astype("float32").reshape([-1, n, n]).mean(axis=0).transpose([1, 0])
+                    )
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMHCMonitor] Error layer {layer_idx}/{component}: {e}")
@@ -311,19 +418,43 @@ class PaddleMHCHealthMonitor(PaddleProbe):
 
         return wrapped
 
+    def _make_logits_capture(self, orig, layer_idx: int, component: str):
+        """Wrap ``_compute_h`` to record the saturation sentinel.
+
+        ``_compute_h`` returns ``(h_pre, h_post, h_res_logits)``; ``h_res_logits``
+        is the raw ``[..., n*n]`` mixing logits, which ``compute_mappings``
+        consumes immediately (``h_res = self._sinkhorn_op(...)``), so a wrapper
+        one level up cannot see it. ``n`` is read from ``h_pre``'s last axis
+        rather than config, in case ``num_residual_streams`` ever varies by layer.
+        Same VRAM discipline as ``_make_capture``.
+        """
+
+        def wrapped(proj, r):
+            out = orig(proj, r)  # the real mappings the model consumes — returned unchanged
+            if not self._should_monitor():
+                return out
+            try:
+                h_pre, _h_post, h_res_logits = out
+                n = int(h_pre.shape[-1])
+                with paddle.no_grad():
+                    for name, value in h_res_softmax_extrema(h_res_logits, n).items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[PaddleMHCMonitor] Error logits layer {layer_idx}/{component}: {e}")
+            return out
+
+        return wrapped
+
     def _make_bda_capture(self, orig, layer_idx: int, component: str):
         """Wrap ``fused_h_res_h_post_bda`` to record the branch/residual ratio.
 
-        This is the only place where both terms of the mHC update are available:
-        the call receives ``h_res`` + ``original_residual`` (the residual term's
-        inputs) and ``layer_output_with_bias`` (the branch term's input). Metrics
-        are derived from the **arguments**, so both the fused fast path and the
-        sequential dropout path are covered identically, and the call itself is
-        forwarded untouched.
-
-        Arguments are read by keyword with a positional fallback: PaddleFleet's
-        transformer layer calls this with keywords today, but relying on that
-        alone would silently stop recording if it ever switched.
+        The only place both mHC update terms are available: the call receives
+        ``h_res`` + ``original_residual`` and ``layer_output_with_bias``. Metrics
+        come from the **arguments**, so the fused fast path and the sequential
+        dropout path are covered identically. Arguments are read by keyword with a
+        positional fallback — PaddleFleet passes keywords today, but relying on
+        that alone would silently stop recording if it switched.
         """
 
         def wrapped(*args, **kwargs):

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 import sys
 import unittest
 from pathlib import Path
@@ -25,14 +26,26 @@ PaddleMHCHealthMonitor = mhc_monitor.PaddleMHCHealthMonitor
 class FakeHC(nn.Layer):
     """Stand-in for HyperConnectionModule exposing compute_mappings."""
 
-    def __init__(self, n, h_pre, h_post, h_res):
+    def __init__(self, n, h_pre, h_post, h_res, h_res_logits=None):
         super().__init__()
         self.n = n
         self._h_pre = h_pre
         self._h_post = h_post
         self._h_res = h_res
+        # Raw pre-Sinkhorn mixing logits. Zeros -> uniform rows -> every column
+        # sum is exactly 1, i.e. the healthy case.
+        if h_res_logits is None:
+            h_res_logits = paddle.zeros([*h_pre.shape[:-1], n * n])
+        self._h_res_logits = h_res_logits
+
+    def _compute_h(self, proj, r):
+        return self._h_pre, self._h_post, self._h_res_logits
 
     def compute_mappings(self, x):
+        # Mirrors the real module: _compute_h yields the raw logits, the Sinkhorn
+        # projection then turns them into h_res. Going through self._compute_h is
+        # what lets the monitor's instance-attribute shadowing see the logits.
+        self._compute_h(None, None)
         return self._h_pre, self._h_post, self._h_res
 
     def fused_h_res_h_post_bda(
@@ -159,6 +172,46 @@ class MHCMetricsTest(unittest.TestCase):
         )
         self.assertAlmostEqual(float(stats["branch_residual_share"]), 0.0, places=6)
 
+    def test_softmax_extrema_are_one_over_n_for_uniform_logits(self):
+        stats = mhc_metrics.h_res_softmax_extrema(paddle.zeros([5, 16]), 4)
+        self.assertAlmostEqual(float(stats["h_res_softmax_min"]), 0.25, places=6)
+        self.assertAlmostEqual(float(stats["h_res_softmax_max"]), 0.25, places=6)
+
+    def test_softmax_min_matches_exp_minus_range_over_S(self):
+        # p_min = exp(-R) / S with S = 1/p_max, so -log(p_min) = R + log(S).
+        # Row 2 has the widest spread (0 - (-4) = 4) and holds the smallest weight.
+        logits = paddle.to_tensor(
+            [[-2.0, 0.0, -3.0, -2.0], [-3.0, 0.0, -2.0, -1.0], [-3.0, -2.0, -4.0, 0.0], [-2.0, -2.0, -3.0, 0.0]],
+            dtype="float32",
+        ).reshape([1, 16])
+        p = paddle.nn.functional.softmax(logits.reshape([1, 4, 4]), axis=-1)
+        s = 1.0 / float(p[0, 2].max())
+        stats = mhc_metrics.h_res_softmax_extrema(logits, 4)
+        self.assertAlmostEqual(float(stats["h_res_softmax_min"]), math.exp(-4.0) / s, places=6)
+
+    def test_softmax_max_saturates_where_min_still_resolves(self):
+        # Row 0 is one winner against three losers at -R; spreads of 18 and 200
+        # both pin `max` at exactly 1.0, so it cannot separate them, while `min`
+        # and the logit range can.
+        near = paddle.zeros([1, 16])
+        far = paddle.zeros([1, 16])
+        near[0, 1:4] = -18.0
+        far[0, 1:4] = -200.0
+        s_near = mhc_metrics.h_res_softmax_extrema(near, 4)
+        s_far = mhc_metrics.h_res_softmax_extrema(far, 4)
+        self.assertEqual(float(s_near["h_res_softmax_max"]), 1.0)
+        self.assertEqual(float(s_far["h_res_softmax_max"]), 1.0)
+        self.assertGreater(float(s_near["h_res_softmax_min"]), float(s_far["h_res_softmax_min"]))
+
+    def test_softmax_min_underflows_to_zero_past_the_alarm(self):
+        # A spread past ~103 drives softmax's smallest entry below fp32's smallest
+        # denormal, so the series bottoms out at exactly 0. That is past the alarm
+        # (1.18e-38, i.e. a spread of ~87) and the model cannot tell 0 from 1e-44
+        # either — `_sinkhorn_normalize` adds the same 1e-6 to both.
+        far = paddle.zeros([1, 16])
+        far[0, 1:4] = -200.0
+        self.assertEqual(float(mhc_metrics.h_res_softmax_extrema(far, 4)["h_res_softmax_min"]), 0.0)
+
 
 class MHCMonitorTest(unittest.TestCase):
     def setUp(self):
@@ -218,20 +271,17 @@ class MHCMonitorTest(unittest.TestCase):
             # h_pre == 0.5 everywhere, h_post == 1.0 everywhere.
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_mean"], 0.5, places=5)
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_mean"], 1.0, places=5)
-            # amax_gain_fwd is a gatekeeper: global only, no per-layer series.
-            self.assertNotIn(f"mhc_health/layer_0/{comp}_amax_gain_fwd", latest)
-            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_amax_gain_fwd"], 1.0, places=4)
-        # The retired series must stay gone.
-        for comp in ("attn", "mlp"):
-            for key in ("amax_gain_bwd", "composite_amax_gain_fwd", "composite_amax_gain_bwd"):
-                self.assertNotIn(f"mhc_health/layer_0/{comp}_{key}", latest)
-                self.assertNotIn(f"mhc_health/global_{comp}_{key}", latest)
+            # Both amax gains are emitted per layer and globally.
+            for key in ("amax_gain_fwd", "amax_gain_bwd"):
+                self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_{key}"], 1.0, places=4)
+                self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_{key}"], 1.0, places=4)
 
-    def test_amax_gain_fwd_is_the_row_sum(self):
-        # An asymmetric, row-stochastic (but not column-stochastic) h_res pins the
-        # convention: amax_gain_fwd must read the ROW sums (1.0 here), never the
-        # column sums (1.5 here). Identity matrices cannot tell the two apart,
-        # which is how the fwd/bwd label mix-up stayed invisible.
+    def test_amax_gain_axes_are_not_swapped(self):
+        # An asymmetric h_res pins the convention. Streams mix as
+        # `out = h_res^T @ x`, so _fwd must read the COLUMN sums of h_res (1.5
+        # here) and _bwd the ROW sums (1.0 here) — single layer and composite
+        # agree. Identity matrices cannot tell the two apart, which is how the
+        # fwd/bwd label mix-up stayed invisible.
         n, s, b = 2, 1, 1
         h_res = paddle.to_tensor([[0.75, 0.25], [0.75, 0.25]]).reshape([1, 1, n, n]).expand([s, b, n, n])
         hc = FakeHC(
@@ -248,7 +298,171 @@ class MHCMonitorTest(unittest.TestCase):
         monitor.step()
 
         latest = training_logs.get_latest(prefix="mhc_health")
-        self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_fwd"], 1.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_fwd"], 1.5, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_bwd"], 1.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_fwd_max"], 1.5, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_bwd_max"], 1.0, places=5)
+
+    def test_softmax_extrema_are_recorded_and_reduce_by_extremum_across_layers(self):
+        # layer_0 healthy (uniform logits), layer_1 saturated. The global series
+        # must reduce by MIN / MAX so the sick layer is not averaged away.
+        n, s, b = 4, 2, 3
+        saturated = (
+            paddle.to_tensor(
+                [[-25.7, 0.0, -100.0, -61.0], [-33.4, 0.0, -89.0, -48.0]]
+                + [[-34.0, -24.9, -104.0, 0.0], [-79.4, -72.6, -104.0, 0.0]],
+                dtype="float32",
+            )
+            .reshape([1, 1, n * n])
+            .expand([s, b, n * n])
+        )
+
+        def sick_hc():
+            return FakeHC(
+                n=n,
+                h_pre=paddle.full([s, b, n], 0.5),
+                h_post=paddle.ones([s, b, n]),
+                h_res=paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n]),
+                h_res_logits=paddle.assign(saturated),
+            )
+
+        model = _mhc_model([self._identity_layer(n, s, b), FakeLayer(attn=sick_hc(), mlp=sick_hc())])
+
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_softmax_min"], 0.25, places=5)
+            self.assertLess(latest[f"mhc_health/layer_1/{comp}_h_res_softmax_min"], 1e-30)
+            self.assertLess(latest[f"mhc_health/global_{comp}_h_res_softmax_min"], 1e-30)
+            # max: uniform layer also reads 1/n, saturated layer pins at 1.0, and
+            # the global series reduces by MAX.
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_softmax_max"], 0.25, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_softmax_max"], 1.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_softmax_max"], 1.0, places=5)
+
+    def test_composite_is_built_in_layer_order_not_call_order(self):
+        # Regression test for what retired the previous composite metric: it was
+        # accumulated in call order, which under recompute is the reverse-layer
+        # backward replay. Here the hooks are fired in reverse on purpose.
+        n, s, b = 4, 1, 1
+        mats = [
+            paddle.to_tensor(
+                [[0.9, 0.1, 0.0, 0.0], [0.1, 0.9, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+                dtype="float32",
+            ),
+            paddle.to_tensor(
+                [[1.0, 0.0, 0.0, 0.0], [0.0, 1.5, 0.0, 0.0], [0.0, 0.0, 0.5, 0.5], [0.0, 0.0, 0.5, 0.5]],
+                dtype="float32",
+            ),
+            paddle.to_tensor(
+                [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+                dtype="float32",
+            ),
+        ]
+
+        def row_gain(m):
+            return float(m.sum(axis=-1).abs().max())
+
+        def col_gain(m):
+            return float(m.sum(axis=-2).abs().max())
+
+        def chain(seq, gain):
+            # apply_h_res mixes with h_res^T, so the composite operator is built
+            # from the transposes.
+            out, acc = [], None
+            for m in seq:
+                op = m.transpose([1, 0])
+                acc = op if acc is None else paddle.matmul(op, acc)
+                out.append(gain(acc))
+            return out
+
+        expected = chain(mats, row_gain)
+        expected_bwd = chain(mats, col_gain)
+        # Guard against a vacuous test: the reversed product must actually differ.
+        self.assertNotAlmostEqual(expected[-1], chain(list(reversed(mats)), row_gain)[-1], places=4)
+
+        def layer_for(mat):
+            def make_hc():
+                return FakeHC(
+                    n=n,
+                    h_pre=paddle.full([s, b, n], 0.5),
+                    h_post=paddle.ones([s, b, n]),
+                    h_res=paddle.assign(mat.reshape([1, 1, n, n]).expand([s, b, n, n])),
+                )
+
+            return FakeLayer(attn=make_hc(), mlp=make_hc())
+
+        model = _mhc_model([layer_for(m) for m in mats])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(list(reversed(targets)), x_dim=n * 8)  # deliberately out of order
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for idx, (want_fwd, want_bwd) in enumerate(zip(expected, expected_bwd)):
+                self.assertAlmostEqual(
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_fwd_max"], want_fwd, places=4
+                )
+                self.assertAlmostEqual(
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_bwd_max"], want_bwd, places=4
+                )
+            # Global reduces by max over layers.
+            self.assertAlmostEqual(
+                latest[f"mhc_health/global_{comp}_composite_amax_gain_fwd_max"], max(expected), places=4
+            )
+            self.assertAlmostEqual(
+                latest[f"mhc_health/global_{comp}_composite_amax_gain_bwd_max"], max(expected_bwd), places=4
+            )
+
+    def test_composite_is_one_for_identity_chain(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b) for _ in range(3)])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for idx in range(3):
+                self.assertAlmostEqual(
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_fwd_max"], 1.0, places=5
+                )
+
+    def test_composite_skips_mtp_layers(self):
+        # MTP layers are off the main trunk; multiplying them into the chain has no
+        # physical meaning. Marking layer_1 as MTP must leave the layer_0 value
+        # untouched and emit nothing for layer_1.
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b) for _ in range(2)])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        monitor._mtp_layer_ids.add(1)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            self.assertAlmostEqual(
+                latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_fwd_max"], 1.0, places=5
+            )
+            self.assertNotIn(f"mhc_health/layer_1/{comp}_composite_amax_gain_fwd_max", latest)
+
+    def test_composite_snapshot_is_cleared_each_step(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        self.assertTrue(monitor._h_res_snapshot)
+        monitor.step()
+        # Stale matrices must not survive into the next step's product.
+        self.assertFalse(monitor._h_res_snapshot)
 
     def test_branch_residual_share_is_recorded_from_bda(self):
         n, s, b, c = 4, 2, 3, 6


### PR DESCRIPTION
## 背景

算法侧希望能看到 mHC 内部更细的形态：现有指标全是层内平均，矩阵内部出问题（某一行退化、跨层累计放大）
在平均后完全看不出来。同时 `amax_gain_fwd` 求和轴与实现的真实算子不一致。

## 改动

新增 5 个指标（每个 hc 模块，`attn_` / `mlp_` 前缀）：

- `h_res_softmax_min` / `h_res_softmax_max` — Sinkhorn **之前**的 softmax 极值，饱和哨兵。饱和行的 softmax 雅可比 `diag(p) − ppᵀ ≈ 0`，`mapping_proj` / `alpha_res` 收不到梯度且不可自愈；成品 `h_res` 的行列和被 Sinkhorn 钉在 1，这是唯一能看到该失效模式的窗口。
- `amax_gain_bwd` — 单层反向最坏放大，承载 Sinkhorn 截断迭代的收敛残差。
- `composite_amax_gain_{fwd,bwd}_max` — 从首层累计到本层的复合算子增益，对应论文 Fig 7(b) 的剖面拱形，单层指标看不出来。

## 口径修正（会改变已上线曲线的含义）

`apply_h_res` 与 fused cuTile kernel 都按 `out_i = Σ_j h_res_ji · x_j` 混流（`hyper_connection.py:456-471`、`fused_mhc_kernels.py:367-373`），即真正作用在流向量上的算子是`h_resᵀ`，不是论文 Eq. (3) 字面写的 `h_res`。因此：

- 前向增益 = `h_res` 的**列**和，反向增益 = 行和。原来的 `amax_gain_fwd`/`_bwd` 是反的，已交换。
- Sinkhorn 最后一步是列归一，所以 `_fwd` 被钉死为 1（不变量守卫），承载残差的是 `_bwd`。
- 论文 Eq. (9) 最后一步是行归一，它 Fig 7 会动的是 forward 那条，**两边曲线不可直接对比**。

## 实现要点

- 复合累乘在 **flush 时**按 `layer_idx` 排序进行，hook 内只存 token 平均并转置后的 `n×n` 快照。这样结果与 hook 触发顺序无关——该顺序在 recompute 下是反向重放的逆序，正是复合指标当初被下线的原因。
- MTP 层不在主干传播路径上，累乘时跳过。
- 复合的作用域是**本 rank 持有的层**。当前配置（`sharding: stage1`，无 PP）下即全部层；真开 PP 后会退化成 stage 内语义，而 `get_pipeline_model_parallel_{rank,world_size}` 在 PaddleFleet 里还是 stub，检测不到也修不了，详见 `docs/mhc_health.md`。
- `h_res_softmax_*` 需要 Sinkhorn 之前的 logits，额外包裹 `_compute_h`（顺带绕开 `use_fused_mhc` 分叉）。
- 热路径纪律不变：全部 detach + `no_grad`、无 D2H 同步、无 hook 内 collective、schema 在`allocate_buffers` 之前声明完。