### PR TITLE
[fix] optim 监控改为受 monitor_interval 门控

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 
-以及一个挂在**优化器**而不是模型上的模块，**始终开启**（无开关，调用方零改动）：
-- **[Optimizer Update](./docs/optim_update.md)** — `optim/update_rms`、`optim/param_rms`、`optim/update_param_ratio`，每 step 一个标量，与 grad norm 并排看
+以及一个挂在**优化器**而不是模型上的模块，**始终装上**（无需点名，调用方零改动；上报频率同样受 `monitor_interval` 门控）：
+- **[Optimizer Update](./docs/optim_update.md)** — `optim/update_rms`、`optim/param_rms`、`optim/update_param_ratio`，与 grad norm 并排看
 
 ---
 
@@ -609,6 +609,6 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **VHA** | `premix_group_div_ratio` | `mean‖W_g−W_g'‖²/mean‖W_g−I‖²` | mean | 0=各组同一变换, 2=完全独立 |
 | **VHA** | `premix_sigma_max` | `σ_max(W)` | max | premix 谱范数 (需 use_vha_premix) |
 | **VHA** | `premix_orth_dev` | `‖WᵀW − I‖_F` | mean | 仅非方阵 premix (正交初始化) |
-| **Optim** | `update_rms` | `sqrt(mean((θ_new−θ_old)²))` | 已全局归约 | 本 step 参数更新幅度 (始终开启) |
-| **Optim** | `param_rms` | `sqrt(mean(θ_new²))` | 已全局归约 | 更新后参数尺度 (始终开启) |
-| **Optim** | `update_param_ratio` | `update_rms / param_rms` | 已全局归约 | trust ratio, ~1e-3 健康 (始终开启) |
+| **Optim** | `update_rms` | `sqrt(mean((θ_new−θ_old)²))` | 已全局归约 | 本 step 参数更新幅度 (始终装上, 受 monitor_interval 门控) |
+| **Optim** | `param_rms` | `sqrt(mean(θ_new²))` | 已全局归约 | 更新后参数尺度 (始终装上, 受 monitor_interval 门控) |
+| **Optim** | `update_param_ratio` | `update_rms / param_rms` | 已全局归约 | trust ratio, ~1e-3 健康 (始终装上, 受 monitor_interval 门控) |

--- a/docs/optim_update.md
+++ b/docs/optim_update.md
@@ -1,6 +1,6 @@
 # Optimizer Update Monitor (`optim/*`)
 
-每个 training step 上报三个标量，与 grad norm / param norm 并排读：
+每 `monitor_interval` 步上报三个标量，与 grad norm / param norm 并排读：
 
 | 指标 | 公式 | 含义 |
 |---|---|---|
@@ -8,10 +8,14 @@
 | `optim/param_rms` | `sqrt(mean(θ_new²))` | 更新后的参数尺度 |
 | `optim/update_param_ratio` | `update_rms / param_rms` | trust ratio，健康量级 ~1e-3 |
 
-**始终开启，没有配置开关，也不需要调用方多写一行**：它在 `_ALWAYS_ON_MONITORS` 里而不在
+**始终装上，没有开关，也不需要调用方多写一行**：它在 `_ALWAYS_ON_MONITORS` 里而不在
 `_MONITOR_MAP` 里，因此 `setup_internal_medicine` / `setup_monitors` 无论 `monitors` 传什么
-都会装上它；不是 `internal_medicine_monitors` 的一项，也不受
-`internal_medicine_monitor_interval` 门控。每 step 都算，随 `logger.log_interval` 打印。
+都会装上它，不需要在 `internal_medicine_monitors` 里点名。
+
+**上报频率受 `internal_medicine_monitor_interval` 门控**，与模型侧 monitor 一致：这三个都是
+慢变量（实测 50 步内 `param_rms` 一位不变），每 step 报一次只会刷屏，还要多付两次 collective。
+门开在 **wrapper 里**而不只是上报时，所以未被监控的 step 上连和都不算 —— wrapper 只多一次布尔
+判断，`step()` 里的 collective 也完全不发起。
 
 指标 key 前缀是 `optim/`，而 `monitor_dict` 的 key 也是 `optim` —— 两者刻意一致，这样调用方
 "遍历 `monitor_dict` key 当 prefix 打印 `training_logs`" 的既有循环就会自动带上这三个值，

--- a/src/internal_medicine/backends/megatron/optim_update_monitor.py
+++ b/src/internal_medicine/backends/megatron/optim_update_monitor.py
@@ -1,6 +1,7 @@
 """Optimizer update-magnitude monitor for the Megatron backend.
 
-Emits three always-on scalars per training step, alongside grad-norm / param-norm:
+Always installed (no ``monitors`` opt-in), reported every ``monitor_interval`` steps
+alongside grad-norm / param-norm:
 
     optim/update_rms        sqrt(mean((theta_new - theta_old)**2))
     optim/param_rms         sqrt(mean(theta_new**2))
@@ -86,7 +87,9 @@ class OptimUpdateMonitor:
     ``step()`` (which runs outside any forward, so collectives are free to happen).
     """
 
-    def __init__(self, verbose: bool = False, debias_low_precision: bool = True):
+    def __init__(self, monitor_interval: int = 1, verbose: bool = False, debias_low_precision: bool = True):
+        self.monitor_interval = monitor_interval
+        self.step_count = 0
         self.verbose = verbose
         self.debias_low_precision = debias_low_precision
         self._patched: list[tuple[Any, str, Any, bool]] = []
@@ -100,6 +103,17 @@ class OptimUpdateMonitor:
         self._warned_fp32 = False
         self._warned_no_pairs = False
         self.latest: dict[str, float] = {}
+
+    def _should_monitor(self) -> bool:
+        """Same interval gate as ``BaseMonitor``, on the optimizer step counter.
+
+        Gating in the WRAPPER (not just at report time) is what makes the interval
+        actually cheap: on a skipped step no sums are computed, so the wrapper costs one
+        boolean and the collectives in ``step`` never fire.
+        """
+        if not self.monitor_interval:
+            return False
+        return self.step_count % self.monitor_interval == 0
 
     def attach_optimizer(self, optimizer) -> bool:
         """Wrap this optimizer instance's main-param copy. Returns True if any wrapped."""
@@ -187,6 +201,8 @@ class OptimUpdateMonitor:
         self._patched.append((target, method, original, was_instance_attr))
 
     def _measure_safe(self, opt) -> None:
+        if not self._should_monitor():
+            return
         try:
             self._measure(opt)
         except Exception as e:
@@ -301,16 +317,23 @@ class OptimUpdateMonitor:
     def step(self, global_step: int | None = None) -> dict[str, float]:
         """Reduce the step's sums, publish the scalars, and return them.
 
+        Advances the interval counter first (mirroring ``BaseMonitor.step``), then reports
+        only if the wrapper actually collected anything. On a skipped step the pending
+        buckets are empty, so this returns ``{}`` without issuing any collective.
+
         Main params are sharded over DP+CP by the distributed optimizer and split again
         over TP/PP, so the sums pool over the shard group and then the model-parallel
         group — mirroring ``calc_params_l2_norm``. Expert params live on different groups
         (expert-DP, then expert-TP/PP), hence the separate bucket. RMS is nonlinear in the
         sums, so all pooling happens before the division.
         """
+        if global_step is not None:
+            self.step_count = global_step
+        self.step_count += 1
         dense, self._pending_dense = self._pending_dense, []
         expert, self._pending_expert = self._pending_expert, []
         self.latest = {}
-        if not dense and not expert and not self._patched:
+        if not dense and not expert:
             return self.latest
 
         device = None
@@ -364,21 +387,26 @@ def setup_optim_update_monitor(
     model=None,
     optimizer=None,
     monitor_dict: dict | None = None,
+    monitor_interval: int = 1,
     verbose: bool = False,
     **_ignored,
 ):
-    """Enable ``optim/update_rms`` + ``param_rms``. Always on; no per-monitor kwargs.
+    """Enable ``optim/update_rms`` + ``param_rms``. Always installed; no opt-in needed.
 
     ``model`` is accepted and ignored so this can sit in the same registry as the
     model-side monitors and be driven by the same ``setup_internal_medicine`` call. With
     no ``optimizer`` given (the normal path — it does not exist at model-setup time) the
     mcore optimizer CLASSES are patched instead, which covers whatever is built later.
 
+    ``monitor_interval`` is honoured exactly like the model-side monitors: these are
+    slow-moving scalars, so reporting them every step would only add log noise and two
+    collectives per step.
+
     Registered under the ``optim`` key, matching ``METRIC_PREFIX``, so a caller that
     prints ``training_logs`` by iterating ``monitor_dict`` keys as prefixes picks these up
     with no extra wiring.
     """
-    monitor = OptimUpdateMonitor(verbose=verbose)
+    monitor = OptimUpdateMonitor(monitor_interval=monitor_interval, verbose=verbose)
     if optimizer is not None:
         monitor.attach_optimizer(optimizer)
     else:

--- a/tests/test_megatron_monitors.py
+++ b/tests/test_megatron_monitors.py
@@ -1107,6 +1107,83 @@ class MegatronOptimUpdateMonitorTest(unittest.TestCase):
         finally:
             monitor.remove_hooks()
 
+    # ---------------- monitor_interval gating ----------------
+
+    def test_reports_only_on_monitored_steps(self):
+        """With monitor_interval=3 only every 3rd step reports. These are slow-moving
+        scalars, so per-step reporting is just log noise plus two collectives."""
+        torch.manual_seed(20)
+        opt = _FakeDistOpt(torch.randn(8192) * 0.02)
+        monitor = OptimUpdateMonitor(monitor_interval=3)
+        monitor.attach_optimizer(opt)
+        reported = []
+        try:
+            for _ in range(7):
+                opt.apply_update(torch.randn(8192) * 3e-4)
+                opt._copy_main_params_to_model_params()
+                reported.append(bool(monitor.step()))
+        finally:
+            monitor.remove_hooks()
+        # step_count runs 0,1,..; the gate fires when count % 3 == 0, i.e. steps 1, 4, 7.
+        self.assertEqual(reported, [True, False, False, True, False, False, True])
+
+    def test_skipped_step_does_no_work_at_all(self):
+        """The gate lives in the WRAPPER, not just at report time: on a skipped step
+        nothing is accumulated, so there is no sum to reduce and no collective to issue."""
+        torch.manual_seed(21)
+        opt = _FakeDistOpt(torch.randn(4096) * 0.02)
+        monitor = OptimUpdateMonitor(monitor_interval=5)
+        monitor.attach_optimizer(opt)
+        try:
+            monitor.step_count = 2  # 2 % 5 != 0 -> unmonitored
+            opt.apply_update(torch.randn(4096) * 3e-4)
+            opt._copy_main_params_to_model_params()
+            self.assertEqual(monitor._pending_dense, [], "wrapper must not accumulate")
+            self.assertEqual(monitor._pending_expert, [])
+            self.assertEqual(monitor.step(), {})
+            self.assertEqual(training_logs.get_latest(prefix="optim"), {})
+        finally:
+            monitor.remove_hooks()
+
+    def test_copy_back_still_happens_on_skipped_steps(self):
+        """Gating must never change the model: the real copy has to run either way."""
+        torch.manual_seed(22)
+        opt = _FakeDistOpt(torch.randn(2048) * 0.02)
+        monitor = OptimUpdateMonitor(monitor_interval=100)
+        monitor.attach_optimizer(opt)
+        try:
+            monitor.step_count = 7  # unmonitored
+            opt.apply_update(torch.randn(2048) * 1e-4)
+            opt._copy_main_params_to_model_params()
+            self.assertEqual(opt.copy_calls, 1)
+            self.assertTrue(torch.equal(opt.model_param, opt.main_param.to(opt.model_param.dtype)))
+        finally:
+            monitor.remove_hooks()
+
+    def test_global_step_syncs_the_gate(self):
+        """The trainer passes its own iteration via step(global_step=...); the gate must
+        follow the trainer's counter so the interval lines up with the log interval."""
+        opt = _FakeDistOpt(torch.randn(512) * 0.02)
+        monitor = OptimUpdateMonitor(monitor_interval=10)
+        monitor.attach_optimizer(opt)
+        try:
+            monitor.step(global_step=49)
+            self.assertTrue(monitor._should_monitor(), "50 % 10 == 0 -> monitored")
+            monitor.step(global_step=50)
+            self.assertFalse(monitor._should_monitor(), "51 % 10 != 0 -> skipped")
+        finally:
+            monitor.remove_hooks()
+
+    def test_setup_helper_threads_monitor_interval(self):
+        opt = _FakeDistOpt(torch.randn(512) * 0.02)
+        monitor_dict = {}
+        setup_optim_update_monitor(None, optimizer=opt, monitor_dict=monitor_dict, monitor_interval=50)
+        monitor = monitor_dict[optim_update_module.METRIC_PREFIX]
+        try:
+            self.assertEqual(monitor.monitor_interval, 50)
+        finally:
+            monitor.remove_hooks()
+
     def test_setup_helper_registers_under_the_metric_prefix(self):
         """The monitor_dict key must equal METRIC_PREFIX ("optim"), because callers print
         training_logs by iterating monitor_dict keys as metric prefixes — a mismatched key


### PR DESCRIPTION
原来每 step 都归约并上报，实跑日志里变成 Bridge 的 iteration 行打一遍、internal_medicine 的 [optim] 块再打 5 行，一步一轮 —— 既是刷屏，也和"与 grad norm 并排看"的初衷相反（反而离 得更远了）。而这三个都是慢变量：l18 实跑 50 步内 param_rms 恒为 0.0166、
update_param_ratio 只在 2e-4~3e-4 之间晃，根本不需要每步分辨率。

改为与模型侧 monitor 同一套门控（step_count % monitor_interval == 0），配置里 internal_medicine_monitor_interval 已是 50，无需改 config。

门开在 **wrapper 里**而不只是上报处：未被监控的 step 上连 sum-of-squares 都不算， _pending_* 保持为空，step() 里两次 collective 也完全不发起，wrapper 只多一次布尔判断。 若只在上报处挡，计算与通信照旧要付，只是少打几行字。

step(global_step=...) 会把计数同步到 trainer 的真实迭代号，因此 interval 对齐的是训练步号， 跨 checkpoint resume 不会错位。

新增 5 个用例：interval=3 时 7 步只报 3 次（T,F,F,T,F,F,T）；跳过的 step 上 _pending_* 为空（证明门确实在 wrapper 里，而不是只挡了上报）；**跳过的 step 上 copy 仍然执行且 model_param 仍等于 main_param**（gating 绝不能改变模型行为）；global_step 能带动门控； setup helper 透传 monitor_interval。另外端到端验证 setup_monitors(monitor_interval=50) 下 key 注册为 optim、interval 透传、count 0/50 触发而 7 不触发。

文档措辞相应区分"装不装"与"多久报一次"：始终装上（无需在 internal_medicine_monitors 里 点名），但上报频率受 monitor_interval 门控 —— 之前混成一句"始终开启、每 step 都算"是错的。