### PR TITLE
fix(qk_stats): honor runtime softmax scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ setup_internal_medicine()
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
 |---|------|--------|------|------|----------|
-| 1 | `max` | `qk_stats/.../max` | `max(Q·K^T/√d)` | 每层+全局 | Logit 最大值，数值稳定性 |
+| 1 | `max` | `qk_stats/.../max` | `max(sQ·K^T)` | 每层+全局 | Logit 最大值，数值稳定性 |
 | 2 | `mean` | `qk_stats/.../mean` | `mean(valid_logits)` | 每层+全局 | Logit 基准量级 |
 | 3 | `entropy_avg` | `qk_stats/.../entropy_avg` | `-Σ(p·log(p))` 均值 | 每层+全局 | 注意力集中度 |
 | 4 | `sink` | `qk_stats/.../sink` | `mean(softmax[..., 0])` | 每层+全局 | Token-0 注意力权重 |
@@ -210,6 +210,8 @@ setup_internal_medicine()
 | 8 | `sink_head_max` | `qk_stats/.../sink_head_max` | `max(sink_per_head)` | 每层+全局 | 最强 sink head 权重 |
 | 9 | `sink_nonsink_gap` | `qk_stats/.../sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | 每层+全局 | Sink/非Sink 分化度 |
 | 10 | `attn_sink_logit` | `qk_stats/.../attn_sink_logit` | `mean(sink_logit)` | 每层+全局 | learned sink logit 量级漂移；稀疏层取 `attn_sink`，full 层取 `softmax_offset` |
+
+其中 `s` 取 attention 层运行时的 `softmax_scale`；未显式设置时回退为 `1 / sqrt(head_dim)`。
 
 > **learnable / off-by-one softmax 的 sink 折叠**：当 `core_attention.softmax_offset`
 > 存在时（`softmax_type` 为 `learnable` / `off-by-one`），`entropy_avg` / `sink` 会把这个

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -113,6 +113,7 @@ def _compute_qk_stats_triton(
     row_stride: int = 1,
     q_row_offset: int = 0,
     attn_sink: paddle.Tensor | None = None,
+    softmax_scale: float | None = None,
 ) -> dict:
     """Triton kernel path for paddle tensors.
 
@@ -132,7 +133,7 @@ def _compute_qk_stats_triton(
 
     batch, num_heads, seq_len_q, head_dim = q.shape
     seq_len_k = k.shape[2]
-    scale = 1.0 / (head_dim**0.5)
+    scale = 1.0 / (head_dim**0.5) if softmax_scale is None else float(softmax_scale)
 
     BLOCK_M = 64
     BLOCK_N = 64
@@ -223,6 +224,7 @@ def compute_qk_stats_paddle(
     row_stride: int = 1,
     q_row_offset: int = 0,
     attn_sink: paddle.Tensor | None = None,
+    softmax_scale: float | None = None,
 ) -> dict:
     """Compute QK stats via Triton kernel.
 
@@ -238,6 +240,8 @@ def compute_qk_stats_paddle(
             ``core_attention.softmax_offset`` whenever it exists — without it the
             reported distribution is renormalised over the real keys only and does
             not match what the model computes.
+        softmax_scale: runtime scale applied to ``QK^T`` by the attention layer.
+            ``None`` preserves the standard ``1 / sqrt(head_dim)`` default.
 
     The [B, S, H, D] -> [B, H, S, D] reordering is expressed via strides
     (no contiguous copy); the triton kernel reads strided memory directly.
@@ -262,6 +266,7 @@ def compute_qk_stats_paddle(
         row_stride=row_stride,
         q_row_offset=q_row_offset,
         attn_sink=attn_sink,
+        softmax_scale=softmax_scale,
     )
 
 
@@ -810,6 +815,7 @@ class PaddleQKStatsMonitor(PaddleProbe):
                         row_stride=effective_stride,
                         q_row_offset=q_row_offset,
                         attn_sink=None if sink_logit is None else sink_logit.detach().astype("float32"),
+                        softmax_scale=getattr(layer, "softmax_scale", None),
                     )
 
                     if self.cp_size > 1 and self.cp_group is not None:

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -187,17 +187,14 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertEqual(layer_discovery.resolve_layer_idx(plain, 0, 4), 5)
 
         # Explicit logical attrs win and are never offset.
-        self.assertEqual(
-            layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9
-        )
+        self.assertEqual(layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9)
 
     def test_mtp_layer_idx_is_absolute_not_max_of_local_main_layers(self):
         """On a PP stage holding a partial stack, MTP must not be numbered max(local)+1."""
         config = SimpleNamespace(num_hidden_layers=43)
         # Last pipeline stage: only layers 36..37 of a 43-layer model, plus MTP.
         main_layers = [
-            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config)
-            for n in (36, 37)
+            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config) for n in (36, 37)
         ]
         mtp_wrapper = SimpleNamespace(
             transformer_layer=SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config),
@@ -774,6 +771,67 @@ class PaddleQKKernelComputeTest(unittest.TestCase):
                 paddle.allclose(grouped[key], expanded[key], atol=1e-4, rtol=1e-4).item(),
                 f"{key} mismatch: grouped={grouped[key].item()} expanded={expanded[key].item()}",
             )
+
+    def test_nondefault_softmax_scale_matches_dense_reference(self):
+        q, k = self._gqa_inputs(B=1, S=64, Hq=4, Hkv=4, D=16, seed=17)
+        scale = 0.137
+
+        actual = self.qk.compute_qk_stats_paddle(q, k, causal=True, softmax_scale=scale)
+
+        qh = q.transpose([0, 2, 1, 3])
+        kh = k.transpose([0, 2, 1, 3])
+        logits = paddle.matmul(qh, kh, transpose_y=True) * scale
+        causal = paddle.tril(paddle.ones([q.shape[1], k.shape[1]], dtype="bool"))
+        masked_logits = paddle.where(causal, logits, paddle.full_like(logits, -1e10))
+        probability = paddle.nn.functional.softmax(masked_logits, axis=-1)
+        entropy = -(probability * paddle.log(probability.clip(min=1e-30))).sum(axis=-1)
+
+        self.assertTrue(paddle.allclose(actual["max_global"], masked_logits.max(), atol=5e-3, rtol=1e-4).item())
+        self.assertTrue(paddle.allclose(actual["entropy_global"], entropy.mean(), atol=1e-3, rtol=1e-4).item())
+        self.assertTrue(paddle.allclose(actual["sink_global"], probability[..., 0].mean(), atol=1e-4, rtol=1e-4).item())
+
+    def test_monitor_hook_uses_core_attention_runtime_scale(self):
+        class CoreAttention(nn.Layer):
+            def __init__(self, softmax_scale):
+                super().__init__()
+                self.softmax_scale = softmax_scale
+
+            def forward(self, query, key, value):
+                return value
+
+        class Attention(nn.Layer):
+            def __init__(self, softmax_scale):
+                super().__init__()
+                self.core_attention = CoreAttention(softmax_scale)
+
+        class TransformerLayer(nn.Layer):
+            def __init__(self, softmax_scale):
+                super().__init__()
+                self.layer_idx = 0
+                self.self_attn = Attention(softmax_scale)
+
+        class Model(nn.Layer):
+            def __init__(self, softmax_scale):
+                super().__init__()
+                self.layers = nn.LayerList([TransformerLayer(softmax_scale)])
+
+        scale = 0.173
+        q, k = self._gqa_inputs(B=1, S=32, Hq=2, Hkv=2, D=16, seed=23)
+        value = paddle.randn(q.shape, dtype="float32")
+        reference = self.qk.compute_qk_stats_paddle(q, k, causal=True, softmax_scale=scale)
+        model = Model(scale)
+        monitor = PaddleQKStatsMonitor()
+        monitor.register_hooks(model)
+        training_logs.reset()
+
+        model.layers[0].self_attn.core_attention(q, k, value)
+        monitor.step()
+
+        metrics = training_logs.get_latest(prefix="qk_stats/layer_0/")
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/max"], float(reference["max_global"]), places=3)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/entropy_avg"], float(reference["entropy_global"]), places=3)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/sink"], float(reference["sink_global"]), places=4)
+        monitor.remove_hooks()
 
     def test_row_stride_is_near_unbiased_for_mean_class_metrics(self):
         """Subsampling query rows must keep the row-averaged metrics close to


### PR DESCRIPTION
## Summary

- Pass the attention layer's runtime `softmax_scale` into the PaddleFleet QK statistics kernel.
- Preserve `1 / sqrt(head_dim)` as the fallback when no custom scale is configured.
- Add numerical end-to-end coverage for both default and custom scaling.

## Motivation

The monitor previously always used `1 / sqrt(head_dim)`. For attention variants with a custom runtime scale, the reported QK logits, probabilities, and entropy could therefore differ from the values used by the model.

## Validation

- Relevant PaddleFleet monitor suite: 121 passed.
- Added numerical tests verifying that the runtime scale changes the reported statistics as expected.