### PR TITLE
feat(qk_stats): report QKV activation norms

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ setup_internal_medicine()
 | 8 | `sink_head_max` | `qk_stats/.../sink_head_max` | `max(sink_per_head)` | 每层+全局 | 最强 sink head 权重 |
 | 9 | `sink_nonsink_gap` | `qk_stats/.../sink_nonsink_gap` | `mean(sink) - mean(nonsink)` | 每层+全局 | Sink/非Sink 分化度 |
 | 10 | `attn_sink_logit` | `qk_stats/.../attn_sink_logit` | `mean(sink_logit)` | 每层+全局 | learned sink logit 量级漂移；稀疏层取 `attn_sink`，full 层取 `softmax_offset` |
+| 11 | `{q,k,v}_norm_mean` | `qk_stats/.../{q,k,v}_norm_mean` | `mean(||q/k/v||₂)` | 每层+全局 | Dense core-attention 的平均向量尺度 |
+| 12 | `{q,k,v}_norm_max` | `qk_stats/.../{q,k,v}_norm_max` | `max(||q/k/v||₂)` | 每层+全局 | Dense core-attention 的局部尺度峰值 |
 
 > **learnable / off-by-one softmax 的 sink 折叠**：当 `core_attention.softmax_offset`
 > 存在时（`softmax_type` 为 `learnable` / `off-by-one`），`entropy_avg` / `sink` 会把这个

--- a/docs/qk_logits.md
+++ b/docs/qk_logits.md
@@ -1,12 +1,24 @@
 # QK Stats Monitor
 
-QK 注意力统计监控模块，监控 9 个核心指标。
+QK 注意力统计监控模块，覆盖 Q/K/V 激活向量尺度、attention logits、熵与 sink。
 
 通过 Triton 优化的 Online Softmax 内核，在单次前向传播中高效计算注意力矩阵的统计特征，覆盖数值稳定性、注意力集中度和 attention sink 现象。
 
 ---
 
 ## 监控指标
+
+### Q/K/V Vector Norms
+
+对于 dense core-attention 实际接收的每个 token/head 向量，记录：
+
+```text
+{q,k,v}_norm_mean = mean(||q/k/v||₂)
+{q,k,v}_norm_max  = max(||q/k/v||₂)
+```
+
+这组指标用于区分 Q/K 尺度增长与方向对齐造成的 logit 变化，并观察 V 分支的尺度漂移。CSA/HCA
+稀疏调用只暴露组合后的 KV 表示，无法可靠拆出独立 V，因此不输出这组指标。
 
 ### 1. Max Logit (注意力 Logit 最大值)
 

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -476,7 +476,14 @@ def compute_qk_stats_sparse_paddle(
 
 class PaddleQKStatsMonitor(PaddleProbe):
     METRIC_PREFIX = "qk_stats"
-    MAX_AGGREGATED = {"max", "entropy_max", "sink_head_max"}
+    MAX_AGGREGATED = {
+        "q_norm_max",
+        "k_norm_max",
+        "v_norm_max",
+        "max",
+        "entropy_max",
+        "sink_head_max",
+    }
     MIN_AGGREGATED = {"entropy_min"}
 
     def __init__(
@@ -561,7 +568,11 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 self.cp_size,
             )
 
-        for layer_idx, _attn_module, item in attention_layers:
+        for layer_idx, attn_module, item in attention_layers:
+            if not self._is_sparse_layer(item) and hasattr(attn_module, "core_attention"):
+                for name in ("q", "k", "v"):
+                    self.declare_layer_metric(layer_idx, f"{name}_norm_mean", attn_type=item.attn_type)
+                    self.declare_layer_metric(layer_idx, f"{name}_norm_max", attn_type=item.attn_type)
             for m in (
                 "max",
                 "mean",
@@ -575,20 +586,21 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 "sink_nonsink_gap",
             ):
                 self.declare_layer_metric(layer_idx, m, attn_type=item.attn_type)
-            if self._is_sparse_layer(item) or self._learnable_sink(_attn_module) is not None:
+            if self._is_sparse_layer(item) or self._learnable_sink(attn_module) is not None:
                 self.declare_layer_metric(layer_idx, "attn_sink_logit", attn_type=item.attn_type)
 
         self.allocate_buffers()
 
         for layer_idx, attn_module, item in attention_layers:
-            if self._is_sparse_layer(item):
+            is_sparse = self._is_sparse_layer(item)
+            if is_sparse:
                 patch = self._patch_sparse_attn(layer_idx, attn_module, item)
                 if patch is not None:
                     self.hooks.append(patch)
                     continue
             if hasattr(attn_module, "core_attention"):
                 hook = attn_module.core_attention.register_forward_pre_hook(
-                    self._make_compute_hook(layer_idx, item.attn_type)
+                    self._make_compute_hook(layer_idx, item.attn_type, record_qkv_norms=not is_sparse)
                 )
                 self.hooks.append(hook)
 
@@ -758,7 +770,13 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 self._warned_cp_gather_failed = True
             return None
 
-    def _make_compute_hook(self, layer_idx: int, attn_type: str | None = None):
+    def _make_compute_hook(
+        self,
+        layer_idx: int,
+        attn_type: str | None = None,
+        *,
+        record_qkv_norms: bool = True,
+    ):
         def hook_fn(layer, inputs):
             if not layer.training:
                 return
@@ -766,7 +784,25 @@ class PaddleQKStatsMonitor(PaddleProbe):
                 return
             try:
                 query, key = inputs[0], inputs[1]
+                value = inputs[2] if len(inputs) > 2 else None
                 with paddle.no_grad():
+                    if record_qkv_norms:
+                        for name, tensor in (("q", query), ("k", key), ("v", value)):
+                            if not isinstance(tensor, paddle.Tensor):
+                                continue
+                            vector_norm = paddle.linalg.norm(tensor.detach().astype("float32"), axis=-1)
+                            self.record_layer_metric(
+                                layer_idx,
+                                f"{name}_norm_mean",
+                                vector_norm.mean(),
+                                attn_type=attn_type,
+                            )
+                            self.record_layer_metric(
+                                layer_idx,
+                                f"{name}_norm_max",
+                                vector_norm.max(),
+                                attn_type=attn_type,
+                            )
                     if self.cp_size > 1:
                         # CP > 1: gather K only, keep Q local.
                         query = query.detach()

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -20,7 +21,8 @@ PaddleMassiveActivationMonitor = importlib.import_module(
 ).PaddleMassiveActivationMonitor
 PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor").PaddleMoEMonitor
 moe_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
-PaddleQKStatsMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor").PaddleQKStatsMonitor
+qk_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor")
+PaddleQKStatsMonitor = qk_monitor_module.PaddleQKStatsMonitor
 paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
 layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
 training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
@@ -187,17 +189,14 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertEqual(layer_discovery.resolve_layer_idx(plain, 0, 4), 5)
 
         # Explicit logical attrs win and are never offset.
-        self.assertEqual(
-            layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9
-        )
+        self.assertEqual(layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9)
 
     def test_mtp_layer_idx_is_absolute_not_max_of_local_main_layers(self):
         """On a PP stage holding a partial stack, MTP must not be numbered max(local)+1."""
         config = SimpleNamespace(num_hidden_layers=43)
         # Last pipeline stage: only layers 36..37 of a 43-layer model, plus MTP.
         main_layers = [
-            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config)
-            for n in (36, 37)
+            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config) for n in (36, 37)
         ]
         mtp_wrapper = SimpleNamespace(
             transformer_layer=SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config),
@@ -741,6 +740,58 @@ class PaddleQKMonitorTest(unittest.TestCase):
 
     def test_row_stride_default_is_exact_full_pass(self):
         self.assertEqual(PaddleQKStatsMonitor().row_stride, 1)
+
+    def test_dense_hook_records_qkv_vector_norms(self):
+        training_logs.reset()
+
+        class CoreAttention(nn.Layer):
+            def forward(self, query, key, value):
+                return value
+
+        class Attention(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.core_attention = CoreAttention()
+
+        class TransformerLayer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layer_idx = 0
+                self.self_attn = Attention()
+
+        class Model(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.LayerList([TransformerLayer()])
+
+        zero = paddle.zeros([1, 1], dtype="float32")
+        fake_stats = {
+            "max_global": zero.sum(),
+            "mean_global": zero.sum(),
+            "entropy_global": zero.sum(),
+            "sink_global": zero.sum(),
+            "entropy_per_head": zero,
+            "sink_per_head": zero,
+        }
+        query = paddle.to_tensor([[[[3.0, 4.0]], [[0.0, 5.0]]]], dtype="float32")
+        key = paddle.to_tensor([[[[5.0, 12.0]], [[8.0, 15.0]]]], dtype="float32")
+        value = paddle.to_tensor([[[[7.0, 24.0]], [[20.0, 21.0]]]], dtype="float32")
+        model = Model()
+        monitor = PaddleQKStatsMonitor()
+
+        with mock.patch.object(qk_monitor_module, "compute_qk_stats_paddle", return_value=fake_stats):
+            monitor.register_hooks(model)
+            model.layers[0].self_attn.core_attention(query, key, value)
+            monitor.step()
+
+        metrics = training_logs.get_latest(prefix="qk_stats/layer_0/")
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/q_norm_mean"], 5.0)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/q_norm_max"], 5.0)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/k_norm_mean"], 15.0)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/k_norm_max"], 17.0)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/v_norm_mean"], 27.0)
+        self.assertAlmostEqual(metrics["qk_stats/layer_0/v_norm_max"], 29.0)
+        monitor.remove_hooks()
 
 
 class PaddleQKKernelComputeTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add per-layer Q/K/V activation vector norm statistics:
  - `q_norm_mean`, `q_norm_max`
  - `k_norm_mean`, `k_norm_max`
  - `v_norm_mean`, `v_norm_max`
- Measure the L2 norm of each token/head vector at the actual core-attention input.
- Document metric definitions and backend limitations.

## Motivation

QK logit changes may come from vector-scale growth or directional alignment. Recording Q/K norms makes these mechanisms distinguishable, while V norms expose scale drift on the content branch.

Sparse CSA/HCA paths are intentionally excluded because they do not reliably expose independent V tensors.

## Validation

- Relevant PaddleFleet monitor suite: 120 passed.
- Covered metric declaration, aggregation, numerical values, and sparse-path exclusion.