### PR TITLE
fix(core): keep gather_and_aggregate collective on ranks with no metrics

### DIFF
--- a/src/internal_medicine/core/training_logs.py
+++ b/src/internal_medicine/core/training_logs.py
@@ -167,8 +167,6 @@ class TrainingLogs:
     def gather_and_aggregate(self):
         """Gather metrics from all ranks and aggregate by naming convention."""
         all_metrics = self.get_latest()
-        if not all_metrics:
-            return {}
 
         gather_fn = getattr(self, "_gather_fn", None)
         if gather_fn is None:

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -59,6 +59,29 @@ class CoreMonitoringTest(unittest.TestCase):
         self.assertEqual(latest["dummy/global_common"], 4.0)
         self.assertEqual(latest["dummy/global_sparse"], 4.0)
 
+    def test_gather_is_collective_even_when_this_rank_has_no_metrics(self):
+        """A PP stage with no monitored layer must still enter the gather.
+
+        ``_gather_fn`` wraps ``all_gather_object``; skipping it on an empty rank
+        hangs every other rank in the collective (observed as a PP=4 deadlock).
+        """
+        calls = []
+
+        def fake_gather(local_metrics):
+            calls.append(dict(local_metrics))
+            # Pretend another rank reported one layer.
+            return [local_metrics, {"dummy/layer_0/mean": 4.0}]
+
+        training_logs.set_gather_fn(fake_gather)
+        try:
+            self.assertEqual(training_logs.get_latest(), {})
+            aggregated = training_logs.gather_and_aggregate()
+        finally:
+            training_logs.set_gather_fn(None)
+
+        self.assertEqual(calls, [{}], "gather_fn must be called even with no local metrics")
+        self.assertEqual(aggregated, {"dummy/layer_0/mean": 4.0})
+
     def test_log_flags_are_respected(self):
         probe = DummyProbe(log_per_layer=False, log_global=True)
         probe._record_metrics(0, {"mean": 2.0})


### PR DESCRIPTION
## Problem

`gather_and_aggregate` returned early when the local metric dict was empty, skipping `_gather_fn` — which wraps `all_gather_object`, a world-wide collective.
A pipeline stage can legitimately hold no monitored layer (e.g. one made of `num_empty_layers_add_in_*` entries plus the LM head), and when that rank skips the collective every other rank blocks in it until the job is killed. Observed locally as a 13-minute hang at PP=4 with all GPUs at 100% and no error output.

## Fix

Drop the early return so every rank that reaches the method enters the gather.

Behaviour is otherwise unchanged:

- no `gather_fn` set (single process, unit tests): returns the same empty dict
- `gather_fn` returns `None`: unchanged
- only global rank 0 writes the jsonl, so non-writer ranks receiving a non-empty aggregated dict cannot cause duplicate writes

The early return dated back to the initial commit as a "skip a useless collective" optimisation; it is not valid for a collective, whose semantics require every rank to participate.