### PR TITLE
fix: align mHC composite metrics with paper semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,11 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 
 监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
 以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。
-只在模型开启 mHC 层时生效——mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
-彻底 no-op（不 wrap、不产生指标）。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 14 个指标，
-指标名以 `attn_` / `mlp_` 前缀区分；除 `branch_residual_share_max`、`h_res_softmax_max`、
-`composite_amax_gain_{fwd,bwd}_max` 取极大值与 `h_res_softmax_min` 取极小值外，其余按 token/batch 求均值。
+只在模型开启 mHC 层时生效，mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
+彻底 no-op。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 16 个指标，
+指标名以 `attn_` / `mlp_` 前缀区分；`branch_residual_share_max`、`h_res_logits_max`、
+`h_res_logits_grad_max`、`composite_amax_gain_{fwd,bwd}_max` 取极大值，`h_res_logits_min` 与
+`h_res_logits_grad_min` 取极小值，其余按 token/batch 求均值。
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
 |---|------|--------|------|------|----------|
@@ -370,57 +371,22 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 | 3 | `{c}_h_post_mean` | `mhc_health/layer_{i}/{c}_h_post_mean` | `mean(h_post)` | 每层+全局 | 扩展门均值 |
 | 4 | `{c}_h_post_std` | `mhc_health/layer_{i}/{c}_h_post_std` | `std(h_post)` | 每层+全局 | 扩展门离散度（token 与 stream 混合） |
 | 5 | `{c}_h_post_stream_concentration` | `mhc_health/layer_{i}/{c}_h_post_stream_concentration` | `mean_t(max_i h_post / mean_i h_post)` | 每层+全局 | stream 集中度，值域 `[1, n]`：1 = 均匀，n = 全压在一条流上 |
-| 6 | `{c}_h_post_token_std` | `mhc_health/layer_{i}/{c}_h_post_token_std` | `std_t(mean_i h_post)` | 每层+全局 | 门控对输入的区分度，→0 = 退化成常数 |
+| 6 | `{c}_h_post_token_std` | `mhc_health/layer_{i}/{c}_h_post_token_std` | `std_t(mean_i h_post)` | 每层+全局 | token 间总门量离散度；→0 不等于每条 stream 的门都为常数 |
 | 7 | `{c}_branch_residual_share` | `mhc_health/layer_{i}/{c}_branch_residual_share` | `mean_t(b / (b + r))`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F` | 每层+全局 | **本层是否还在写入残差流**，值域 `[0, 1]`：0.5 = 两项等量 |
 | 8 | `{c}_branch_residual_share_max` | `mhc_health/layer_{i}/{c}_branch_residual_share_max` | 同上取最坏 token | 每层+全局 | 单 token 被分支主导的程度（贴 1 = 存在近零残差 token） |
 | 9 | `{c}_amax_gain_fwd` | `mhc_health/layer_{i}/{c}_amax_gain_fwd` | `mean_t(max_i \|Σ_j h_res_ji\|)`（`h_res` 的列和 = `h_resᵀ` 的行和） | 每层+全局 | 单层前向最坏放大。列和被 Sinkhorn 最后一步钉死为 1，故这条是不变量守卫（见下） |
 | 10 | `{c}_amax_gain_bwd` | `mhc_health/layer_{i}/{c}_amax_gain_bwd` | `mean_t(max_j \|Σ_i h_res_ji\|)`（`h_res` 的行和） | 每层+全局 | 单层反向最坏放大。承载 Sinkhorn 截断迭代的收敛残差 |
-| 11 | `{c}_h_res_softmax_min` | `mhc_health/layer_{i}/{c}_h_res_softmax_min` | `min_t min_{i,j} softmax(z)`，`z` = Sinkhorn 之前的 `h_res` logits | 每层+全局 | **饱和哨兵**，值域 `(0, 1/n]`：`1/n` = 行内均匀，趋 0 = 该行退化成 one-hot。阈值 `1.18e-38`（fp32 最小正规数），越线即模型自己的 `softmax` 已下溢。按 **min** 归约 |
-| 12 | `{c}_h_res_softmax_max` | `mhc_health/layer_{i}/{c}_h_res_softmax_max` | `max_t max_{i,j} softmax(z)` | 每层+全局 | 单个最大混合权重，值域 `[1/n, 1]`。行内跨度约 18 之后在 fp32 里精确等于 1.0 且不再变化，故只能当"是否已饱和"的开关，不反映饱和深度。按 **max** 归约 |
-| 13 | `{c}_composite_amax_gain_fwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd_max` | `max_i \|Σ_j A_{k,i,j}\|`，`A_k = h_res_kᵀ @ A_{k-1}` 按层序累乘（`h_res_kᵀ` 才是 `apply_h_res` 实际作用的算子） | 每层+全局 | 从首层到本层累计的前向最坏放大。按 **max** 归约 |
-| 14 | `{c}_composite_amax_gain_bwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd_max` | `max_j \|Σ_i A_{k,i,j}\|` | 每层+全局 | 同上取列和。按 **max** 归约 |
+| 11 | `{c}_h_res_logits_min` | `mhc_health/layer_{i}/{c}_h_res_logits_min` | `min z`，`z` = Sinkhorn 输入 logits | 每层+全局 | 迭代前 residual-mixing logits 的最小值。按 step 内 layer/microbatch **min** 归约 |
+| 12 | `{c}_h_res_logits_max` | `mhc_health/layer_{i}/{c}_h_res_logits_max` | `max z` | 每层+全局 | 同上取最大值。与 min 联合观察 raw logits 的 signed 范围。按 **max** 归约 |
+| 13 | `{c}_h_res_logits_grad_min` | `mhc_health/layer_{i}/{c}_h_res_logits_grad_min` | `min dL/dz`，`z` = Sinkhorn 输入 logits | 每层+全局 | 迭代前 logits 的未缩放 activation gradient 最小值。按 step 内 layer/microbatch **min** 归约 |
+| 14 | `{c}_h_res_logits_grad_max` | `mhc_health/layer_{i}/{c}_h_res_logits_grad_max` | `max dL/dz` | 每层+全局 | 同上取最大值。AMP loss scale 被反除，不除 gradient accumulation。按 **max** 归约 |
+| 15 | `{c}_composite_amax_gain_fwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd_max` | 入口到当前 branch 的 attention/MLP 交错 prefix 最大绝对行和 | 每层+全局 | 按 **max** 跨 microbatch/层归约 |
+| 16 | `{c}_composite_amax_gain_bwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd_max` | 当前 branch 到模型尾部的 attention/MLP 交错 suffix 最大绝对列和 | 每层+全局 | 按 **max** 跨 microbatch/层归约 |
 
 `{c}` ∈ `{attn, mlp}`。
 
-**哪个轴带信息**：`apply_h_res` 与 fused cuTile kernel 都按 `out_i = Σ_j h_res_ji · x_j` 混流，即真正作用在流
-向量上的算子是 `h_resᵀ`，所以前向增益是 `h_res` 的列和、反向增益是行和（单层与复合同口径）。我们的
-`_sinkhorn_normalize` 最后一步是**列**归一，所以 `_fwd` 被钉死为 1 充当不变量守卫，`_bwd` 才承载截断迭代的残差；
-论文 Eq. (9) 最后一步是行归一，它 Fig 7 里会动的是 forward 那条，**两边曲线不可直接对比**。
-
-指标 1~6 与 9~10 来自包裹 `compute_mappings`（`h_pre` 不在 `forward` 返回值里，只能从这里拿到真实映射）；
-指标 11~12 需要 Sinkhorn **之前**的 `h_res` logits，故额外包裹 `_compute_h`（顺带绕开 `use_fused_mhc` 分叉）；
-指标 13~14 在 **flush 时**按 `layer_idx` 排序累乘（hook 内只存 token 平均并**转置**后的 `n×n` 快照，
-转置是因为 `apply_h_res` 实际作用的算子是 `h_resᵀ`），因此与 hook 触发顺序无关——而该顺序在 recompute 下是
-反向重放的逆序，正是它当初被下线的原因。MTP 层不在主干链上，累乘时跳过。作用域是本 rank 持有的层，
-当前配置（`sharding: stage1`，无 PP）下即全部 43 层；开 PP 后会退化为 stage 内语义，详见 docs。
-指标 7~8 需要 sublayer 输出，只有两项合并处才同时可见，故额外包裹 `fused_h_res_h_post_bda`，且指标从**入参**
-推导，因此 fused 快路径与带 dropout 的顺序路径口径一致。两个范数都是精确值但不 materialize 任何
-`[tokens, n, C]` 中间张量：branch 项是外积，`‖h_post_t ⊗ x_t‖_F = ‖h_post_t‖₂·‖x_t‖₂`；residual 项用
-`‖mixed_t‖²_F = Σ_{j,k} S[t,j,k]·G[t,j,k]`（`S` 为 `h_res` 的自相关、`G` 为 n 条流的 Gram），两者都是
-`[tokens, n, n]`。branch 项在 dropout **之前**测量（本仓库预训练配置 `hidden_dropout_prob = 0`）。
-
-### 健康判读
-
-- `h_post_mean` 趋 0 → 该层 sublayer 输出被门控压掉。注意 `h_post = 2σ(·)` 恒为正，**不存在正负相消**，
-  所以均值小就等于幅度小；但需配合 7 才能确认「贡献」是否真的消失（`F(·)` 的幅度可能同步增大补偿）。
-- `branch_residual_share` 无绝对阈值，看**深度剖面**与趋势。值域 `[0, 1]`：0.5 = 分支与残差等量，趋 0 = 该层退化为
-  纯残差搬运。判读看 `_max` 与均值的差距、以及`_max` 是否长期贴 1。
-- 二者组合定位失效模式：
-  - `h_post_mean`→0、`stream_concentration`≈1、`share` 同步塌 → **整体关闭**。此时 sigmoid 已进饱和区
-    （`h_post = 0.004` 对应 logit ≈ −6.2，`σ′ ≈ 0.002`），靠自身难以恢复，应查门控参数的 lr / weight decay
-    与 `mhc_init_gating_factor`。
-  - `stream_concentration`≈n → **退化为单流**，该层放弃了多流结构，`num_residual_streams` 的开销在这些层上没有
-    收益；可考虑逐层配置 n。注意这未必是病：HC 允许不同层使用不同的流组合，需结合「是否总是同一条流」判断。
-- `h_post_token_std`→0 → 门控丢失对 token 的区分度，从动态门退化成常数标量。
-- `amax_gain_bwd` 偏离 1.0 → Sinkhorn 未收敛或初始化异常。它承载截断迭代的残差，量级很小，
-  **只当哨兵用，不要拿它做诊断**。`amax_gain_fwd` 读 `h_res` 的列和，而列和被 Sinkhorn 最后一步钉死为 1，
-  所以它是不变量守卫：一旦它偏离 1，说明归一化本身出了问题（数值异常或实现改动），比 `_bwd` 更严重。
-- `composite_amax_gain_{fwd,bwd}_max` → 从首层累计到本层的最坏放大，逐层输出构成剖面曲线（论文 Fig 7b 的拱形
-  只有复合能显示，单层看不出）。与单层同口径：`_fwd` 被钉死，会动的是 `_bwd`。
-- `h_res_softmax_min` 下降 → 该层 `h_res` 的 logits 正在饱和，**梯度冻结**。饱和行的 softmax Jacobian
-  `diag(p) − ppᵀ ≈ 0`，`mapping_proj.weight` / `alpha_res` 收不到梯度，该层 `h_res` 冻在当前形态且不可自愈。
-  阈值 `1.18e-38`（fp32 最小正规数），越线即模型自己的 `softmax` 已下溢、行内比例不可逆丢失。健康值 `1/n`。
-  这条曲线是唯一的观测窗口——成品 `h_res` 的行和列和被 Sinkhorn 归一化钉在 1，其余指标全读健康。
+指标公式、采集路径、健康判读及论文 composite 定义统一维护在
+[`docs/mhc_health.md`](docs/mhc_health.md)，README 不再重复展开。
 
 ---
 

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -3,7 +3,7 @@
 监控 mHC (Manifold-Constrained Hyper-Connections) 层的健康状况。mHC 用如下传播替换普通残差：
 
 ```
-x_{l+1} = H_res @ x_l + H_post^T · F(H_pre @ x_l)
+x_{l+1} = H_res^T @ x_l + H_post^T · F(H_pre @ x_l)
 ```
 
 每个 token、每个 hyper-connection 模块学习三个映射（`n = num_residual_streams`）：
@@ -63,9 +63,9 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 
 ## 监控指标
 
-每个 hc 模块产出 14 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 8 个），指标名以
-`attn_` / `mlp_` 前缀区分，除 `branch_residual_share_max`、`h_res_softmax_max`、
-`composite_amax_gain_{fwd,bwd}_max` 取极大值与 `h_res_softmax_min` 取极小值外全部按 token/batch 求均值
+每个 hc 模块产出 16 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 8 个），指标名以
+`attn_` / `mlp_` 前缀区分。`branch_residual_share_max`、`h_res_logits_max`、`h_res_logits_grad_max`、
+`composite_amax_gain_{fwd,bwd}_max` 取极大值，`h_res_logits_min` 与 `h_res_logits_grad_min` 取极小值，其余按 token/batch 求均值
 （并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，
 `{c}` ∈ `{attn, mlp}`；对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
 
@@ -76,7 +76,12 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 | `{c}_h_pre_mean`  | `mean(h_pre)`  | 聚合门均值 |
 | `{c}_h_pre_std`   | `std(h_pre)`   | 聚合门离散度 |
 | `{c}_h_post_mean` | `mean(h_post)` | 扩展门均值 |
-| `{c}_h_post_std`  | `std(h_post)`  | 扩展门离散度 |
+| `{c}_h_post_std`  | `std_{t,i}(h_post[t,i])` | token 与 stream 混合后的总离散度；单独看无法区分流间分工和 token 间变化 |
+
+`h_post_std` 的信息量有限，但不是零：它能发现所有 gate entry 是否整体收缩为近似常数。它必须和
+`h_post_token_std`、`h_post_stream_concentration` 联合解释。总离散度高但 token std 低，更像稳定的 stream 间分工；
+两者都高，才说明每个 token 的总门量也在明显变化。反过来，`h_post_token_std -> 0` 仍允许不同 token 在 stream 间
+重新分配相同总门量，因此不能据此断言门控已完全失去输入区分能力。
 
 ### 结构指标（paddlefleet 独有）
 
@@ -87,9 +92,9 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 | 指标 | 公式 | 诊断意义 |
 |------|------|----------|
 | `{c}_h_post_stream_concentration` | `mean_t( max_i h_post[t,i] / mean_i h_post[t,i] )` | 流间集中度，区间 `[1, n]`。1 = 各流等权；趋 `n` = 质量压到单流，该层退化成普通单流残差，`num_residual_streams` 预算未被使用 |
-| `{c}_h_post_token_std` | `std_t( mean_i h_post[t,i] )` | 门对输入的敏感度（`h = r · proj · α + bias`）。→0 = 门不再区分 token，等价于常数标量 |
+| `{c}_h_post_token_std` | `std_t( mean_i h_post[t,i] )` | token 间“总门量”的离散度。→0 只说明各 token 的 stream 均值接近，不代表每条 stream 的门都与 token 无关 |
 | `{c}_branch_residual_share` | `mean_t( b / (b + r) )`，`b = ‖H_postᵀ F(·)‖_F`、`r = ‖H_resᵀ x_l‖_F` | 本层写入量在「写入 + 残差重混」中的占比，区间 `[0, 1]`。0.5 = 两项等量；趋 0 = 该层退化为纯残差搬运。|
-| `{c}_branch_residual_share_max` | `max_t( b / (b + r) )` | 最坏 token 的写入占比；贴 1 表示存在残差近零的 token。唯一按极值跨 microbatch/层/rank 归约的指标 |
+| `{c}_branch_residual_share_max` | `max_t( b / (b + r) )` | 长尾告警：捕获均值掩盖的 branch-dominated token。对 token 数量和离群点敏感，且两项绝对值都很小时比值仍可贴 1，不能脱离均值和幅度单独诊断 |
 
 两个范数都是精确值，但不物化 `[tokens, n, C]` 中间量：分支项是外积（`‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂·‖xb_t‖₂`），
 残差项用 `[tokens, n, n]` 的 Gram/mix 收缩得到，`n = 4` 时开销约为本层投影的 `C/n²` 分之一。
@@ -119,38 +124,77 @@ amax_gain_bwd = mean_t( max_j | Σ_i  h_res_ji | )      # h_res 的行和（back
 注意论文 Eq. (9) 最后一步是**行**归一，所以它 Fig 7 里会动的是 forward 那条，而我们会动的是 `_bwd`——
 **两边曲线不可直接对比。**
 
-### logits 饱和哨兵（迭代前的行内跨度）
+### 迭代前 logits 范围
 
-`softmax` 在行内**平移不变**，所以决定 `h_res` 有多尖的唯一量是行内跨度 `max_j z_j − min_j z_j`。跨度直接决定
-softmax 的最小输出：`min ≈ exp(−跨度)`，于是阈值由 dtype 给出，不需要拍：
-
-- `exp(-87) ≈ 1.2e-38` —— fp32 最小正规数
-- `exp(-103) ≈ 1.4e-45` —— fp32 最小 denormal，再往下就是 0
-
-跨度超过 ~87，模型自己的 `softmax` 就开始下溢：行内相对比例被摧毁，紧随其后的 Sinkhorn 把残存比例按最多
-`1/eps` 放大。
+直接统计 `_compute_h` 产出、进入 Sinkhorn 前的 raw residual-mixing logits `z`。这两条保留符号，不执行
+softmax，因此不会受概率饱和到 0/1 的截断影响：
 
 | 指标 | 公式 | 诊断意义 |
 |------|------|----------|
-| `{c}_h_res_softmax_min` | `min_t min_{i,j} softmax(z)_{t,i,j}` | 最小混合权重。值域 `(0, 1/n]`，`1/n` = 行内均匀，趋 0 = 该行退化成 one-hot。按 **min** 归约 |
-| `{c}_h_res_softmax_max` | `max_t max_{i,j} softmax(z)_{t,i,j}` | 单个最大混合权重。值域 `[1/n, 1]`，跨度到约 18 之后在 fp32 里精确等于 1.0 并保持不变，所以只能当"是否已经饱和"的开关看，不反映饱和深度。按 **max** 归约 |
+| `{c}_h_res_logits_min` | `min z` | step 内该层所有 microbatch/token/stream 的最小 raw logit。按 **min** 归约 |
+| `{c}_h_res_logits_max` | `max z` | 同上取最大值。按 **max** 归约 |
+
+`max-min` 可作为跨 token 的保守全局跨度，用于观察 logits 尺度持续扩张或异常尖峰；它不是逐行跨度的最大值，
+因此不能直接套用单行 softmax 的精确饱和阈值。与下面的 logits gradient min/max 联合看，可以区分 logits 尺度漂移与
+反向信号减弱。
+
+### 迭代前 logits 梯度
+
+对 `_compute_h` 产出、传入 Sinkhorn 的 raw `h_res` logits `z` 注册 tensor gradient hook，监控的是
+`dL/dz`，不是 Sinkhorn 最终矩阵或循环中间 `M` 的梯度：
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_h_res_logits_grad_min` | `min dL/dz` | step 内该层所有 microbatch/token/stream 的最小 activation gradient。按 **min** 归约 |
+| `{c}_h_res_logits_grad_max` | `max dL/dz` | 同上取最大值。按 **max** 归约 |
+
+hook 热路径只在 GPU 上计算 fp32 min/max 并写 0 维 accumulator。AMP 下 hook 先收到 scaled gradient，随后在
+`on_optimizer_begin`（`scaler.step/update` 之前）用本 step loss scale 统一反除；不除 gradient accumulation，保留每个
+microbatch 在真实反向路径上的 activation-gradient 量级。recompute 的首次 forward 运行于 `no_grad`，由现有
+`_should_monitor()` 跳过；grad-enabled backward replay 再注册 hook，因此不会重复采集 checkpoint 的首次执行。
 
 ### 复合映射（composite_amax_gain_{fwd,bwd}_max）
 
-`apply_h_res` 的实际运算是 `mixed = h_resᵀ @ residual`，所以
-**真正作用在流向量上的算子是 `h_resᵀ`**。从首层到第 k 层的复合算子是
+#### 论文定义
+
+论文第 14 页 Figure 7(b) 按 residual branch 编号。记投影后的第 `l` 个 residual mixing 算子为
+`R_l = P_{M_res}(H_l^res)`，总 branch 数为 `L`。论文的 forward composite 是从入口到当前位置的 prefix：
 
 ```
-A_k = h_res_kᵀ @ ⋯ @ h_res_0ᵀ
+F_l = prod_{i=1}^{l} R_{l+1-i}
+    = R_l @ R_{l-1} @ ... @ R_1
 ```
 
-逐层记录它的最大绝对行和（`_fwd`，前向信号增益）与最大绝对列和（`_bwd`，反向梯度增益）。这条曲线对应论文
-Figure 7(b)：单层指标看不出的拱形（中间层高、两端低）只有复合能显示。
+论文的 backward composite 则是从当前位置到模型尾部的 suffix：
 
-| 指标 | 公式 | 诊断意义 |
+```
+B_l = prod_{i=1}^{L-l} R_{L-i}
+    = R_{L-1} @ R_{L-2} @ ... @ R_l
+```
+
+前向信号经过 `F_l`；从模型输出反传到位置 `l` 的梯度经过 `B_l^T`。因此论文中的 composite forward amplification
+应读 `||F_l||∞`，composite backward amplification 应读 `||B_l^T||∞ = ||B_l||1`。这里的 `l` 是每个顺序执行的
+residual branch；映射到 Transformer 时，attention 和 MLP 是交错的相邻 branch，不能拆成两条互不相干的链。
+
+#### 当前 PaddleFleet 实现
+
+`apply_h_res` 的实际运算是 `mixed = h_resᵀ @ residual`，所以实现先对 token 求平均并转置，得到真正作用在
+流向量上的算子 `T_q = mean_token(h_res_q)ᵀ`。所有非 MTP branch 按物理执行顺序排列：
+
+```
+T_{0,attn}, T_{0,mlp}, T_{1,attn}, T_{1,mlp}, ...
+```
+
+`{c}` 只标识当前观测点是 attention 还是 MLP branch，不再表示两条独立累积链。正序遍历构造入口到当前 branch 的
+prefix `F_q = T_q @ ... @ T_0`；逆序遍历构造当前 branch 到尾部的 suffix
+`B_q = T_tail @ ... @ T_q`。
+
+| 指标 | 公式 | 精确语义 |
 |------|------|----------|
-| `{c}_composite_amax_gain_fwd_max` | `max_i \|Σ_j A_{k,i,j}\|` | 从首层到本层累计的前向最坏放大。逐层输出形成剖面曲线；global 按 **max** 归约给出峰值 |
-| `{c}_composite_amax_gain_bwd_max` | `max_j \|Σ_i A_{k,i,j}\|` | 同上取列和 |
+| `{c}_composite_amax_gain_fwd_max` | `||F_q||∞ = max_i Σ_j |F_{q,i,j}|` | 入口到当前 `{c}` branch 的交错 prefix 前向最坏放大；global 按 **max** 归约 |
+| `{c}_composite_amax_gain_bwd_max` | `||B_qᵀ||∞ = ||B_q||₁ = max_j Σ_i |B_{q,i,j}|` | 模型尾部反传到当前 `{c}` branch 的交错 suffix 反向最坏放大；global 按 **max** 归约 |
+
+该实现与论文 Figure 7(b) 的 prefix-forward / suffix-backward 定义一致。
 
 四个实现要点：
 
@@ -159,13 +203,13 @@ Figure 7(b)：单层指标看不出的拱形（中间层高、两端低）只有
    `h_resᵀ` 口径计算（只是没有显式转置，直接换了求和轴），所以两组指标的 `_fwd`/`_bwd` 语义一致、可以对着读。
 2. **先对 token 求平均再累乘**（论文 Fig 7/8 同口径），所以每层每组件只存一个 `n×n` fp32 快照，而不是把 per-token
    `h_res` 在整个 step 内驻留。这是它当初被下线的第一条理由，现在不成立。
-3. **累乘发生在 flush 时、按 `layer_idx` 排序**，不在 hook 里增量累乘。所以结果与 hook 触发顺序无关——而触发顺序
-   在 recompute 下是反向重放的逆序，那正是它当初被下线的第二条理由。`_record_composite` 有对应的回归测试
-   （故意逆序触发 hook，断言结果仍等于正序累乘）。
+3. **累乘发生在 microbatch 结算时**，快照按 `(layer_idx, attn-before-mlp)` 排序，不在 hook 里增量累乘。因此结果与
+   hook 触发顺序无关；recompute 即使按反向层序重放，也会恢复成物理 branch 顺序。回归测试会故意逆序触发 hook，
+   并用非交换矩阵分别核对正序 prefix 和逆序 suffix。
 4. **MTP 层被排除。** MTP 层不在主干传播路径上，乘进链条没有物理意义。
 
-作用域限制：复合只覆盖**本 rank 持有的层**。当前配置（`sharding: stage1`，无 PP）下每张卡都持有全部 43 层，所以
-就是全网语义。真开 PP 后它会退化成 stage 内语义，而我们既检测不到也修不了——`get_pipeline_model_parallel_rank`
+作用域限制：复合只覆盖**本 rank 持有的层**。在 `sharding: stage1` 且无 PP 时，每张卡持有全部 Transformer 层，
+所以覆盖全网层范围。真开 PP 后它会退化成 stage 内语义，而我们既检测不到也修不了——`get_pipeline_model_parallel_rank`
 和 `get_pipeline_model_parallel_world_size` 在 PaddleFleet 里目前是 stub（无条件返回 0 / 1，
 `parallel_state.py:229`、`:246`）。要支持 PP 需要先等这两个函数实现，再补一次 flush 时的 all-gather；届时
 **collective 必须放在所有 per-layer `try/except` 之外**，否则单个 rank 吞异常会让整个 job 挂死而不是报错。
@@ -174,8 +218,9 @@ Figure 7(b)：单层指标看不出的拱形（中间层高、两端低）只有
 
 - `{c}_amax_gain_bwd`：曾因读数与 `amax_gain_fwd` 一致而下线。这个结果本身是预期的（`_fwd` 读的列和被 Sinkhorn
   最后一步钉死为 1），两条现在都保留：`_fwd` 当不变量守卫，`_bwd` 才是承载收敛残差的那条。
-- `{c}_composite_amax_gain_{fwd,bwd}_max`：曾因两条理由下线，现在都不成立——per-token `h_res` 全 step 驻留的开销
-  （改成先对 token 求平均后只剩一个 `n×n` 快照），以及依赖执行顺序（改成按 `layer_idx` 排序、flush 时累乘后无关）。
+- `{c}_composite_amax_gain_{fwd,bwd}_max`：恢复时先解决了 per-token `h_res` 全 step 驻留和 recompute 逆序触发；本次进一步
+  按论文改为 attention/MLP 交错的 prefix-forward / suffix-backward，并在每个 microbatch 结束时结算到 GPU accumulator。
+  因而一个 optimizer step 内的全部 gradient-accumulation microbatch 都参与既定的 max 归约。
 
 
 
@@ -183,11 +228,13 @@ Figure 7(b)：单层指标看不出的拱形（中间层高、两端低）只有
 
 ## 与 microbatch / 激活重算的交互
 
-- 每个梯度累积 microbatch 都会按序重新调用所有 hc 模块，每次调用独立记录一条样本，flush 时对 microbatch 求均值。
+- 每个梯度累积 microbatch 都会重新调用所有 hc 模块。中间 microbatch 在 `on_substep_end` 结算 composite，最后一个在
+  `on_step_end` 的 flush 前结算；每次结算后立即清空快照。各 microbatch 的结果写入同一 GPU max accumulator，因此
+  optimizer-step 日志表示全部 microbatch 中每个 branch 的最坏 composite gain。
 - 整个捕获受 `_should_monitor()` 门控；非监控步只是 `orig(x)` + 一次布尔判断。
 - `_should_monitor()` 要求 grad enabled。这个判据的名字暗示"跳过重算"，**实际语义相反**：recompute 的真前向跑在
   `no_grad` 下，反向重放才开 grad，所以采集实际发生在反向重放。数值不受影响（重算确定性），但依赖执行顺序的指标
-  会出错——这曾经让复合映射下线，现在复合改成按 `layer_idx` 排序、在 flush 时累乘，不再受影响。
-- 这个判据留着是因为它顺带保证了"每个模块每 step 只取一条样本"：mHC 的 hyper-connection 在一次前向里会被进入
+  会出错——这曾经让复合映射下线；现在结算时按 `(layer_idx, attn-before-mlp)` 恢复物理顺序，不再受影响。
+- 这个判据还会过滤同一 microbatch 中不承载梯度的重复路径：mHC 的 hyper-connection 在一次前向里会被进入
   两次（`high_precision_mhc` 打开时 AMP 关闭的 fp32 路径 + bf16 路径），两条都记会稀释所有均值。详见 README
   「已知限制：采集口径依赖 grad 判据」。

--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -35,9 +35,6 @@ class PaddleProbe(Probe):
         # global_key → (聚合方式, [对应的 layer keys])，flush 时从 layer 推导 global
         self._layer_metric_groups: dict[str, tuple[str, list[str]]] = {}
         self._layer_metric_keys: set[str] = set()  # 所有 per-layer key，用于 flush 时判断是否输出
-        # GLOBAL_ONLY_METRICS 对应的 per-layer key：仍然累加（global 要从它们推导），
-        # 但不写进日志。给"守门型"指标用——恒定值不值得占 N 层 × M 组件条曲线。
-        self._global_only_layer_keys: set[str] = set()
         self._disabled_keys: set[str] = set()  # log_global=False 时被禁用的 global keys
         self._mtp_layer_ids: set[int] = set()
         self._buffers_allocated = False
@@ -191,8 +188,6 @@ class PaddleProbe(Probe):
             if layer_key not in all_declared:
                 self.declare_mean(layer_key)
         self._layer_metric_keys.add(layer_key)
-        if metric_name in self.GLOBAL_ONLY:
-            self._global_only_layer_keys.add(layer_key)
         if not self.log_global:
             return
         # 注册 global 分组: flush 时从这些 layer keys 聚合出 global 值
@@ -221,7 +216,7 @@ class PaddleProbe(Probe):
         """per-layer key 是否写进日志（global 派生不受此影响）。"""
         if key not in self._layer_metric_keys:
             return True  # 显式 declare 的非逐层 key
-        return self.log_per_layer and key not in self._global_only_layer_keys
+        return self.log_per_layer
 
     def _flush_gpu_buffer(self) -> dict[str, float]:
         """单次批量 D2H：收集所有累加器 → 推导 global → stack→cpu→tolist → 重置。"""

--- a/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
@@ -31,72 +31,22 @@ def amax_gain(mat: paddle.Tensor, axis: int) -> paddle.Tensor:
     return sums.abs().max(axis=-1).mean()  # 0-dim
 
 
-def h_res_softmax_extrema(h_res_logits: paddle.Tensor, n: int) -> dict[str, paddle.Tensor]:
-    """Extreme mixing weights of the row-wise softmax, before Sinkhorn.
-
-    Saturation sentinel. ``min`` is the informative half: bounded by ``(0, 1/n]``
-    with ``1/n`` = uniform row, falling as the row peaks, and it crosses fp32's
-    smallest normal (``1.18e-38``) exactly when the model's own ``softmax``
-    underflows and the within-row proportions are lost. ``max`` is capped at 1 by
-    the row sum and pins at exactly 1.0 in fp32 from a within-row logit spread of
-    ~18 onwards, so it only answers "saturated yes/no", not how far.
-
-    What it diagnoses is **gradient freezing**, not NaN: a saturated row's softmax
-    Jacobian ``diag(p) - p pᵀ`` is ~0, so ``mapping_proj`` / ``alpha_res`` stop
-    receiving gradient and that layer's ``h_res`` freezes, while the finished
-    ``h_res`` still reports row/column sums of ~1 and every other metric
-    here reads healthy. (NaN was ruled out separately: both the native and cuTile
-    Sinkhorn paths stay finite in fp32 even on ``-inf`` logits, because the
-    ``eps`` in the normalization denominators caps amplification at ``1/eps``.)
-
-    The softmax deliberately omits the model's ``+ eps`` (``_sinkhorn_normalize``
-    in ``hyper_connection.py``), which would floor every entry at 1e-6 and clamp
-    ``min`` there. The trade is that ``min`` reads exactly 0 past a spread of
-    ~103 — past the alarm, and the model cannot tell 0 from 1e-44 either.
-
-    Args:
-        h_res_logits: ``[..., n*n]`` raw mixing logits, i.e. ``_compute_h``'s
-            third return value — before the reshape and Sinkhorn projection.
-        n: ``num_residual_streams``.
-
-    Returns:
-        ``h_res_softmax_min`` / ``h_res_softmax_max`` over every row of every
-        token, as 0-dim tensors; one softmax serves both. No host sync.
-    """
-    logits = h_res_logits.detach().astype("float32").reshape([-1, n, n])
-    weights = paddle.nn.functional.softmax(logits, axis=-1)
+def h_res_logits_extrema(h_res_logits: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Min/max of the raw residual-mixing logits before Sinkhorn."""
+    logits = h_res_logits.detach().astype("float32")
     return {
-        "h_res_softmax_min": weights.min(),
-        "h_res_softmax_max": weights.max(),
+        "h_res_logits_min": logits.min(),
+        "h_res_logits_max": logits.max(),
     }
 
 
 def gate_stats(h: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:
-    """Mean and (unbiased) std of a gate tensor ``h`` over all elements.
-
-    Returns two 0-dim tensors ``(mean, std)``; no host sync.
-    """
+    """Mean and (unbiased) std of a gate tensor ``h`` over all elements."""
     return h.mean(), h.std()
 
 
 def h_post_structure_stats(h_post: paddle.Tensor) -> dict[str, paddle.Tensor]:
-    """Structure of the expansion gate across streams and across tokens.
-
-    ``h_post_mean`` / ``h_post_std`` pool the token and stream axes together, so
-    a shrinking mean cannot tell "all n streams went quiet" from "n-1 died and
-    one carries everything". These two split the axes:
-
-    ``h_post_stream_concentration`` — ``mean_t(max_i h_post / mean_i h_post)``,
-    taken per token *before* averaging so it stays bounded by ``[1, n]``
-    regardless of token-level scale: 1 = streams equally weighted, ``n`` = all
-    mass on one stream (the ``num_residual_streams`` budget is unused).
-
-    ``h_post_token_std`` — std over tokens of the per-token stream mean. The gate
-    is a function of the input (``h = r · proj · α + bias``), so →0 means it
-    stopped discriminating tokens and is effectively a constant scalar.
-
-    Returns 0-dim GPU tensors; no host sync.
-    """
+    """Structure of the expansion gate across streams and across tokens."""
     flat = h_post.detach().astype("float32")
     flat = flat.reshape([-1, flat.shape[-1]])  # [tokens, n]
 
@@ -118,30 +68,7 @@ def branch_residual_share(
     layer_output: paddle.Tensor,
     bias: paddle.Tensor | None = None,
 ) -> dict[str, paddle.Tensor]:
-    """How much of the mHC update this layer wrote itself, per token.
-
-    mHC propagates ``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)``: the first term
-    only re-mixes what earlier layers wrote, the second is this layer's own
-    contribution. The share
-
-        ``branch_residual_share = b / (b + r)``,
-        ``b = ‖H_postᵀ F(·)‖_F``, ``r = ‖H_resᵀ x_l‖_F``
-
-    reads "is this layer still writing anything" — which ``h_post_mean`` cannot,
-    since a shrinking gate may be offset by a growing ``F(·)``.
-
-    The bounded form is deliberate: ``r`` really does hit 0 (an all-zero token in
-    ``layer_0`` or an MTP layer's shifted slot), and the raw ratio ``b / r`` then
-    pinned at the epsilon floor ``b / 1e-6 ≈ 1e6`` and hijacked the token mean
-    and the derived ``global_*`` series. Here such a token reads 1.0 and every
-    token contributes at most 1.0.
-
-    Both norms are exact but materialise no ``[tokens, n, C]`` intermediate: the
-    branch term is an outer product (``‖h_post_t ⊗ xb_t‖_F = ‖h_post_t‖₂·‖xb_t‖₂``)
-    and the residual term contracts two ``[tokens, n, n]`` matrices —
-    ``‖mixed_t‖²_F = Σ_{j,k} S[t,j,k]·G[t,j,k]`` with ``S`` the ``h_res``
-    autocorrelation and ``G`` the Gram matrix of the n streams. Cost is
-    ``C/n²`` times cheaper than the layer's own projections.
+    """How much of the mHC update this layer wrote itself, per token?
 
     Args:
         h_res: ``[..., n, n]`` Sinkhorn doubly-stochastic mixing matrix.

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -1,12 +1,6 @@
 """mHC Health Monitor for PaddleFleet.
 
-Paddle port of ``backends/megatron/mhc_monitor.py``. Monitors the three per-token
-mappings of every ``HyperConnectionModule`` in an mHC (Manifold-Constrained
-Hyper-Connections) model, plus the relative magnitude of the two update terms of
-``x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)`` (i.e. how much this layer still
-writes into the residual streams).
-
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 14
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 16
 series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
@@ -14,7 +8,8 @@ series, name-prefixed by component:
     {attn,mlp}_h_post_stream_concentration  {attn,mlp}_h_post_token_std
     {attn,mlp}_branch_residual_share  {attn,mlp}_branch_residual_share_max
     {attn,mlp}_amax_gain_fwd  {attn,mlp}_amax_gain_bwd
-    {attn,mlp}_h_res_softmax_min  {attn,mlp}_h_res_softmax_max
+    {attn,mlp}_h_res_logits_min  {attn,mlp}_h_res_logits_max
+    {attn,mlp}_h_res_logits_grad_min  {attn,mlp}_h_res_logits_grad_max
     {attn,mlp}_composite_amax_gain_fwd_max  {attn,mlp}_composite_amax_gain_bwd_max
 
 Forward hooks are not enough, so three bound methods are wrapped instead (see
@@ -25,39 +20,6 @@ Forward hooks are not enough, so three bound methods are wrapped instead (see
   projection, and wrapping here also sidesteps the ``use_fused_mhc`` fork.
 - ``fused_h_res_h_post_bda`` — the only point where both update terms are
   visible.
-
-Everything is detached and computed under ``no_grad`` (see the VRAM-safety notes
-on the hook).
-
-Which axis carries signal: both the single-layer and the composite gains are
-computed on the operator that really acts on the stream vector, ``h_res^T``
-(``apply_h_res`` and the fused cuTile kernel both contract over ``h_res``'s first
-index). ``_fwd`` is therefore a column sum of ``h_res`` and ``_bwd`` a row sum.
-Our ``_sinkhorn_normalize`` ends on a **column** normalization, so ``_fwd`` is
-pinned to 1 by construction and ``_bwd`` carries the truncated-iteration
-residual. The paper's Eq. (9) ends on a row normalization, so its Fig. 7 plots
-the mirror image — the curve that moves there is its forward gain, ours is
-``_bwd``. Both directions are emitted anyway so the pinned side acts as a guard.
-
-``composite_amax_gain_*`` and ``amax_gain_bwd`` were all retired once and are
-back. The composite objections were the cost of keeping a per-token ``h_res``
-resident for the whole step and order-dependence under recompute: averaging over
-tokens first shrinks the snapshot to one ``n x n`` matrix per layer, and keying
-snapshots by ``layer_idx`` instead of accumulating in call order removes the
-order-dependence (see ``_record_composite`` for the remaining scope caveat).
-``amax_gain_bwd`` was dropped for reading equal to ``amax_gain_fwd``, which is
-expected given the pinned axis above; it is kept now as the explicit invariant
-guard.
-
-Residual-stream amplification itself is still unmonitored; the candidates are the
-Sinkhorn convergence residual (row sums vs 1) and the spectrum of ``h_res``.
-
-The monitor is a hard no-op unless the model actually uses the mHC layer: if the
-mHC classes cannot be imported, or no ``HyperConnectionTransformerLayer`` is
-found, ``setup_mhc_monitor`` attaches nothing and registers no metrics.
-
-Hot-path discipline (no D2H sync, no hook-time collectives, schema fixed at
-registration): see ``.claude/skills/monitor-hook-perf-rules``.
 """
 
 import logging
@@ -72,7 +34,7 @@ from .mhc_metrics import (
     branch_residual_share,
     gate_stats,
     h_post_structure_stats,
-    h_res_softmax_extrema,
+    h_res_logits_extrema,
 )
 
 logger = logging.getLogger(__name__)
@@ -100,8 +62,10 @@ _METRIC_NAMES = (
     "branch_residual_share_max",
     "amax_gain_fwd",
     "amax_gain_bwd",
-    "h_res_softmax_min",
-    "h_res_softmax_max",
+    "h_res_logits_min",
+    "h_res_logits_max",
+    "h_res_logits_grad_min",
+    "h_res_logits_grad_max",
     "composite_amax_gain_fwd_max",
     "composite_amax_gain_bwd_max",
 )
@@ -112,23 +76,20 @@ _METRIC_NAMES = (
 _MAX_METRICS = frozenset(
     {
         "branch_residual_share_max",
-        "h_res_softmax_max",
+        "h_res_logits_max",
+        "h_res_logits_grad_max",
         "composite_amax_gain_fwd_max",
         "composite_amax_gain_bwd_max",
     }
 )
-_MIN_METRICS = frozenset({"h_res_softmax_min"})
-
-# Nothing is global-only: the single-layer amax gains used to be, on the grounds
-# that they are 1 by construction, but the per-layer profile is wanted alongside
-# the composite one.
-_GLOBAL_ONLY_METRICS: frozenset[str] = frozenset()
+_MIN_METRICS = frozenset({"h_res_logits_min", "h_res_logits_grad_min"})
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
     ("attn", "self_attention_hyper_connection"),
     ("mlp", "mlp_hyper_connection"),
 )
+_COMPONENT_ORDER = {component: order for order, (component, _) in enumerate(_COMPONENTS)}
 
 
 def _iter_chunks(model):
@@ -173,7 +134,6 @@ class PaddleMHCHealthMonitor(PaddleProbe):
     ):
         self.MAX_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MAX_METRICS}
         self.MIN_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MIN_METRICS}
-        self.GLOBAL_ONLY = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _GLOBAL_ONLY_METRICS}
         super().__init__(
             log_per_layer=log_per_layer,
             log_global=log_global,
@@ -188,6 +148,9 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         self._h_res_snapshot: dict[tuple[int, str], paddle.Tensor] = {}
         # MTP layers are off the main trunk and must not enter the product.
         self._mtp_layer_ids: set[int] = set()
+        # Gradient hooks see AMP-scaled activation gradients. The callback
+        # finalizes these accumulators with this step's scale before flush.
+        self._grad_metrics_finalized = False
 
     # ------------------------------------------------------------------
     # Discovery
@@ -261,10 +224,6 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                 orig = mod.compute_mappings
                 mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
                 self._wrapped.append((mod, "compute_mappings", orig))
-                # Wrapping `_compute_h` also sidesteps the `use_fused_mhc` fork:
-                # the fused path swaps `_sinkhorn_op` for a cuTile kernel whose
-                # intermediates are unreachable, but `_compute_h` is plain paddle
-                # either way.
                 orig_h = getattr(mod, "_compute_h", None)
                 if orig_h is not None:
                     mod._compute_h = self._make_logits_capture(orig_h, layer_idx, comp)
@@ -312,62 +271,77 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         from the first layer up to layer ``k``. ``_fwd`` is its max-abs row sum
         (worst forward signal gain), ``_bwd`` its max-abs column sum.
 
-        Built from snapshots sorted by ``layer_idx``, so the result does not
-        depend on the order the hooks fired in — under recompute that order is
-        the reverse-layer backward replay, which is what retired the previous
-        composite metric. MTP layers are skipped: they are off the main trunk, so
-        multiplying them into the chain has no physical meaning.
-
         Scope is the layers this rank owns: the whole model under sharding (every
         rank holds all layers), but one stage under real pipeline parallelism,
         which we can neither detect nor correct while
         ``get_pipeline_model_parallel_{rank,world_size}`` are stubs in PaddleFleet
         (they return 0 / 1 unconditionally).
         """
-        for comp, _ in _COMPONENTS:
-            chain = sorted(
-                (
-                    (idx, mat)
-                    for (idx, c), mat in self._h_res_snapshot.items()
-                    if c == comp and idx not in self._mtp_layer_ids
-                ),
-                key=lambda item: item[0],
+        branches = sorted(
+            (
+                (idx, component, mat)
+                for (idx, component), mat in self._h_res_snapshot.items()
+                if idx not in self._mtp_layer_ids
+            ),
+            key=lambda item: (item[0], _COMPONENT_ORDER[item[1]]),
+        )
+
+        prefix = None
+        for layer_idx, component, mat in branches:
+            prefix = mat if prefix is None else paddle.matmul(mat, prefix)
+            self.record_layer_metric(
+                layer_idx,
+                f"{component}_composite_amax_gain_fwd_max",
+                amax_gain(prefix, axis=-1),
             )
-            composite = None
-            for layer_idx, mat in chain:
-                composite = mat if composite is None else paddle.matmul(mat, composite)
-                self.record_layer_metric(
-                    layer_idx, f"{comp}_composite_amax_gain_fwd_max", amax_gain(composite, axis=-1)
-                )
-                self.record_layer_metric(
-                    layer_idx, f"{comp}_composite_amax_gain_bwd_max", amax_gain(composite, axis=-2)
-                )
+
+        suffix = None
+        for layer_idx, component, mat in reversed(branches):
+            suffix = mat if suffix is None else paddle.matmul(suffix, mat)
+            self.record_layer_metric(
+                layer_idx,
+                f"{component}_composite_amax_gain_bwd_max",
+                amax_gain(suffix, axis=-2),
+            )
+
+    def finalize_composite_microbatch(self) -> None:
+        """Record and release one microbatch's detached composite snapshots."""
+        if not self._h_res_snapshot:
+            return
+        try:
+            with paddle.no_grad():
+                self._record_composite()
+        except Exception as e:
+            if self.verbose:
+                logger.error(f"[PaddleMHCMonitor] Error composite: {e}")
+        finally:
+            self._h_res_snapshot.clear()
+
+    def finalize_scaled_grad_metrics(self, scaler=None) -> None:
+        """Remove AMP loss scaling from this step's logits-gradient extrema."""
+        if self._grad_metrics_finalized:
+            return
+        scale = getattr(scaler, "_scale", None) if scaler is not None else None
+        if scale is not None:
+            scale = paddle.assign(scale).detach().astype("float32")
+            for key in self._max_keys | self._min_keys:
+                if "_h_res_logits_grad_" in key and self._gpu_cnt[key] > 0:
+                    self._gpu_acc[key].divide_(scale)
+        self._grad_metrics_finalized = True
 
     def _flush_buffers(self) -> None:
-        if self._h_res_snapshot:
-            try:
-                with paddle.no_grad():
-                    self._record_composite()
-            except Exception as e:
-                if self.verbose:
-                    logger.error(f"[PaddleMHCMonitor] Error composite: {e}")
-            self._h_res_snapshot.clear()
+        # Direct users and non-AMP trainers may not emit on_optimizer_begin.
+        self.finalize_scaled_grad_metrics()
+        self.finalize_composite_microbatch()
         super()._flush_buffers()
+        self._grad_metrics_finalized = False
 
     # ------------------------------------------------------------------
     # Capture wrapper (the hot path)
     # ------------------------------------------------------------------
 
     def _make_capture(self, orig, layer_idx: int, component: str):
-        """Wrap ``compute_mappings`` to record metrics from its real return value.
-
-        VRAM safety: the mappings arrive attached to the training autograd graph,
-        so they are detached and all metric math runs under ``no_grad`` — nothing
-        stored may pin the graph through backward. The wrapper also keeps no state
-        across calls, since a monitored module can be entered more than once per
-        step (recompute replay, and mHC's own fp32 / bf16 paths) and any
-        cross-call accumulator would depend on execution order.
-        """
+        """Wrap ``compute_mappings`` to record metrics from its real return value."""
 
         def wrapped(x):
             out = orig(x)  # the real mappings the model consumes — returned unchanged
@@ -389,24 +363,10 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                     for name, value in h_post_structure_stats(h_post).items():
                         self.record_layer_metric(layer_idx, f"{component}_{name}", value)
 
-                    # Gains of the *operator*, not of `h_res` as written: streams
-                    # mix as `out_i = Σ_j h_res[j, i] · x_j`, so stream i's
-                    # forward gain is a **column** sum of `h_res` and its
-                    # backward gain a row sum. Columns are pinned to 1 by
-                    # construction (the Sinkhorn iteration ends on a column
-                    # normalization), so `_fwd` is a flat invariant guard while
-                    # `_bwd` carries the convergence residual.
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-2))
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, axis=-1))
 
-                    # Token-mean snapshot of the *operator* for the composite
-                    # product. `apply_h_res` mixes streams as
-                    # `mixed = h_res^T @ residual`, so the matrix that actually
-                    # acts on the stream vector is the transpose — composing
-                    # `h_res` itself would give neither the forward nor the
-                    # backward chain. Paper Fig 7b averages over tokens too, so
-                    # this holds one n x n matrix per layer/component. Last write
-                    # wins if the module is entered more than once per step.
+                    # Token-mean snapshot of the *operator* for the composite product.
                     n = int(h_res.shape[-1])
                     self._h_res_snapshot[(layer_idx, component)] = (
                         h_res.astype("float32").reshape([-1, n, n]).mean(axis=0).transpose([1, 0])
@@ -419,25 +379,41 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         return wrapped
 
     def _make_logits_capture(self, orig, layer_idx: int, component: str):
-        """Wrap ``_compute_h`` to record the saturation sentinel.
-
-        ``_compute_h`` returns ``(h_pre, h_post, h_res_logits)``; ``h_res_logits``
-        is the raw ``[..., n*n]`` mixing logits, which ``compute_mappings``
-        consumes immediately (``h_res = self._sinkhorn_op(...)``), so a wrapper
-        one level up cannot see it. ``n`` is read from ``h_pre``'s last axis
-        rather than config, in case ``num_residual_streams`` ever varies by layer.
-        Same VRAM discipline as ``_make_capture``.
-        """
+        """Wrap ``_compute_h`` to record the saturation sentinel."""
 
         def wrapped(proj, r):
             out = orig(proj, r)  # the real mappings the model consumes — returned unchanged
             if not self._should_monitor():
                 return out
             try:
-                h_pre, _h_post, h_res_logits = out
-                n = int(h_pre.shape[-1])
+                _h_pre, _h_post, h_res_logits = out
+                if not h_res_logits.stop_gradient:
+
+                    def record_grad_extrema(grad):
+                        try:
+                            grad_fp32 = grad.detach().astype("float32")
+                            self.record_layer_metric(
+                                layer_idx,
+                                f"{component}_h_res_logits_grad_min",
+                                grad_fp32.min(),
+                            )
+                            self.record_layer_metric(
+                                layer_idx,
+                                f"{component}_h_res_logits_grad_max",
+                                grad_fp32.max(),
+                            )
+                            self._grad_metrics_finalized = False
+                        except Exception as e:
+                            if self.verbose:
+                                logger.error(
+                                    f"[PaddleMHCMonitor] Error logits gradient "
+                                    f"layer {layer_idx}/{component}: {e}"
+                                )
+                        return grad
+
+                    h_res_logits.register_hook(record_grad_extrema)
                 with paddle.no_grad():
-                    for name, value in h_res_softmax_extrema(h_res_logits, n).items():
+                    for name, value in h_res_logits_extrema(h_res_logits).items():
                         self.record_layer_metric(layer_idx, f"{component}_{name}", value)
             except Exception as e:
                 if self.verbose:

--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -28,11 +28,6 @@ class Probe(ABC):
     METRIC_PREFIX: str = ""
     MAX_AGGREGATED: set[str] = set()
     MIN_AGGREGATED: set[str] = set()
-    # Metric names whose per-layer series is accumulated (the global value is
-    # derived from it) but never written to the log. For "gatekeeper" metrics
-    # that are constant by construction and only speak when an invariant breaks:
-    # one global curve carries the same signal as N layers x M components.
-    GLOBAL_ONLY: set[str] = set()
 
     def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
         self.log_per_layer = log_per_layer

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -1,5 +1,4 @@
 import importlib
-import math
 import sys
 import unittest
 from pathlib import Path
@@ -172,45 +171,20 @@ class MHCMetricsTest(unittest.TestCase):
         )
         self.assertAlmostEqual(float(stats["branch_residual_share"]), 0.0, places=6)
 
-    def test_softmax_extrema_are_one_over_n_for_uniform_logits(self):
-        stats = mhc_metrics.h_res_softmax_extrema(paddle.zeros([5, 16]), 4)
-        self.assertAlmostEqual(float(stats["h_res_softmax_min"]), 0.25, places=6)
-        self.assertAlmostEqual(float(stats["h_res_softmax_max"]), 0.25, places=6)
+    def test_logits_extrema_preserve_signed_raw_range(self):
+        logits = paddle.to_tensor([[-200.0, -18.0, 0.0, 7.5]], dtype="float32")
+        stats = mhc_metrics.h_res_logits_extrema(logits)
+        self.assertAlmostEqual(float(stats["h_res_logits_min"]), -200.0, places=6)
+        self.assertAlmostEqual(float(stats["h_res_logits_max"]), 7.5, places=6)
 
-    def test_softmax_min_matches_exp_minus_range_over_S(self):
-        # p_min = exp(-R) / S with S = 1/p_max, so -log(p_min) = R + log(S).
-        # Row 2 has the widest spread (0 - (-4) = 4) and holds the smallest weight.
-        logits = paddle.to_tensor(
-            [[-2.0, 0.0, -3.0, -2.0], [-3.0, 0.0, -2.0, -1.0], [-3.0, -2.0, -4.0, 0.0], [-2.0, -2.0, -3.0, 0.0]],
-            dtype="float32",
-        ).reshape([1, 16])
-        p = paddle.nn.functional.softmax(logits.reshape([1, 4, 4]), axis=-1)
-        s = 1.0 / float(p[0, 2].max())
-        stats = mhc_metrics.h_res_softmax_extrema(logits, 4)
-        self.assertAlmostEqual(float(stats["h_res_softmax_min"]), math.exp(-4.0) / s, places=6)
-
-    def test_softmax_max_saturates_where_min_still_resolves(self):
-        # Row 0 is one winner against three losers at -R; spreads of 18 and 200
-        # both pin `max` at exactly 1.0, so it cannot separate them, while `min`
-        # and the logit range can.
-        near = paddle.zeros([1, 16])
-        far = paddle.zeros([1, 16])
-        near[0, 1:4] = -18.0
-        far[0, 1:4] = -200.0
-        s_near = mhc_metrics.h_res_softmax_extrema(near, 4)
-        s_far = mhc_metrics.h_res_softmax_extrema(far, 4)
-        self.assertEqual(float(s_near["h_res_softmax_max"]), 1.0)
-        self.assertEqual(float(s_far["h_res_softmax_max"]), 1.0)
-        self.assertGreater(float(s_near["h_res_softmax_min"]), float(s_far["h_res_softmax_min"]))
-
-    def test_softmax_min_underflows_to_zero_past_the_alarm(self):
-        # A spread past ~103 drives softmax's smallest entry below fp32's smallest
-        # denormal, so the series bottoms out at exactly 0. That is past the alarm
-        # (1.18e-38, i.e. a spread of ~87) and the model cannot tell 0 from 1e-44
-        # either — `_sinkhorn_normalize` adds the same 1e-6 to both.
-        far = paddle.zeros([1, 16])
-        far[0, 1:4] = -200.0
-        self.assertEqual(float(mhc_metrics.h_res_softmax_extrema(far, 4)["h_res_softmax_min"]), 0.0)
+    def test_logits_extrema_are_detached_fp32_scalars(self):
+        logits = paddle.to_tensor([[-3.0, 2.0]], dtype="float16")
+        logits.stop_gradient = False
+        stats = mhc_metrics.h_res_logits_extrema(logits)
+        for value in stats.values():
+            self.assertEqual(value.shape, [])
+            self.assertEqual(value.dtype, paddle.float32)
+            self.assertTrue(value.stop_gradient)
 
 
 class MHCMonitorTest(unittest.TestCase):
@@ -303,13 +277,82 @@ class MHCMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_fwd_max"], 1.5, places=5)
         self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_bwd_max"], 1.0, places=5)
 
-    def test_softmax_extrema_are_recorded_and_reduce_by_extremum_across_layers(self):
-        # layer_0 healthy (uniform logits), layer_1 saturated. The global series
-        # must reduce by MIN / MAX so the sick layer is not averaged away.
+    def test_logits_gradient_extrema_are_unscaled_without_changing_backward(self):
+        n, s, b = 2, 1, 1
+        source = paddle.zeros([s, b, n * n], dtype="float32")
+        source.stop_gradient = False
+        logits = source * 1.0
+        hc = FakeHC(
+            n=n,
+            h_pre=paddle.full([s, b, n], 0.5),
+            h_post=paddle.ones([s, b, n]),
+            h_res=paddle.eye(n).reshape([s, b, n, n]),
+            h_res_logits=logits,
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=self._identity_layer(n, s, b).mlp_hyper_connection)])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        self._prepare_and_attach(monitor, model)
+
+        _, _, captured = hc._compute_h(None, None)
+        weight = paddle.to_tensor([[[2.0, -7.0, 4.0, 1.5]]], dtype="float32")
+        loss_scale = 16.0
+        (captured * weight * loss_scale).sum().backward()
+
+        # The hook observes but never modifies the autograd gradient.
+        self.assertTrue(paddle.allclose(source.grad, weight * loss_scale))
+        monitor.finalize_scaled_grad_metrics(SimpleNamespace(_scale=paddle.to_tensor(loss_scale)))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for key in (
+            "mhc_health/layer_0/attn_h_res_logits_grad_min",
+            "mhc_health/global_attn_h_res_logits_grad_min",
+        ):
+            self.assertAlmostEqual(latest[key], -7.0, places=5)
+        for key in (
+            "mhc_health/layer_0/attn_h_res_logits_grad_max",
+            "mhc_health/global_attn_h_res_logits_grad_max",
+        ):
+            self.assertAlmostEqual(latest[key], 4.0, places=5)
+
+    def test_logits_gradient_hook_skips_no_grad_recompute_forward(self):
+        n, s, b = 2, 1, 1
+        source = paddle.zeros([s, b, n * n], dtype="float32")
+        source.stop_gradient = False
+        hc = FakeHC(
+            n=n,
+            h_pre=paddle.full([s, b, n], 0.5),
+            h_post=paddle.ones([s, b, n]),
+            h_res=paddle.eye(n).reshape([s, b, n, n]),
+            h_res_logits=source * 1.0,
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=self._identity_layer(n, s, b).mlp_hyper_connection)])
+        monitor = PaddleMHCHealthMonitor()
+        self._prepare_and_attach(monitor, model)
+
+        with paddle.no_grad():
+            hc._compute_h(None, None)
+        min_key = "mhc_health/layer_0/attn_h_res_logits_grad_min"
+        max_key = "mhc_health/layer_0/attn_h_res_logits_grad_max"
+        self.assertEqual(monitor._gpu_cnt[min_key], 0)
+        self.assertEqual(monitor._gpu_cnt[max_key], 0)
+
+        _, _, replay_logits = hc._compute_h(None, None)
+        replay_logits.sum().backward()
+        self.assertEqual(monitor._gpu_cnt[min_key], 1)
+        self.assertEqual(monitor._gpu_cnt[max_key], 1)
+        monitor.step()
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest[min_key], 1.0, places=5)
+        self.assertAlmostEqual(latest[max_key], 1.0, places=5)
+
+    def test_logits_extrema_are_recorded_and_reduce_by_extremum_across_layers(self):
+        # layer_0 has zero logits; layer_1 spans [-104, 7.5]. The global series
+        # must reduce by MIN / MAX so an extreme layer is not averaged away.
         n, s, b = 4, 2, 3
-        saturated = (
+        extreme = (
             paddle.to_tensor(
-                [[-25.7, 0.0, -100.0, -61.0], [-33.4, 0.0, -89.0, -48.0]]
+                [[-25.7, 7.5, -100.0, -61.0], [-33.4, 0.0, -89.0, -48.0]]
                 + [[-34.0, -24.9, -104.0, 0.0], [-79.4, -72.6, -104.0, 0.0]],
                 dtype="float32",
             )
@@ -323,7 +366,7 @@ class MHCMonitorTest(unittest.TestCase):
                 h_pre=paddle.full([s, b, n], 0.5),
                 h_post=paddle.ones([s, b, n]),
                 h_res=paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n]),
-                h_res_logits=paddle.assign(saturated),
+                h_res_logits=paddle.assign(extreme),
             )
 
         model = _mhc_model([self._identity_layer(n, s, b), FakeLayer(attn=sick_hc(), mlp=sick_hc())])
@@ -335,14 +378,12 @@ class MHCMonitorTest(unittest.TestCase):
 
         latest = training_logs.get_latest(prefix="mhc_health")
         for comp in ("attn", "mlp"):
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_softmax_min"], 0.25, places=5)
-            self.assertLess(latest[f"mhc_health/layer_1/{comp}_h_res_softmax_min"], 1e-30)
-            self.assertLess(latest[f"mhc_health/global_{comp}_h_res_softmax_min"], 1e-30)
-            # max: uniform layer also reads 1/n, saturated layer pins at 1.0, and
-            # the global series reduces by MAX.
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_softmax_max"], 0.25, places=5)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_softmax_max"], 1.0, places=5)
-            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_softmax_max"], 1.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_logits_min"], 0.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_logits_min"], -104.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_logits_min"], -104.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_logits_max"], 0.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_logits_max"], 7.5, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_logits_max"], 7.5, places=5)
 
     def test_composite_is_built_in_layer_order_not_call_order(self):
         # Regression test for what retired the previous composite metric: it was
@@ -370,20 +411,29 @@ class MHCMonitorTest(unittest.TestCase):
         def col_gain(m):
             return float(m.sum(axis=-2).abs().max())
 
-        def chain(seq, gain):
-            # apply_h_res mixes with h_res^T, so the composite operator is built
-            # from the transposes.
-            out, acc = [], None
-            for m in seq:
-                op = m.transpose([1, 0])
-                acc = op if acc is None else paddle.matmul(op, acc)
-                out.append(gain(acc))
-            return out
+        components = ("attn", "mlp")
+        branches = [
+            (layer_idx, component, mat.transpose([1, 0]))
+            for layer_idx, mat in enumerate(mats)
+            for component in components
+        ]
 
-        expected = chain(mats, row_gain)
-        expected_bwd = chain(mats, col_gain)
-        # Guard against a vacuous test: the reversed product must actually differ.
-        self.assertNotAlmostEqual(expected[-1], chain(list(reversed(mats)), row_gain)[-1], places=4)
+        expected_fwd = {}
+        prefix = None
+        for layer_idx, component, op in branches:
+            prefix = op if prefix is None else paddle.matmul(op, prefix)
+            expected_fwd[(layer_idx, component)] = row_gain(prefix)
+
+        expected_bwd = {}
+        suffix = None
+        for layer_idx, component, op in reversed(branches):
+            suffix = op if suffix is None else paddle.matmul(suffix, op)
+            expected_bwd[(layer_idx, component)] = col_gain(suffix)
+        # Guard against a vacuous test: reversing the physical branch order differs.
+        wrong_prefix = None
+        for _, _, op in reversed(branches):
+            wrong_prefix = op if wrong_prefix is None else paddle.matmul(op, wrong_prefix)
+        self.assertNotAlmostEqual(expected_fwd[(2, "mlp")], row_gain(wrong_prefix), places=4)
 
         def layer_for(mat):
             def make_hc():
@@ -403,20 +453,28 @@ class MHCMonitorTest(unittest.TestCase):
         monitor.step()
 
         latest = training_logs.get_latest(prefix="mhc_health")
-        for comp in ("attn", "mlp"):
-            for idx, (want_fwd, want_bwd) in enumerate(zip(expected, expected_bwd)):
+        for comp in components:
+            for idx in range(len(mats)):
+                key = (idx, comp)
                 self.assertAlmostEqual(
-                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_fwd_max"], want_fwd, places=4
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_fwd_max"],
+                    expected_fwd[key],
+                    places=4,
                 )
                 self.assertAlmostEqual(
-                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_bwd_max"], want_bwd, places=4
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_bwd_max"],
+                    expected_bwd[key],
+                    places=4,
                 )
-            # Global reduces by max over layers.
             self.assertAlmostEqual(
-                latest[f"mhc_health/global_{comp}_composite_amax_gain_fwd_max"], max(expected), places=4
+                latest[f"mhc_health/global_{comp}_composite_amax_gain_fwd_max"],
+                max(value for (idx, component), value in expected_fwd.items() if component == comp),
+                places=4,
             )
             self.assertAlmostEqual(
-                latest[f"mhc_health/global_{comp}_composite_amax_gain_bwd_max"], max(expected_bwd), places=4
+                latest[f"mhc_health/global_{comp}_composite_amax_gain_bwd_max"],
+                max(value for (idx, component), value in expected_bwd.items() if component == comp),
+                places=4,
             )
 
     def test_composite_is_one_for_identity_chain(self):
@@ -463,6 +521,39 @@ class MHCMonitorTest(unittest.TestCase):
         monitor.step()
         # Stale matrices must not survive into the next step's product.
         self.assertFalse(monitor._h_res_snapshot)
+
+    def test_composite_aggregates_each_microbatch_before_snapshot_overwrite(self):
+        n, s, b = 2, 1, 1
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        amplified = paddle.diag(paddle.to_tensor([3.0, 1.0])).reshape([1, 1, n, n])
+        for _, _, mod in targets:
+            mod._h_res = amplified
+        self._drive(targets, x_dim=n * 8)
+        monitor.finalize_composite_microbatch()
+        self.assertFalse(monitor._h_res_snapshot)
+
+        identity = paddle.eye(n).reshape([1, 1, n, n])
+        for _, _, mod in targets:
+            mod._h_res = identity
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(
+            latest["mhc_health/layer_0/attn_composite_amax_gain_fwd_max"], 3.0, places=5
+        )
+        self.assertAlmostEqual(
+            latest["mhc_health/layer_0/mlp_composite_amax_gain_fwd_max"], 9.0, places=5
+        )
+        self.assertAlmostEqual(
+            latest["mhc_health/layer_0/attn_composite_amax_gain_bwd_max"], 9.0, places=5
+        )
+        self.assertAlmostEqual(
+            latest["mhc_health/layer_0/mlp_composite_amax_gain_bwd_max"], 3.0, places=5
+        )
 
     def test_branch_residual_share_is_recorded_from_bda(self):
         n, s, b, c = 4, 2, 3, 6


### PR DESCRIPTION
# fix: align mHC composite metrics with paper semantics

## 背景

原 mHC composite 指标的累计语义与论文 Figure 7(b) 不一致：

- Attention 和 MLP 被拆成两条独立链，没有按照真实 residual branch 顺序交错累计。
- `composite_amax_gain_bwd_max` 使用了入口到当前层的 prefix，而论文定义要求使用当前 branch 到模型尾部的 suffix。
- Gradient accumulation 场景下，同一 optimizer step 只保留最后一个 microbatch 的 composite 快照。

## 修改内容

- 按真实执行顺序构造 residual branch 链：

  ```text
  attn_0 -> mlp_0 -> attn_1 -> mlp_1 -> ...
  ```

- Forward composite 使用入口到当前 branch 的 prefix：

  ```text
  F_q = T_q @ ... @ T_0
  gain_fwd = ||F_q||∞
  ```

- Backward composite 使用当前 branch 到模型尾部的 suffix：

  ```text
  B_q = T_tail @ ... @ T_q
  gain_bwd = ||B_q||1
  ```

- 在每个 gradient-accumulation microbatch 结束时结算 composite，并写入 GPU max accumulator，避免快照被后续 microbatch 覆盖。
- 保持 recompute 兼容：快照按 `(layer_idx, attn-before-mlp)` 排序，统计结果不依赖 backward replay 的 hook 触发顺序。
- MTP 层继续排除在主干 composite 链之外。
- 更新 mHC 文档、README、viewer 指标说明和自动诊断逻辑。
- 移除工具侧已经失效的 `h_res_softmax_min/max` 解释，补齐 raw logits 和 signed logits-gradient 指标元数据。

## 指标语义

修正后：

- `{c}_composite_amax_gain_fwd_max`：模型入口到当前 `{c}` branch 的交错 prefix 前向最坏放大。
- `{c}_composite_amax_gain_bwd_max`：模型尾部反传到当前 `{c}` branch 的交错 suffix 反向最坏放大。
- `{c}` 只表示当前观测点是 attention 或 MLP，不再表示两条独立累计链。

## 验证

- mHC PaddleFleet 专项测试：`28 passed`
- 当前环境可运行测试：`114 passed`
- Python syntax check 通过
- `git diff --check` 通过
- 新增非交换矩阵测试，覆盖：
  - Attention/MLP 交错顺序
  - Forward prefix 左乘方向
  - Backward suffix 右乘方向
  - Recompute 逆序 hook
  - 多 microbatch 聚合