### PR TITLE
fix: reduce per-expert norm across EP group when intermediate is sharded

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -18,6 +18,7 @@ return tuple. Currently adapted for StandardMoEGate (PaddleFormers).
 import logging
 
 import paddle
+import paddle.distributed as dist
 import paddle.nn as nn
 
 from .base import PaddleProbe
@@ -81,13 +82,37 @@ def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=
     return intersection / union.clip(min=1.0)
 
 
-def _per_expert_stacked_norms(w1, w2=None):
-    """Per-expert L2 norm over stacked expert weights, fully vectorized."""
+def _per_expert_stacked_sumsq(w1, w2=None):
+    """Per-expert sum of squares over stacked expert weights, fully vectorized.
+
+    Returns the sum of squares rather than the norm: under the 'allgather' MoE
+    dispatcher each expert is sharded along its intermediate dim, so the
+    per-shard sums must be reduced across the EP group *before* the sqrt.
+    """
     num_experts = w1.shape[0]
     sq = (w1.detach().astype("float32").reshape([num_experts, -1]) ** 2).sum(axis=-1)
     if w2 is not None:
         sq = sq + (w2.detach().astype("float32").reshape([num_experts, -1]) ** 2).sum(axis=-1)
-    return paddle.sqrt(sq)
+    return sq
+
+
+def _intermediate_shard_group(experts):
+    """EP group along which every expert's intermediate dim is sharded, or None.
+
+    ``moe_layer`` builds the fused expert module with
+    ``intermediate_size_per_partition = moe_intermediate_size // EP`` when
+    ``moe_token_dispatcher_type == 'allgather'`` and EP > 1 — every rank then
+    holds *all* experts but only a 1/EP slice of each. Without reducing, every
+    weight-norm metric reads low by sqrt(EP) (and shared_routed_ratio high by
+    the same factor) the moment that dispatcher is switched on.
+    """
+    if experts is None:
+        return None
+    local = getattr(experts, "intermediate_size_per_partition", None)
+    full = getattr(getattr(experts, "config", None), "moe_intermediate_size", None)
+    if not local or not full or local >= full:
+        return None
+    return getattr(experts, "ep_group", None)
 
 
 def _module_sumsq(module):
@@ -320,13 +345,42 @@ class PaddleMoEMonitor(PaddleProbe):
         """Compute per-layer expert weight norms for all monitored MoE layers."""
         if not self._buffers_allocated or not self._should_monitor():
             return
+        pending = []
+        shard_group = None
         for layer_idx, moe_layer in self._expert_norm_layers:
             try:
                 with paddle.no_grad():
-                    self._compute_expert_metrics(layer_idx, moe_layer)
+                    routed_sq, shared_sq, group = self._collect_expert_sumsq(moe_layer)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMoEMonitor] expert-norm collect error layer {layer_idx}: {e}")
+                continue
+            if group is not None:
+                shard_group = group
+            pending.append((layer_idx, routed_sq, shared_sq, group is not None))
+        if not pending:
+            return
+        with paddle.no_grad():
+            # One collective for the whole model rather than one per layer: the
+            # intermediate-dim shards only carry 1/EP of each expert, so the
+            # sums must be reduced before the sqrt.
+            sharded = [sq for _, sq, _, needs_reduce in pending if needs_reduce and sq is not None]
+            if sharded and shard_group is not None:
+                sizes = [int(sq.shape[0]) for sq in sharded]
+                flat = paddle.concat([sq.reshape([-1]) for sq in sharded])
+                dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=shard_group)
+                reduced = iter(paddle.split(flat, sizes))
+                pending = [
+                    (
+                        layer_idx,
+                        next(reduced) if (needs_reduce and sq is not None) else sq,
+                        shared_sq,
+                        needs_reduce,
+                    )
+                    for layer_idx, sq, shared_sq, needs_reduce in pending
+                ]
+            for layer_idx, routed_sq, shared_sq, _ in pending:
+                self._record_expert_metrics(layer_idx, routed_sq, shared_sq)
 
     def _compute_gate_metrics(self, layer_idx, gate, outputs, moe_layer):
         """Compute router metrics from gate forward output."""
@@ -364,29 +418,33 @@ class PaddleMoEMonitor(PaddleProbe):
             self.record_layer_metric(layer_idx, "expert_bias_max", bias.max())
             self.record_layer_metric(layer_idx, "expert_bias_min", bias.min())
 
-    def _compute_expert_metrics(self, layer_idx, moe_layer):
-        routed_norm_mean = None
+    def _collect_expert_sumsq(self, moe_layer):
+        """Per-expert / shared-expert sums of squares for one MoE layer.
+
+        Returns ``(routed_sumsq[num_experts] | None, shared_sumsq | None,
+        shard_group | None)``. Sqrt is deferred to ``_record_expert_metrics`` so
+        an intermediate-sharded layout can be reduced across EP first.
+        """
+        routed_sq = None
+        shard_group = None
 
         # grouped-gemm experts: weight1/weight2 are [num_experts, ...] blocks.
         if hasattr(moe_layer, "grouped_gemm_experts") and moe_layer.grouped_gemm_experts is not None:
             ggm = moe_layer.grouped_gemm_experts
             if hasattr(ggm, "weight1") and hasattr(ggm, "weight2"):
-                norms = _per_expert_stacked_norms(ggm.weight1, ggm.weight2)
-                norm_stats = _norm_stats(norms)
-                for name, val in norm_stats.items():
-                    self.record_layer_metric(layer_idx, name, val)
-                routed_norm_mean = norm_stats.get("expert_norm_mean")
+                routed_sq = _per_expert_stacked_sumsq(ggm.weight1, ggm.weight2)
+                shard_group = _intermediate_shard_group(ggm)
 
         elif hasattr(moe_layer, "experts") and moe_layer.experts is not None:
             experts = moe_layer.experts
-            norms = None
             # Fused-expert layout (moe_expert_fusion=True): self.experts is a
             # single module whose up_gate_proj/down_proj weights carry a leading
             # expert dim [num_experts, ...]. Vectorize over that dim.
             if hasattr(experts, "up_gate_proj") and hasattr(experts, "down_proj"):
-                w1 = experts.up_gate_proj.weight
-                w2 = experts.down_proj.weight
-                norms = _per_expert_stacked_norms(w1, w2)
+                routed_sq = _per_expert_stacked_sumsq(
+                    experts.up_gate_proj.weight, experts.down_proj.weight
+                )
+                shard_group = _intermediate_shard_group(experts)
             elif isinstance(experts, (list, nn.LayerList)) or hasattr(experts, "__iter__"):
                 # Non-fused layout: LayerList of per-expert modules. One sum-sq
                 # per expert (each is a small handful of params), then stack.
@@ -396,25 +454,35 @@ class PaddleMoEMonitor(PaddleProbe):
                         continue
                     sq = _module_sumsq(expert)
                     if sq is not None:
-                        per_expert.append(paddle.sqrt(sq))
+                        per_expert.append(sq)
                 if per_expert:
-                    norms = paddle.stack(per_expert)
-            if norms is not None:
-                norm_stats = _norm_stats(norms)
-                for name, val in norm_stats.items():
-                    self.record_layer_metric(layer_idx, name, val)
-                routed_norm_mean = norm_stats.get("expert_norm_mean")
+                    routed_sq = paddle.stack(per_expert)
 
+        shared_sq = None
         if hasattr(moe_layer, "shared_experts") and moe_layer.shared_experts is not None:
+            # Shared experts are replicated, never intermediate-sharded
+            # (moe_layer builds them with the full moe_shared_expert_intermediate_size),
+            # so they stay out of the EP reduction.
             shared_sq = _module_sumsq(moe_layer.shared_experts)
-            if shared_sq is not None:
-                shared_norm = paddle.sqrt(shared_sq)
-                self.record_layer_metric(layer_idx, "shared_expert_norm", shared_norm)
-                if routed_norm_mean is not None:
-                    # clip 防止除零（对齐 megatron compute_shared_routed_ratio），保持 GPU 张量无 D2H
-                    self.record_layer_metric(
-                        layer_idx, "shared_routed_ratio", shared_norm / routed_norm_mean.clip(min=1e-8)
-                    )
+
+        return routed_sq, shared_sq, shard_group
+
+    def _record_expert_metrics(self, layer_idx, routed_sq, shared_sq):
+        routed_norm_mean = None
+        if routed_sq is not None:
+            norm_stats = _norm_stats(paddle.sqrt(routed_sq))
+            for name, val in norm_stats.items():
+                self.record_layer_metric(layer_idx, name, val)
+            routed_norm_mean = norm_stats.get("expert_norm_mean")
+
+        if shared_sq is not None:
+            shared_norm = paddle.sqrt(shared_sq)
+            self.record_layer_metric(layer_idx, "shared_expert_norm", shared_norm)
+            if routed_norm_mean is not None:
+                # clip 防止除零（对齐 megatron compute_shared_routed_ratio），保持 GPU 张量无 D2H
+                self.record_layer_metric(
+                    layer_idx, "shared_routed_ratio", shared_norm / routed_norm_mean.clip(min=1e-8)
+                )
 
     def remove_hooks(self):
         super().remove_hooks()

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -265,17 +265,37 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["moe_health/global_full_router_entropy"], 3.0, places=4)
         self.assertNotIn("moe_health/global_router_entropy", latest)
 
-    def test_fused_expert_norm_matches_per_expert_concat_norm(self):
-        """Vectorized per-expert norm equals the old concat([w1_i, w2_i]).norm()."""
+    def test_fused_expert_sumsq_matches_per_expert_concat_norm(self):
+        """Vectorized per-expert sum-of-squares sqrts to the old concat([w1_i, w2_i]).norm()."""
         moe_monitor_mod = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
         num_experts, h, i = 4, 8, 6
         w1 = paddle.randn([num_experts, h, i], dtype="float32")
         w2 = paddle.randn([num_experts, i, h], dtype="float32")
 
-        got = moe_monitor_mod._per_expert_stacked_norms(w1, w2)
+        got = paddle.sqrt(moe_monitor_mod._per_expert_stacked_sumsq(w1, w2))
         expected = paddle.stack([paddle.concat([w1[e].flatten(), w2[e].flatten()]).norm() for e in range(num_experts)])
         self.assertEqual(list(got.shape), [num_experts])
         self.assertTrue(bool(paddle.allclose(got, expected, atol=1e-5)))
+
+    def test_intermediate_shard_group_detects_allgather_layout(self):
+        """An expert module holding only I/EP of each expert reports its EP group."""
+        moe_monitor_mod = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
+        ep_group = object()
+
+        replicated = SimpleNamespace(
+            intermediate_size_per_partition=2048,
+            config=SimpleNamespace(moe_intermediate_size=2048),
+            ep_group=ep_group,
+        )
+        self.assertIsNone(moe_monitor_mod._intermediate_shard_group(replicated))
+
+        sharded = SimpleNamespace(
+            intermediate_size_per_partition=256,
+            config=SimpleNamespace(moe_intermediate_size=2048),
+            ep_group=ep_group,
+        )
+        self.assertIs(moe_monitor_mod._intermediate_shard_group(sharded), ep_group)
+        self.assertIsNone(moe_monitor_mod._intermediate_shard_group(None))
 
     def test_collect_expert_norms_fused_layout_records_metrics(self):
         """collect_expert_norms records expert + shared norms for a fused-expert MoE layer."""


### PR DESCRIPTION
## 问题

`moe_token_dispatcher_type='allgather'` + EP>1 时，`moe_health` 的专家权重 norm 系统性偏小 sqrt(EP)，`shared_routed_ratio` 反向偏大同样倍数。线上 43 层作业上线该 dispatcher 后，`expert_norm_mean` 从 ~139 跳到 ~47（2.83 ≈ sqrt(8)），`shared_routed_ratio` 从 1.4 跳到 3.97。

**模型权重没有任何变化，纯粹是指标读数问题。** 落盘 checkpoint 也不受影响（`moe_expert.py:409-486` 的 `_get_intermediate_sharded_state_dict` 会把切片拼回全局 `[E, I_full, H]`）。

## 根因

`moe_layer.py:365-380` 在 allgather + EP>1 时用`intermediate_size_per_partition = moe_intermediate_size // EP` 构建专家 ，每张卡持有**全部**专家，但每个专家只有 1/EP 的 intermediate 切片。原实现对本地切片直接求 L2，而 **L2 norm 不可加**，所以读数是真值的 1/sqrt(EP)。

shared expert 是完整复制的（`moe_layer.py:405-416` 用完整的`moe_shared_expert_intermediate_size`），norm 不变，于是
`shared_routed_ratio = shared / routed` 被抬高 sqrt(EP)。

## 改动

- `_per_expert_stacked_norms` → `_per_expert_stacked_sumsq`：只返回平方和， **sqrt 推迟到跨卡归约之后**（平方和可加，norm 不可加）。
- 新增 `_intermediate_shard_group()`：以`intermediate_size_per_partition < config.moe_intermediate_size` 判定切分并返回 `ep_group`。刻意不读 dispatcher 名、不写死 EP 数值 —— 判据落在真正决定 norm 的那个量上，换 dispatcher 名或改 EP 都不用动这里。属性取不到时退化为「不归约」（即原行为），不会让探针把训练搞挂。
- `_compute_expert_metrics` 拆为 `_collect_expert_sumsq` + `_record_expert_metrics`，以便在两者之间插入通信。
- `collect_expert_norms`：把全模型各层的 sumsq concat 成一维张量，**整模型一次** `all_reduce(SUM)` 后再 split/sqrt。逐层归约会产生 N 个仅含几百 float 的 NCCL op，纯启动开销。
- shared expert **不参与**归约（复制而非切分，误加会反向错一次）。
- 未切分路径（deepep 等）`_intermediate_shard_group()` 返回 `None` → **完全跳过 all_reduce，零新增通信**。

该收集路径在 step_begin（offline FP8 quant 前读 bf16 权重），不在 forward hook 内；
本次新增的 collective 是正确性必需而非顺手添加；全程保持 GPU 张量，无 D2H 同步。

## 验证

单元测试：`tests/test_paddlefleet_monitors.py` **59 passed**。改了一条老断言（`_per_expert_stacked_norms` 已不存在，改为 `sqrt(_per_expert_stacked_sumsq(...))`与逐专家 `concat().norm()` 对齐），新增
`test_intermediate_shard_group_detects_allgather_layout`。

端到端 2×2 对照，单机 8 卡 EP=8，12 层 / 32 experts / I=2048 → I_local=256
（step 10，12 层均值）：

| 指标 | 跨rank聚合 | deepep+fix | deepep−fix | allgather+fix | allgather−fix |
|---|---|---|---|---|---|
| `expert_norm_mean` | mean | 20.997732 | 20.997732 | 20.997732 | **7.423818** |
| `expert_norm_std` | mean | 0.003402 | 0.003402 | 0.003691 | 0.003913 |
| `expert_norm_min` | min | 20.989548 | 20.989548 | 20.990259 | **7.412323** |
| `expert_norm_max` | max | 21.005498 | 21.005499 | 21.005369 | **7.435166** |
| `shared_expert_norm` | mean | 29.696835 | 29.696834 | 29.696835 | 29.696835 |
| `shared_routed_ratio` | mean | 1.414288 | 1.414288 | 1.414288 | **4.000210** |

- `allgather−fix / allgather+fix` 在 `expert_norm_mean` 上 = **0.3536**（理论 1/sqrt(8) = 0.353553，逐层 min=max=mean，精确到浮点极限）；在 `shared_routed_ratio` 上 = **2.8284**（理论 sqrt(8) = 2.828427）。
- `deepep−fix / deepep+fix` 六个指标全部 = **1.0000**，逐层`max|diff|` ~2.