### PR TITLE
fix(paddlefleet): make per-layer metric ids independent of pipeline l…

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -195,13 +198,42 @@ def classify_attn_type(layer) -> str | None:
     return attn_meta(layer)[0]
 
 
+def _layer_config(layer):
+    """Return the ``TransformerConfig`` of a layer or of the layer it wraps."""
+    config = getattr(layer, "config", None)
+    if config is None:
+        config = getattr(getattr(layer, "transformer_layer", None), "config", None)
+    return config
+
+
+def _head_offset(layer) -> int:
+    """``num_empty_layers_add_in_head`` of the stack this layer belongs to."""
+    offset = getattr(_layer_config(layer), "num_empty_layers_add_in_head", 0) or 0
+    return offset if isinstance(offset, int) else 0
+
+
 def resolve_layer_idx(layer, local_idx: int, num_local_layers: int, pp_rank: int = 0, layer_offset: int = 0) -> int:
     """Resolve a PaddleFleet metric layer id without converting 0-based ids."""
-    for attr in ("layer_idx", "layer_index", "idx", "layer_number"):
+    for attr in ("layer_idx", "layer_index", "idx"):
         value = getattr(layer, attr, None)
         if isinstance(value, int):
             return value
+    layer_number = getattr(layer, "layer_number", None)
+    if isinstance(layer_number, int):
+        return layer_number - _head_offset(layer)
     return pp_rank * num_local_layers + layer_offset + local_idx
+
+
+def _absolute_mtp_idx(wrapper, layer, mtp_local_idx: int) -> int | None:
+    """Absolute metric id of an MTP layer, or ``None`` when undeterminable."""
+    config = _layer_config(wrapper) or _layer_config(layer)
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+    if not isinstance(num_hidden_layers, int) or num_hidden_layers <= 0:
+        return None
+    local = getattr(wrapper, "layer_number", None)
+    if not isinstance(local, int) or local < 0:
+        local = mtp_local_idx
+    return num_hidden_layers + local
 
 
 def iter_monitor_layers(
@@ -245,12 +277,20 @@ def iter_monitor_layers(
         idx = resolve_layer_idx(layer, local_idx, num_main_layers, pp_rank=pp_rank, layer_offset=layer_offset)
         monitor_layers.append(_make(idx, layer, False))
 
-    next_mtp_idx = max((item.idx for item in monitor_layers), default=layer_offset - 1) + 1
     for mtp_idx, wrapper in enumerate(mtp_wrappers):
         layer = unwrap_mtp_layer(wrapper)
         if not matches(layer):
             continue
-        idx = next_mtp_idx + mtp_idx
+        idx = _absolute_mtp_idx(wrapper, layer, mtp_idx)
+        if idx is None:
+            logger.warning(
+                "Skipping MTP metric layer: num_hidden_layers is unavailable, so no "
+                "layout-independent id can be assigned. Deriving one from the main layer ids "
+                "present on this rank would silently mislabel it (that rule collapses to id 0 "
+                "when no main layer matched), so no metric is emitted for this layer."
+            )
+            continue
         monitor_layers.append(_make(idx, layer, True))
 
     return monitor_layers
+

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -163,9 +163,10 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertIsNone(result[0].attn_type)
 
     def test_iter_monitor_layers_marks_unwrapped_mtp_layer(self):
-        main_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
-        mtp_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False))
-        mtp_wrapper = SimpleNamespace(transformer_layer=mtp_layer)
+        config = SimpleNamespace(num_hidden_layers=1)
+        main_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config)
+        mtp_layer = SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config)
+        mtp_wrapper = SimpleNamespace(transformer_layer=mtp_layer, config=config)
 
         result = layer_discovery.iter_monitor_layers(
             [main_layer, mtp_wrapper],
@@ -174,6 +175,57 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
 
         self.assertEqual([item.idx for item in result], [0, 1])
         self.assertEqual([item.is_mtp for item in result], [False, True])
+
+    def test_resolve_layer_idx_strips_head_empty_layer_offset(self):
+        """PaddleFleet sets layer_number = logical_idx + num_empty_layers_add_in_head."""
+        config = SimpleNamespace(num_empty_layers_add_in_head=2)
+        layer = SimpleNamespace(layer_number=5, config=config)
+        self.assertEqual(layer_discovery.resolve_layer_idx(layer, 0, 4), 3)
+
+        # No head empty layers (the common case) keeps the raw number.
+        plain = SimpleNamespace(layer_number=5, config=SimpleNamespace())
+        self.assertEqual(layer_discovery.resolve_layer_idx(plain, 0, 4), 5)
+
+        # Explicit logical attrs win and are never offset.
+        self.assertEqual(
+            layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9
+        )
+
+    def test_mtp_layer_idx_is_absolute_not_max_of_local_main_layers(self):
+        """On a PP stage holding a partial stack, MTP must not be numbered max(local)+1."""
+        config = SimpleNamespace(num_hidden_layers=43)
+        # Last pipeline stage: only layers 36..37 of a 43-layer model, plus MTP.
+        main_layers = [
+            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config)
+            for n in (36, 37)
+        ]
+        mtp_wrapper = SimpleNamespace(
+            transformer_layer=SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config),
+            layer_number=0,
+            config=config,
+        )
+
+        result = layer_discovery.iter_monitor_layers(
+            [*main_layers, mtp_wrapper], lambda layer: hasattr(layer, "self_attn")
+        )
+
+        self.assertEqual([item.idx for item in result], [36, 37, 43])
+        self.assertEqual([item.is_mtp for item in result], [False, False, True])
+
+    def test_mtp_layer_idx_is_absolute_when_no_main_layer_matched(self):
+        """The degenerate 'nothing matched' case must not produce id 0."""
+        config = SimpleNamespace(num_hidden_layers=43)
+        mtp_wrapper = SimpleNamespace(
+            transformer_layer=SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config),
+            layer_number=0,
+            config=config,
+        )
+
+        result = layer_discovery.iter_monitor_layers(
+            [SimpleNamespace(), mtp_wrapper], lambda layer: hasattr(layer, "self_attn")
+        )
+
+        self.assertEqual([item.idx for item in result], [43])
 
 
 class PaddleMoEMonitorTest(unittest.TestCase):


### PR DESCRIPTION
## 问题

per-layer 指标的层号依赖流水线切分方式，而不只依赖模型结构。这带来两个后果：

- `num_empty_layers_add_in_head > 0` 时，所有主层的 key 整体偏移 head 空层数
- MTP 的层号取决于本 rank 上恰好有哪些层通过了 monitor 的 `matches()`

于是改一次 `num_empty_layers_add_in_head` 或 PP/VPP 续训，同一个 jsonl 里就会出现两套 key 布局，per-layer 图表现为两条曲线交错；同一个 MTP 层还可能被不同 monitor 标成不同的层号。

12 层模型 + 1 个 MTP、PP=4 的实测：

- `head=0`：`main=[0..11] mtp=[12]`
- `head=2`：`main=[2..13] mtp=[14]`   <- 同一个模型，只改了一个切分参数

## 根因

1. `layer_number = logical_idx + num_empty_layers_add_in_head`（`transformer/transformer_layer.py:103`），它不是逻辑层号。PaddleFleet 自身在需要逻辑层号的地方都会把 offset 减回去（`transformer/attention.py:260`），我们直接读了原始值。
2. MTP 层号取自 `max(matched main id) + 1`。只有当本 rank 持有层栈尾部、且 head offset 为 0 时才正确：PP/VPP 下会漂移，没有主层匹配时会塌成 `layer_0_mtp`。

## 改动

- `resolve_layer_idx` 减掉 head offset；显式的 `layer_idx` / `layer_index` / `idx` 仍然优先，且不做偏移。
- MTP 层号改为 `num_hidden_layers + local`（`local` 是 MTP wrapper 自身从 0 开始的`layer_number`），与切分方式无关。拿不到 `num_hidden_layers` 时跳过该层并打 warning，不给猜出来的号——少一条曲线是看得见的，标错的曲线是看不见的。

## 验证

单机 8 卡、12 层 + 1 MTP、PP=4、15 步，唯一变量是 `num_empty_layers_add_in_head`：

- `head=0`，修复后：`main=[0..11] mtp=[12]`
- `head=2`，修复前：`main=[2..13] mtp=[14]`
- `head=2`，修复后：`main=[0..11] mtp=[12]`

单测覆盖 head offset 剥离、PP 部分栈下的 MTP 层号（`[36, 37, 43]` 而非 `[36, 37, 38]`）、无匹配主层时的 MTP 层号（`[43]` 而非 `[0]`）。

## 兼容性

`num_empty_layers_add_in_head > 0` 的模型，指标 key 会变。跨越合入点的看板会出现一次布局变化；之后层号不再随切分方式漂移。

MTP 那条路径（`max(main)+1` 给出错号）目前只有单测覆盖，未端到端复现：本地 MTP 总与最后一个 transformer 层同 stage，`max(main)+1` 恰好是对的。