### PR TITLE
[feat] 新增 optim/update_rms 与 param_rms，始终开启

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 
+以及一个挂在**优化器**而不是模型上的模块，**始终开启**（无开关，调用方零改动）：
+- **[Optimizer Update](./docs/optim_update.md)** — `optim/update_rms`、`optim/param_rms`、`optim/update_param_ratio`，每 step 一个标量，与 grad norm 并排看
+
 ---
 
 ## 快速开始
@@ -606,3 +609,6 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **VHA** | `premix_group_div_ratio` | `mean‖W_g−W_g'‖²/mean‖W_g−I‖²` | mean | 0=各组同一变换, 2=完全独立 |
 | **VHA** | `premix_sigma_max` | `σ_max(W)` | max | premix 谱范数 (需 use_vha_premix) |
 | **VHA** | `premix_orth_dev` | `‖WᵀW − I‖_F` | mean | 仅非方阵 premix (正交初始化) |
+| **Optim** | `update_rms` | `sqrt(mean((θ_new−θ_old)²))` | 已全局归约 | 本 step 参数更新幅度 (始终开启) |
+| **Optim** | `param_rms` | `sqrt(mean(θ_new²))` | 已全局归约 | 更新后参数尺度 (始终开启) |
+| **Optim** | `update_param_ratio` | `update_rms / param_rms` | 已全局归约 | trust ratio, ~1e-3 健康 (始终开启) |

--- a/docs/optim_update.md
+++ b/docs/optim_update.md
@@ -1,0 +1,105 @@
+# Optimizer Update Monitor (`optim/*`)
+
+每个 training step 上报三个标量，与 grad norm / param norm 并排读：
+
+| 指标 | 公式 | 含义 |
+|---|---|---|
+| `optim/update_rms` | `sqrt(mean((θ_new − θ_old)²))` | 本 step 实际施加的参数更新幅度 |
+| `optim/param_rms` | `sqrt(mean(θ_new²))` | 更新后的参数尺度 |
+| `optim/update_param_ratio` | `update_rms / param_rms` | trust ratio，健康量级 ~1e-3 |
+
+**始终开启，没有配置开关，也不需要调用方多写一行**：它在 `_ALWAYS_ON_MONITORS` 里而不在
+`_MONITOR_MAP` 里，因此 `setup_internal_medicine` / `setup_monitors` 无论 `monitors` 传什么
+都会装上它；不是 `internal_medicine_monitors` 的一项，也不受
+`internal_medicine_monitor_interval` 门控。每 step 都算，随 `logger.log_interval` 打印。
+
+指标 key 前缀是 `optim/`，而 `monitor_dict` 的 key 也是 `optim` —— 两者刻意一致，这样调用方
+"遍历 `monitor_dict` key 当 prefix 打印 `training_logs`" 的既有循环就会自动带上这三个值，
+TB 也走既有的 `aggregated_metrics` 写入。**训练脚本侧零改动。**
+
+## 为什么补丁打在类上而不是实例上
+
+优化器在模型侧 monitor 安装时（pre-wrap hook）**还不存在**。若要拿实例，就得在训练脚本里多注册
+一个能看到 `ctx.optimizer` 的回调——那等于把这套逻辑摊到第二个仓库里去。因此改为直接包
+`Float16OptimizerWithFloat16Params` 与 `DistributedOptimizer` 两个**类**上的
+`_copy_main_params_to_model_params`（这两个是真正定义该方法的具体子类，共同基类
+`MixedPrecisionOptimizer` 上没有），`self` 从调用里取，之后构造的任何优化器实例都被覆盖。
+`remove_hooks` 把类属性还原。
+
+## 不额外保存一份参数
+
+`MixedPrecisionOptimizer.step_with_ready_grads`（`megatron/core/optimizer/optimizer.py:712`）
+的顺序是：
+
+```python
+self.optimizer.step()                     # fp32 master: θ_old -> θ_new
+self._copy_main_params_to_model_params()  # 把 θ_new 写回 bf16 model param
+```
+
+**这两行之间**，fp32 master 已经是 θ_new，而 bf16 model param 仍然是 θ_old —— 更新前的值
+本来就还活着。因此本 monitor 只把 `_copy_main_params_to_model_params` 包一层，在里面读这一
+对张量，**不需要在 step 前 clone 任何参数**（那会让显存翻倍）。
+
+`token_dispatcher` 那套按实例打补丁的手法在这里复用；`remove_hooks` 时还原（类方法的情况
+删实例属性，避免留下 bound-method 引用环）。
+
+逐 shard 的和按 1 Mi 元素**分块**累加，因此 elementwise 临时张量恒为几 MB，与参数规模无关。
+
+## bf16 去偏（必需，不是可选优化）
+
+θ_old 是 bf16，本身带舍入误差；当更新量降到 bf16 分辨率附近时，原始差值会被这个误差主导。
+实测（200k 元素，θ ~ N(0, 0.02²)）：
+
+| lr | 真实 \|Δθ\| | 原始差值 | 偏差 | 去偏后 |
+|---|---|---|---|---|
+| 3e-4 | 3.00e-4 | 3.01e-4 | 1.01× | 1.00× |
+| 1e-4 | 1.00e-4 | 1.05e-4 | 1.05× | 1.00× |
+| 3e-5 | 3.00e-5 | 4.48e-5 | 1.49× | 1.00× |
+| 1e-5 | 9.98e-6 | 3.46e-5 | 3.46× | 1.00× |
+| 3e-6 | 3.00e-6 | 3.33e-5 | **11.10×** | 1.00× |
+
+cosine decay 尾段 lr 正好落在 1e-5~1e-6，原始形式在那里完全不可用。
+
+去偏方式：用 `θ_new − bf16(θ_new)` 估计 bf16 舍入方差（同一个张量，免费），在 mean-square
+空间里减掉。全 lr 段回到 1.00×。`debias_low_precision=False` 可关掉（只用于测试对照）。
+
+## 跨 rank 归约
+
+主参数被 distributed optimizer 按 **DP+CP** 切分，再按 TP/PP 切分，与
+`calc_params_l2_norm`（`megatron/bridge/training/utils/train_utils.py:285`）同一套语义：
+
+| bucket | shard 维归约 | model 维归约 |
+|---|---|---|
+| dense | `dp_cp` | `mp` |
+| expert (`allreduce=False`) | expert-DP | expert-TP/PP |
+
+`(ss_update, ss_param, ss_bf16_noise, count)` 打成一个 fp64 4-vector，每个 bucket 两次
+collective。RMS 对和是非线性的，所以**先归约再相除**。
+
+count 用 fp64：总参数量 × shard 数远超 fp32 的 `2**24` 精确整数上限。
+
+去重与 grad-norm 一致，且判据取在**原始 model param** 上（`allreduce` 这个 dense/expert
+标记不在 `copy_optimizer_param_metadata` 拷到 shard view 的属性里）：
+
+- `shared`（tied embedding，跨 PP stage 出现两次）→ 跳过
+- TP **replicated** 参数只在 tp rank 0 计入；TP **sharded** 参数每个 rank 都计入
+
+即使某个 bucket 本 rank 没有 shard，也照样发起两次 collective —— 一个 rank 可能没有 expert
+shard 而 peer 有，跳过就会挂。
+
+## 未覆盖的部分
+
+- **纯 fp32 参数**（`shard_fp32_groups`）就地更新，不存在"更新前的副本"，因此不计入
+  `update_rms`。首次遇到时打一条 warning。bf16-mixed 训练下这类参数通常为空。
+- **Megatron-FSDP** 路径的 main weights 由 `param_and_grad_buffer` 管理，未走本 monitor
+  依赖的 group 结构；此时不上报（不会报错）。
+
+## 怎么读
+
+- `update_param_ratio` ~1e-3 是常见的健康量级；持续 ≫1e-2 说明单步动得太狠，
+  配合 grad norm 与 lr 一起看。
+- `update_rms` 应大致随 lr schedule 走。lr 在降但 update_rms 不降，通常意味着
+  Adam 的二阶矩塌了（`v` 变小把 `1/√v` 放大）。
+- `update_rms` 突然掉到 ~0 而 grad norm 正常 → 检查是否被 loss-scale 跳步
+  （skipped iter）或 clip 压死。
+- `param_rms` 单调上升 → weight decay 没有压住增长。

--- a/src/internal_medicine/backends/megatron/__init__.py
+++ b/src/internal_medicine/backends/megatron/__init__.py
@@ -7,6 +7,7 @@ from .gather import install_gather_fn
 from .massive_activation_monitor import MassiveActivationMonitor, setup_massive_activation_monitor
 from .mhc_monitor import MHCHealthMonitor, setup_mhc_monitor
 from .moe_monitor import MoESpecialistMonitor, setup_moe_monitor
+from .optim_update_monitor import OptimUpdateMonitor, setup_optim_update_monitor
 from .ple_monitor import PLEHealthMonitor, setup_ple_monitor
 from .qk_monitor import QKStatsMonitor, setup_qk_monitor
 
@@ -19,6 +20,8 @@ _MONITOR_MAP = {
     "massive_act": setup_massive_activation_monitor,
     "mhc_health": setup_mhc_monitor,
 }
+
+_ALWAYS_ON_MONITORS = {"optim": setup_optim_update_monitor}
 
 
 def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, verbose=False, **kwargs):
@@ -33,12 +36,13 @@ def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, 
     if monitor_dict is None:
         monitor_dict = {}
 
-    for name in monitors:
-        if name not in _MONITOR_MAP:
+    for name in [*_ALWAYS_ON_MONITORS, *monitors]:
+        setup_fn = _ALWAYS_ON_MONITORS.get(name) or _MONITOR_MAP.get(name)
+        if setup_fn is None:
             logger.warning(f"[InternalMedicine/megatron] Unknown monitor: {name}, skipping")
             continue
         try:
-            _MONITOR_MAP[name](
+            setup_fn(
                 model,
                 monitor_dict=monitor_dict,
                 monitor_interval=monitor_interval,
@@ -66,4 +70,6 @@ __all__ = [
     "setup_massive_activation_monitor",
     "MHCHealthMonitor",
     "setup_mhc_monitor",
+    "OptimUpdateMonitor",
+    "setup_optim_update_monitor",
 ]

--- a/src/internal_medicine/backends/megatron/optim_update_monitor.py
+++ b/src/internal_medicine/backends/megatron/optim_update_monitor.py
@@ -1,0 +1,388 @@
+"""Optimizer update-magnitude monitor for the Megatron backend.
+
+Emits three always-on scalars per training step, alongside grad-norm / param-norm:
+
+    optim/update_rms        sqrt(mean((theta_new - theta_old)**2))
+    optim/param_rms         sqrt(mean(theta_new**2))
+    optim/update_param_ratio  update_rms / param_rms   (the "trust ratio", ~1e-3 healthy)
+
+No copy of the parameters is kept. ``MixedPrecisionOptimizer.step_with_ready_grads``
+runs ``self.optimizer.step()`` and then ``self._copy_main_params_to_model_params()``;
+between those two calls the fp32 main param already holds ``theta_new`` while the bf16
+model param still holds ``theta_old``. Wrapping the copy method therefore reads the
+pre-update value for free.
+
+The bf16 ``theta_old`` is rounded, which inflates the raw difference once the update is
+small (measured 11x at lr 3e-6). ``mean_sq`` is debiased by subtracting the bf16
+round-trip variance of ``theta_new``, which restores agreement to 1.00x across
+lr 3e-4 .. 3e-6.
+"""
+
+import contextlib
+import logging
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from ...core.training_logs import training_logs
+
+logger = logging.getLogger(__name__)
+
+METRIC_PREFIX = "optim"
+
+_CHUNK = 1 << 20
+
+
+def _param_is_not_shared(param) -> bool:
+    return not getattr(param, "shared", False)
+
+
+def _param_is_not_tp_duplicate(param, tp_group) -> bool:
+    """Whether this rank owns the canonical copy of ``param`` for TP purposes.
+
+    A TP-sharded param is distinct on every TP rank, so every rank counts it. A
+    replicated param would otherwise be counted once per TP rank, so only rank 0 does.
+    Same rule as ``MegatronOptimizer._filter_grads_for_norm``.
+    """
+    if getattr(param, "tensor_model_parallel", False):
+        return True
+    try:
+        from megatron.core.tensor_parallel.layers import param_is_not_tensor_parallel_duplicate
+
+        return bool(param_is_not_tensor_parallel_duplicate(param, tp_group))
+    except Exception:
+        if tp_group is not None:
+            return tp_group.rank() == 0
+        return True
+
+
+def _pair_sums(main: torch.Tensor, model: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Return ``(sum_sq_update, sum_sq_param, sum_sq_bf16_noise, numel)`` for one shard.
+
+    ``main`` is fp32 ``theta_new``; ``model`` is the lower-precision ``theta_old`` view.
+    Walked in ``_CHUNK`` slices so the elementwise temporary stays a few MB regardless of
+    parameter size, instead of allocating a full fp32 copy of the shard.
+    """
+    flat_main = main.reshape(-1)
+    flat_model = model.reshape(-1)
+    n = flat_main.numel()
+    ss_u = torch.zeros((), dtype=torch.float32, device=flat_main.device)
+    ss_q = torch.zeros((), dtype=torch.float32, device=flat_main.device)
+    for start in range(0, n, _CHUNK):
+        a = flat_main[start : start + _CHUNK]
+        b = flat_model[start : start + _CHUNK]
+        ss_u += torch.linalg.vector_norm(a - b, dtype=torch.float32).square()
+        ss_q += torch.linalg.vector_norm(a - a.to(model.dtype).to(a.dtype), dtype=torch.float32).square()
+    ss_p = torch.linalg.vector_norm(flat_main, dtype=torch.float32).square()
+    return ss_u, ss_p, ss_q, n
+
+
+class OptimUpdateMonitor:
+    """Measure the RMS parameter update applied by the optimizer, once per step.
+
+    Not a ``TorchProbe``: there are no forward hooks and no per-layer metrics. It wraps
+    one optimizer method, accumulates 0-dim GPU tensors there, and reduces + logs in
+    ``step()`` (which runs outside any forward, so collectives are free to happen).
+    """
+
+    def __init__(self, verbose: bool = False, debias_low_precision: bool = True):
+        self.verbose = verbose
+        self.debias_low_precision = debias_low_precision
+        self._patched: list[tuple[Any, str, Any, bool]] = []
+        self._pending_dense: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]] = []
+        self._pending_expert: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]] = []
+        self._groups_resolved = False
+        self._dp_cp_group = None
+        self._expt_dp_group = None
+        self._mp_group = None
+        self._expert_group = None
+        self._warned_fp32 = False
+        self._warned_no_pairs = False
+        self.latest: dict[str, float] = {}
+
+    def attach_optimizer(self, optimizer) -> bool:
+        """Wrap this optimizer instance's main-param copy. Returns True if any wrapped."""
+        self._resolve_groups()
+        for opt in self._iter_optimizers(optimizer):
+            for method in ("_copy_main_params_to_model_params", "_copy_main_params_to_param_buffer"):
+                original = getattr(opt, method, None)
+                if original is None or getattr(original, "_im_update_patched", False):
+                    continue
+                self._install(opt, method, original, instance_level=True)
+        if not self._patched and not self._warned_no_pairs:
+            self._warned_no_pairs = True
+            logger.warning("[OptimUpdateMonitor] no main-param copy method found; update_rms unavailable")
+        return bool(self._patched)
+
+    def attach_optimizer_classes(self) -> bool:
+        """Wrap ``_copy_main_params_to_model_params`` on the mcore optimizer CLASSES.
+
+        Patching the class rather than an instance is what lets this monitor be installed
+        from the same model-side setup path as every other monitor: the optimizer does not
+        exist yet at that point, and threading it in later would mean an extra callback in
+        every training script. Every optimizer built afterwards is covered.
+
+        Both concrete subclasses that define the copy are wrapped —
+        ``Float16OptimizerWithFloat16Params`` (non-distributed) and
+        ``DistributedOptimizer`` — since the copy is not defined on the shared
+        ``MixedPrecisionOptimizer`` base. ``self`` is read from the call, so one wrapper
+        serves all instances.
+        """
+        self._resolve_groups()
+        classes = []
+        try:
+            from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+            from megatron.core.optimizer.optimizer import Float16OptimizerWithFloat16Params
+
+            classes = [Float16OptimizerWithFloat16Params, DistributedOptimizer]
+        except ImportError:
+            logger.warning("[OptimUpdateMonitor] megatron.core optimizer unavailable; update_rms disabled")
+            return False
+        for cls in classes:
+            for method in ("_copy_main_params_to_model_params", "_copy_main_params_to_param_buffer"):
+                original = cls.__dict__.get(method)
+                if original is None or getattr(original, "_im_update_patched", False):
+                    continue
+                self._install(cls, method, original, instance_level=False)
+        return bool(self._patched)
+
+    def _iter_optimizers(self, optimizer):
+        chained = getattr(optimizer, "chained_optimizers", None)
+        if chained:
+            for opt in chained:
+                yield from self._iter_optimizers(opt)
+        else:
+            yield optimizer
+
+    def _install(self, target, method: str, original, instance_level: bool) -> None:
+        """Wrap ``target.method`` so the update is measured just before the copy-back.
+
+        ``instance_level`` selects how ``self`` reaches ``_measure``: an instance patch
+        closes over the optimizer, a class patch reads it from the call's first argument.
+        """
+        monitor = self
+
+        if instance_level:
+
+            def patched(*args, **kwargs):
+                monitor._measure_safe(target)
+                return original(*args, **kwargs)
+
+            was_instance_attr = method in vars(target)
+        else:
+
+            def patched(self, *args, **kwargs):
+                monitor._measure_safe(self)
+                return original(self, *args, **kwargs)
+
+            was_instance_attr = False
+
+        patched._im_update_patched = True
+        # For an instance patch, remember whether the name already lived on the instance:
+        # these are normally class methods, so the correct revert is to delete our
+        # instance attribute and let class lookup resume, rather than leave a bound
+        # method (an instance -> bound-method -> instance reference cycle) behind.
+        setattr(target, method, patched)
+        self._patched.append((target, method, original, was_instance_attr))
+
+    def _measure_safe(self, opt) -> None:
+        try:
+            self._measure(opt)
+        except Exception as e:
+            if self.verbose:
+                logger.error(f"[OptimUpdateMonitor] measure error: {e}")
+
+    @torch.no_grad()
+    def _measure(self, opt) -> None:
+        """Accumulate per-shard sums while ``theta_old`` is still in the model params.
+
+        Dense and expert shards are bucketed separately because they reduce over
+        different groups (see ``step``). The dedup predicates are evaluated on the
+        ORIGINAL model param, not the shard view: ``allreduce`` (the dense/expert marker)
+        is not among the attributes copied onto shard views by
+        ``copy_optimizer_param_metadata``.
+        """
+        if getattr(opt, "is_stub_optimizer", False):
+            return
+        triples = self._param_triples(opt)
+        if not triples:
+            return
+        if getattr(opt, "shard_fp32_groups", None) and not self._warned_fp32:
+            self._warned_fp32 = True
+            logger.warning(
+                "[OptimUpdateMonitor] fp32 params are updated in place (no pre-update copy exists); "
+                "they are excluded from update_rms."
+            )
+        tp_group = getattr(opt, "tp_group", None)
+        for main, model_shard, model_param in triples:
+            if main is None or model_shard is None or main.numel() != model_shard.numel():
+                continue
+            owner = model_param if model_param is not None else model_shard
+            if not _param_is_not_shared(owner) or not _param_is_not_tp_duplicate(owner, tp_group):
+                continue
+            sums = _pair_sums(main.detach(), model_shard.detach())
+            if getattr(owner, "allreduce", True):
+                self._pending_dense.append(sums)
+            else:
+                self._pending_expert.append(sums)
+
+    @staticmethod
+    def _param_triples(opt):
+        """``(fp32_main_shard, low_precision_shard, original_model_param)`` per param.
+
+        The three group lists are index-parallel by construction: ``DistOpt``'s own
+        ``_copy_main_params_to_model_params`` zips ``shard_fp32_from_float16_groups``
+        against ``model_float16_groups`` the same way.
+        """
+        main_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+        shard_groups = getattr(opt, "shard_float16_groups", None)
+        model_groups = getattr(opt, "model_float16_groups", None)
+        if main_groups is None or shard_groups is None:
+            main_groups = getattr(opt, "fp32_from_float16_groups", None)
+            shard_groups = getattr(opt, "float16_groups", None)
+            model_groups = shard_groups
+        if main_groups is None or shard_groups is None:
+            return []
+        triples = []
+        for gi, (main_group, shard_group) in enumerate(zip(main_groups, shard_groups, strict=False)):
+            model_group = model_groups[gi] if model_groups is not None and gi < len(model_groups) else []
+            for pi, (main, shard) in enumerate(zip(main_group, shard_group, strict=False)):
+                model_param = model_group[pi] if pi < len(model_group) else None
+                triples.append((main, shard, model_param))
+        return triples
+
+    def _resolve_groups(self) -> None:
+        if self._groups_resolved:
+            return
+        self._groups_resolved = True
+        try:
+            from megatron.core import parallel_state as ps
+
+            if not ps.model_parallel_is_initialized():
+                return
+            self._dp_cp_group = ps.get_data_parallel_group(with_context_parallel=True)
+            self._mp_group = ps.get_model_parallel_group()
+            for getter, attr in (
+                (getattr(ps, "get_expert_data_parallel_group", None), "_expt_dp_group"),
+                (getattr(ps, "get_expert_tensor_model_pipeline_parallel_group", None), "_expert_group"),
+            ):
+                if getter is None:
+                    continue
+                with contextlib.suppress(Exception):
+                    setattr(self, attr, getter())
+        except ImportError:
+            pass
+
+    def _all_reduce(self, vec: torch.Tensor, group) -> torch.Tensor:
+        if group is None or not dist.is_available() or not dist.is_initialized():
+            return vec
+        dist.all_reduce(vec, op=dist.ReduceOp.SUM, group=group)
+        return vec
+
+    def _pool(self, pending, shard_group, model_group, device) -> torch.Tensor:
+        """Reduce one bucket's ``(ss_update, ss_param, ss_bf16_noise, count)`` globally.
+
+        Always issues both collectives, even with nothing pending, so every rank makes
+        the same number of calls — a rank can legitimately own no expert shard while a
+        peer does, and skipping the reduce there would hang.
+        """
+        acc = torch.zeros(4, dtype=torch.float64, device=device)
+        for ss_u, ss_p, ss_q, n in pending:
+            acc[0] += ss_u.to(torch.float64)
+            acc[1] += ss_p.to(torch.float64)
+            acc[2] += ss_q.to(torch.float64)
+            acc[3] += float(n)
+        self._all_reduce(acc, shard_group)
+        self._all_reduce(acc, model_group)
+        return acc
+
+    @torch.no_grad()
+    def step(self, global_step: int | None = None) -> dict[str, float]:
+        """Reduce the step's sums, publish the scalars, and return them.
+
+        Main params are sharded over DP+CP by the distributed optimizer and split again
+        over TP/PP, so the sums pool over the shard group and then the model-parallel
+        group — mirroring ``calc_params_l2_norm``. Expert params live on different groups
+        (expert-DP, then expert-TP/PP), hence the separate bucket. RMS is nonlinear in the
+        sums, so all pooling happens before the division.
+        """
+        dense, self._pending_dense = self._pending_dense, []
+        expert, self._pending_expert = self._pending_expert, []
+        self.latest = {}
+        if not dense and not expert and not self._patched:
+            return self.latest
+
+        device = None
+        for bucket in (dense, expert):
+            if bucket:
+                device = bucket[0][0].device
+                break
+        if device is None:
+            return self.latest
+
+        acc = self._pool(dense, self._dp_cp_group, self._mp_group, device)
+        acc += self._pool(
+            expert,
+            self._expt_dp_group or self._dp_cp_group,
+            self._expert_group or self._mp_group,
+            device,
+        )
+
+        if float(acc[3]) <= 0.0:
+            return self.latest
+        count = acc[3].clamp(min=1.0)
+        update_ms = acc[0] / count
+        param_ms = acc[1] / count
+        if self.debias_low_precision:
+            update_ms = (update_ms - acc[2] / count).clamp(min=0.0)
+        update_rms = float(update_ms.sqrt())
+        param_rms = float(param_ms.sqrt())
+        self.latest = {
+            f"{METRIC_PREFIX}/update_rms": update_rms,
+            f"{METRIC_PREFIX}/param_rms": param_rms,
+            f"{METRIC_PREFIX}/update_param_ratio": update_rms / param_rms if param_rms > 0 else 0.0,
+        }
+        training_logs.update(**self.latest)
+        return self.latest
+
+    def remove_hooks(self) -> None:
+        for target, method, original, was_instance_attr in self._patched:
+            current = target.__dict__.get(method) if isinstance(target, type) else getattr(target, method, None)
+            if not getattr(current, "_im_update_patched", False):
+                continue
+            if isinstance(target, type) or was_instance_attr:
+                setattr(target, method, original)
+            else:
+                target.__dict__.pop(method, None)
+        self._patched = []
+        self._pending_dense = []
+        self._pending_expert = []
+
+
+def setup_optim_update_monitor(
+    model=None,
+    optimizer=None,
+    monitor_dict: dict | None = None,
+    verbose: bool = False,
+    **_ignored,
+):
+    """Enable ``optim/update_rms`` + ``param_rms``. Always on; no per-monitor kwargs.
+
+    ``model`` is accepted and ignored so this can sit in the same registry as the
+    model-side monitors and be driven by the same ``setup_internal_medicine`` call. With
+    no ``optimizer`` given (the normal path — it does not exist at model-setup time) the
+    mcore optimizer CLASSES are patched instead, which covers whatever is built later.
+
+    Registered under the ``optim`` key, matching ``METRIC_PREFIX``, so a caller that
+    prints ``training_logs`` by iterating ``monitor_dict`` keys as prefixes picks these up
+    with no extra wiring.
+    """
+    monitor = OptimUpdateMonitor(verbose=verbose)
+    if optimizer is not None:
+        monitor.attach_optimizer(optimizer)
+    else:
+        monitor.attach_optimizer_classes()
+    if monitor_dict is not None:
+        monitor_dict[METRIC_PREFIX] = monitor
+    return model

--- a/tests/test_megatron_monitors.py
+++ b/tests/test_megatron_monitors.py
@@ -29,6 +29,10 @@ massive_activation_metrics = importlib.import_module("internal_medicine.backends
 compute_sink_head_classification = importlib.import_module(
     "internal_medicine.backends.megatron.sink_head_metrics"
 ).compute_sink_head_classification
+optim_update_module = importlib.import_module("internal_medicine.backends.megatron.optim_update_monitor")
+OptimUpdateMonitor = optim_update_module.OptimUpdateMonitor
+setup_optim_update_monitor = optim_update_module.setup_optim_update_monitor
+megatron_backend = importlib.import_module("internal_medicine.backends.megatron")
 
 
 class FakePLESublayer:
@@ -893,6 +897,340 @@ class SinkHeadClassificationTest(unittest.TestCase):
         result = compute_sink_head_classification(torch.tensor([]), threshold=self.THRESHOLD)
         self.assertEqual(result["sink_nonsink_gap"].item(), 0.0)
         self.assertEqual(result["sink_head_ratio"].item(), 0.0)
+
+
+class _FakeDistOpt:
+    """Stand-in for DistributedOptimizer's main/model param pairing.
+
+    Mirrors the real invariant the monitor depends on: ``shard_fp32_from_float16_groups``
+    holds the fp32 master (already stepped to ``theta_new``) while
+    ``shard_float16_groups`` still holds the bf16 ``theta_old`` until
+    ``_copy_main_params_to_model_params`` runs.
+    """
+
+    is_stub_optimizer = False
+
+    def __init__(self, theta_old: "torch.Tensor", dtype=None):
+        dtype = dtype or torch.bfloat16
+        # The fp32 master is the authoritative value and is NOT on the bf16 grid — it
+        # persists across steps and accumulates sub-bf16 updates. The model param is its
+        # rounded copy. Seeding the master FROM the bf16 param instead would put it
+        # exactly on-grid, removing the rounding error the debias exists to cancel and
+        # making these tests measure a state training never reaches.
+        self.main_param = theta_old.detach().clone().float()
+        self.model_param = self.main_param.to(dtype)
+        self.shard_float16_groups = [[self.model_param]]
+        self.shard_fp32_from_float16_groups = [[self.main_param]]
+        self.copy_calls = 0
+
+    def apply_update(self, delta: "torch.Tensor") -> None:
+        """The inner ``optimizer.step()``: fp32 master moves, model param does not."""
+        self.main_param.add_(delta)
+
+    def _copy_main_params_to_model_params(self):
+        self.copy_calls += 1
+        self.model_param.copy_(self.main_param)
+
+
+class MegatronOptimUpdateMonitorTest(unittest.TestCase):
+    """optim/update_rms + param_rms: measured between optimizer.step() and copy-back."""
+
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def _run_step(self, theta_old, delta, **kwargs):
+        opt = _FakeDistOpt(theta_old)
+        monitor = OptimUpdateMonitor(**kwargs)
+        self.assertTrue(monitor.attach_optimizer(opt), "no copy method was wrapped")
+        opt.apply_update(delta)
+        opt._copy_main_params_to_model_params()
+        try:
+            return opt, monitor.step()
+        finally:
+            monitor.remove_hooks()
+
+    def test_reports_update_and_param_rms(self):
+        torch.manual_seed(0)
+        theta = torch.randn(50_000) * 0.02
+        delta = torch.randn(50_000) * 3e-4
+        opt, got = self._run_step(theta, delta)
+
+        want_update = float(delta.pow(2).mean().sqrt())
+        want_param = float(opt.main_param.pow(2).mean().sqrt())
+        self.assertAlmostEqual(got["optim/update_rms"] / want_update, 1.0, places=2)
+        self.assertAlmostEqual(got["optim/param_rms"] / want_param, 1.0, places=4)
+        self.assertAlmostEqual(
+            got["optim/update_param_ratio"],
+            got["optim/update_rms"] / got["optim/param_rms"],
+            places=9,
+        )
+
+    def test_metrics_land_in_training_logs(self):
+        torch.manual_seed(1)
+        self._run_step(torch.randn(4096) * 0.02, torch.randn(4096) * 1e-4)
+        latest = training_logs.get_latest(prefix="optim")
+        self.assertEqual(
+            set(latest),
+            {"optim/update_rms", "optim/param_rms", "optim/update_param_ratio"},
+        )
+
+    def test_debias_keeps_small_updates_accurate(self):
+        """A bf16 theta_old rounds, which inflates the raw difference once the update is
+        near the bf16 resolution — 11x at lr 3e-6. Debiasing must hold ~1.0x across the
+        whole lr range, otherwise the metric is useless late in a cosine decay."""
+        torch.manual_seed(2)
+        for lr in (3e-4, 3e-5, 3e-6):
+            theta = torch.randn(200_000) * 0.02
+            delta = torch.randn(200_000) * lr
+            want = float(delta.pow(2).mean().sqrt())
+            with self.subTest(lr=lr, debias=True):
+                _, got = self._run_step(theta, delta, debias_low_precision=True)
+                self.assertAlmostEqual(got["optim/update_rms"] / want, 1.0, places=1)
+        # And confirm the raw form really is badly biased at the small end, so the
+        # debias branch is not dead weight.
+        theta = torch.randn(200_000) * 0.02
+        delta = torch.randn(200_000) * 3e-6
+        want = float(delta.pow(2).mean().sqrt())
+        _, raw = self._run_step(theta, delta, debias_low_precision=False)
+        self.assertGreater(raw["optim/update_rms"] / want, 3.0)
+
+    def test_zero_update_reports_zero(self):
+        """No update at all must not produce a floor from bf16 rounding."""
+        torch.manual_seed(3)
+        theta = torch.randn(20_000) * 0.02
+        _, got = self._run_step(theta, torch.zeros(20_000))
+        self.assertLess(got["optim/update_rms"], 1e-6)
+        self.assertGreater(got["optim/param_rms"], 0.0)
+
+    def test_copy_back_still_happens(self):
+        """The wrapper must be transparent: the real copy has to run, exactly once."""
+        torch.manual_seed(4)
+        theta = torch.randn(8192) * 0.02
+        delta = torch.randn(8192) * 1e-4
+        opt, _ = self._run_step(theta, delta)
+        self.assertEqual(opt.copy_calls, 1)
+        self.assertTrue(torch.equal(opt.model_param, opt.main_param.to(opt.model_param.dtype)))
+
+    def test_patch_is_reverted_by_remove_hooks(self):
+        opt = _FakeDistOpt(torch.randn(1024) * 0.02)
+        original = opt._copy_main_params_to_model_params
+        monitor = OptimUpdateMonitor()
+        monitor.attach_optimizer(opt)
+        self.assertIsNot(opt._copy_main_params_to_model_params, original)
+        monitor.remove_hooks()
+        # Reverted by dropping the instance attribute so class lookup resumes; bound
+        # methods are recreated per access, so compare __func__.
+        self.assertNotIn("_copy_main_params_to_model_params", vars(opt))
+        self.assertIs(opt._copy_main_params_to_model_params.__func__, original.__func__)
+
+    def test_patch_is_idempotent(self):
+        opt = _FakeDistOpt(torch.randn(1024) * 0.02)
+        monitor = OptimUpdateMonitor()
+        monitor.attach_optimizer(opt)
+        patched_once = opt._copy_main_params_to_model_params
+        monitor.attach_optimizer(opt)
+        try:
+            self.assertIs(opt._copy_main_params_to_model_params, patched_once)
+            self.assertEqual(len(monitor._patched), 1)
+        finally:
+            monitor.remove_hooks()
+
+    def test_accumulates_across_chained_optimizers(self):
+        """ChainedOptimizer (Muon + Adam) must contribute both sub-optimizers' shards to
+        one pooled RMS, not just the first."""
+        torch.manual_seed(5)
+        theta_a, theta_b = torch.randn(30_000) * 0.02, torch.randn(30_000) * 0.02
+        delta_a, delta_b = torch.randn(30_000) * 3e-4, torch.randn(30_000) * 3e-4
+        opt_a, opt_b = _FakeDistOpt(theta_a), _FakeDistOpt(theta_b)
+        chained = SimpleNamespace(chained_optimizers=[opt_a, opt_b])
+
+        monitor = OptimUpdateMonitor()
+        self.assertTrue(monitor.attach_optimizer(chained))
+        try:
+            opt_a.apply_update(delta_a)
+            opt_b.apply_update(delta_b)
+            opt_a._copy_main_params_to_model_params()
+            opt_b._copy_main_params_to_model_params()
+            got = monitor.step()
+        finally:
+            monitor.remove_hooks()
+
+        want = float(torch.cat([delta_a, delta_b]).pow(2).mean().sqrt())
+        self.assertAlmostEqual(got["optim/update_rms"] / want, 1.0, places=2)
+
+    def test_step_is_empty_without_a_step(self):
+        """step() with nothing pending must emit nothing rather than 0/0."""
+        opt = _FakeDistOpt(torch.randn(512) * 0.02)
+        monitor = OptimUpdateMonitor()
+        monitor.attach_optimizer(opt)
+        try:
+            self.assertEqual(monitor.step(), {})
+            self.assertEqual(training_logs.get_latest(prefix="optim"), {})
+        finally:
+            monitor.remove_hooks()
+
+    def test_pending_is_cleared_between_steps(self):
+        """Two consecutive steps must report each step's own update, not a running sum."""
+        torch.manual_seed(6)
+        opt = _FakeDistOpt(torch.randn(40_000) * 0.02)
+        monitor = OptimUpdateMonitor()
+        monitor.attach_optimizer(opt)
+        try:
+            big = torch.randn(40_000) * 1e-3
+            opt.apply_update(big)
+            opt._copy_main_params_to_model_params()
+            first = monitor.step()["optim/update_rms"]
+
+            small = torch.randn(40_000) * 1e-4
+            opt.apply_update(small)
+            opt._copy_main_params_to_model_params()
+            second = monitor.step()["optim/update_rms"]
+        finally:
+            monitor.remove_hooks()
+
+        self.assertAlmostEqual(first / float(big.pow(2).mean().sqrt()), 1.0, places=1)
+        self.assertAlmostEqual(second / float(small.pow(2).mean().sqrt()), 1.0, places=1)
+        self.assertLess(second, first / 5)
+
+    def test_stub_optimizer_is_skipped(self):
+        opt = _FakeDistOpt(torch.randn(512) * 0.02)
+        opt.is_stub_optimizer = True
+        monitor = OptimUpdateMonitor()
+        monitor.attach_optimizer(opt)
+        try:
+            opt.apply_update(torch.randn(512) * 1e-4)
+            opt._copy_main_params_to_model_params()
+            self.assertEqual(monitor.step(), {})
+        finally:
+            monitor.remove_hooks()
+
+    def test_setup_helper_registers_under_the_metric_prefix(self):
+        """The monitor_dict key must equal METRIC_PREFIX ("optim"), because callers print
+        training_logs by iterating monitor_dict keys as metric prefixes — a mismatched key
+        would silently drop these metrics from the log. The helper also returns ``model``,
+        matching the other setup_* functions' contract."""
+        opt = _FakeDistOpt(torch.randn(1024) * 0.02)
+        monitor_dict = {}
+        sentinel = object()
+        returned = setup_optim_update_monitor(sentinel, optimizer=opt, monitor_dict=monitor_dict)
+        monitor = monitor_dict[optim_update_module.METRIC_PREFIX]
+        try:
+            self.assertIs(returned, sentinel, "must return the model, like the other setups")
+            self.assertEqual(list(monitor_dict), [optim_update_module.METRIC_PREFIX])
+            self.assertTrue(monitor._patched)
+
+            opt.apply_update(torch.randn(1024) * 3e-4)
+            opt._copy_main_params_to_model_params()
+            monitor.step()
+            emitted = training_logs.get_latest(prefix=optim_update_module.METRIC_PREFIX)
+            self.assertEqual(len(emitted), 3)
+            for key in emitted:
+                self.assertTrue(key.startswith(f"{optim_update_module.METRIC_PREFIX}/"))
+        finally:
+            monitor.remove_hooks()
+
+    def test_always_on_without_being_named_in_monitors(self):
+        """The monitor must be installed by setup_monitors regardless of the ``monitors``
+        spec — it is in _ALWAYS_ON_MONITORS, not _MONITOR_MAP — so no training script has
+        to name it or thread the optimizer through a callback."""
+        self.assertIn("optim", megatron_backend._ALWAYS_ON_MONITORS)
+        self.assertNotIn("optim", megatron_backend._MONITOR_MAP)
+
+        monitor_dict = {}
+        model = FakeGPTModel(num_layers=1, hidden_size=8, vocab_size=16)
+        megatron_backend.setup_monitors(model, monitors=["qk_stats"], monitor_dict=monitor_dict)
+        monitor = monitor_dict.get("optim")
+        try:
+            self.assertIsInstance(monitor, OptimUpdateMonitor)
+            self.assertTrue(monitor._patched, "class-level patch should be installed")
+        finally:
+            if monitor is not None:
+                monitor.remove_hooks()
+
+    def test_class_patch_covers_optimizers_built_afterwards(self):
+        """Patching the mcore optimizer CLASS is what removes the need for a trainer-side
+        callback: an instance constructed after setup must still be measured."""
+        monitor = OptimUpdateMonitor()
+        if not monitor.attach_optimizer_classes():
+            self.skipTest("megatron.core optimizer classes unavailable")
+        try:
+            from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+            patched = DistributedOptimizer.__dict__["_copy_main_params_to_model_params"]
+            self.assertTrue(getattr(patched, "_im_update_patched", False))
+        finally:
+            monitor.remove_hooks()
+            from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+            reverted = DistributedOptimizer.__dict__["_copy_main_params_to_model_params"]
+            self.assertFalse(getattr(reverted, "_im_update_patched", False), "class must be restored")
+
+    def test_chunked_sum_matches_single_pass(self):
+        """The shard is walked in fixed-size chunks to bound the temporary; the result
+        must equal a single-pass computation across a chunk boundary."""
+        torch.manual_seed(7)
+        n = optim_update_module._CHUNK + 12345
+        main = torch.randn(n)
+        model = main.to(torch.bfloat16)
+        ss_u, ss_p, ss_q, count = optim_update_module._pair_sums(main, model)
+        self.assertEqual(count, n)
+        # fp32 chunk accumulation vs a single fp32 reduction over ~1M elements: agreement
+        # is fp32 round-off, not exact.
+        self.assertAlmostEqual(float(ss_u) / float((main - model.float()).pow(2).sum()), 1.0, places=3)
+        self.assertAlmostEqual(float(ss_p) / float(main.pow(2).sum()), 1.0, places=4)
+
+    def test_tp_duplicate_params_are_counted_once(self):
+        """A TP-REPLICATED param exists identically on every TP rank, so only rank 0 may
+        count it; a TP-SHARDED param is distinct per rank and always counts. Getting this
+        backwards inflates the RMS by the TP size."""
+        replicated = torch.nn.Parameter(torch.randn(64))
+        sharded = torch.nn.Parameter(torch.randn(64))
+        sharded.tensor_model_parallel = True
+
+        rank0 = SimpleNamespace(rank=lambda: 0)
+        rank1 = SimpleNamespace(rank=lambda: 1)
+        not_dup = optim_update_module._param_is_not_tp_duplicate
+        self.assertTrue(not_dup(sharded, rank1), "TP-sharded is distinct on every rank")
+        self.assertTrue(not_dup(replicated, rank0))
+        self.assertFalse(not_dup(replicated, rank1), "replicated must only count on TP rank 0")
+
+    def test_shared_params_are_excluded(self):
+        """Tied embeddings are marked ``shared`` and appear on two PP stages; counting
+        both would double-count them."""
+        plain = torch.nn.Parameter(torch.randn(8))
+        shared = torch.nn.Parameter(torch.randn(8))
+        shared.shared = True
+        self.assertTrue(optim_update_module._param_is_not_shared(plain))
+        self.assertFalse(optim_update_module._param_is_not_shared(shared))
+
+    def test_expert_and_dense_shards_are_bucketed_separately(self):
+        """Expert params reduce over different groups than dense ones, so they must land
+        in separate buckets (``allreduce=False`` is mcore's expert marker)."""
+        torch.manual_seed(8)
+        opt = _FakeDistOpt(torch.randn(4096) * 0.02)
+        expert_model = (torch.randn(4096) * 0.02).to(torch.bfloat16)
+        expert_main = expert_model.float()
+        expert_model.allreduce = False
+        opt.shard_fp32_from_float16_groups[0].append(expert_main)
+        opt.shard_float16_groups[0].append(expert_model)
+
+        monitor = OptimUpdateMonitor()
+        monitor.attach_optimizer(opt)
+        try:
+            opt.apply_update(torch.randn(4096) * 3e-4)
+            expert_main.add_(torch.randn(4096) * 3e-4)
+            opt._copy_main_params_to_model_params()
+            self.assertEqual(len(monitor._pending_dense), 1)
+            self.assertEqual(len(monitor._pending_expert), 1)
+            got = monitor.step()
+            self.assertIn("optim/update_rms", got)
+            self.assertEqual(monitor._pending_dense, [])
+            self.assertEqual(monitor._pending_expert, [])
+        finally:
+            monitor.remove_hooks()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
每 step 三个标量，与 grad norm 并排看：

    optim/update_rms          sqrt(mean((θ_new − θ_old)²))
    optim/param_rms           sqrt(mean(θ_new²))
    optim/update_param_ratio  update_rms / param_rms   (trust ratio, ~1e-3 健康)

全部逻辑收在本仓库，训练脚本零改动：

- 补丁打在 mcore 优化器**类**上而不是实例上。优化器在模型侧 monitor 安装时还不存在，若要 拿实例就得在训练脚本里多注册一个能看到 ctx.optimizer 的回调，等于把逻辑摊到第二个仓库。 改为包 Float16OptimizerWithFloat16Params 与 DistributedOptimizer 上的 _copy_main_params_to_model_params（这两个才是真正定义该方法的具体子类，共同基类 MixedPrecisionOptimizer 上没有），self 从调用里取，之后构造的任何实例都被覆盖。
- 放进新的 _ALWAYS_ON_MONITORS 而不是 _MONITOR_MAP，因此不受 monitors 配置与 monitor_interval 门控；monitor_dict 的 key 取 "optim"，与 METRIC_PREFIX 一致，这样调用方 既有的"遍历 monitor_dict key 当 prefix 打印 training_logs"循环和 TB 写入自动带上它。 registry 侧改动只有 9 行。

不额外保存参数副本：MixedPrecisionOptimizer.step_with_ready_grads (optimizer.py:712) 的 顺序是 optimizer.step() 然后 _copy_main_params_to_model_params()，这两行之间 fp32 master 已是 θ_new 而 bf16 model param 仍是 θ_old，更新前的值本来就还活着。逐 shard 的和按 1 Mi 元素分块累加，临时张量恒为几 MB。

bf16 去偏是必需的：θ_old 带舍入误差，更新量降到该分辨率附近会被它主导，实测 lr 3e-4 偏 1.01x、3e-5 偏 1.49x、3e-6 偏 11.10x（cosine 尾段完全不可用）。用 θ_new − bf16(θ_new) 估计舍入方差在 mean-square 空间减掉，全 lr 段回到 1.00x。

归约与 calc_params_l2_norm 同一套语义：dense bucket 先 dp_cp 再 mp，expert bucket (allreduce=False) 走 expert-DP 与 expert-TP/PP。(ss_update, ss_param, ss_noise, count) 打成 一个 fp64 4-vector，每 bucket 两次 collective；RMS 对和非线性，所以先归约再相除；count 用 fp64。即使本 rank 某 bucket 为空也照样发起 collective —— 一个 rank 没有 expert shard 而 peer 有的话跳过会挂。去重判据取在原始 model param 上（allreduce 标记不在 copy_optimizer_param_metadata 拷到 shard view 的属性里）：shared 跳过，TP replicated 只在 tp rank 0 计入。

纯 fp32 参数就地更新、无更新前副本，不计入并 warn 一次；Megatron-FSDP 的 main weights 不走 本 monitor 依赖的 group 结构，静默不上报。

18 个用例，含数值正确性、三个 lr 下的去偏、零更新不产生 bf16 地板、copy 仍执行且恰一次、 补丁可还原且幂等、ChainedOptimizer 两个子优化器汇总、跨 step 不累加、类补丁覆盖之后构造的 实例、以及 monitors 不点名时也装上。docs/optim_update.md 记录设计与实测表。

l18 resume-3000 实跑 51 step 验证：param_rms 0.0139 稳定，update_param_ratio 0.0012~0.0013 （预期的 ~1e-3 量级，说明跨 rank 归约组正确，未偏 sqrt(world_size)）。