### PR TITLE
feat(massive_act): add module-position activation and residual-write diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,12 @@ global 指标已按层类型拆分，不要再把不同类型平均到一起。
 | 19 | `logit_lens_logsumexp_mean` | `massive_act/.../logit_lens_logsumexp_mean` | `mean_t(logsumexp(final_norm(h)·Wᵀ))` | 每层+全局 | logit-lens 对数配分均值，追踪 logit 原始尺度 |
 | 20 | `logit_lens_cross_entropy_mean` | `massive_act/.../logit_lens_cross_entropy_mean` | `mean_t(log_z − l[y])` | 每层+全局 | logit-lens 逐层交叉熵，末层≈LM loss |
 | 21 | `hidden_spectral_entropy` | `massive_act/.../hidden_spectral_entropy` | `-Σ p_i log p_i, p_i=σ_i²/‖h‖_F²` | 每层+全局 | post-norm 隐状态谱熵(有效秩)，表征多样性/秩坍缩 |
+| 22 | `{position}_{rms,abs_max,abs_p99,outlier_ratio}` | `massive_act/.../{position}_*` | 五个真实执行位置的尺度与 tail | 每层+全局 | 定位异常由 Attention、FFN/MoE 还是 residual 累积产生 |
+| 23 | `{attn,ffn}_update_rms_ratio` | `massive_act/.../{attn,ffn}_update_rms_ratio` | `RMS(residual_after-residual_before)/RMS(residual_before)` | 每层+全局 | 模块对 residual stream 的实际写入比例 |
+
+PaddleFleet 的 `position` 为 `layer_input`、`attn_out`、`post_attn_residual`、
+`ffn_or_moe_out`、`post_ffn_residual`。两个 residual 位置从真实 forward 边界采样，update ratio
+由实际 residual 差分计算，因此包含 bias、dropout、BDA 与 mHC residual mixing 的影响。
 
 > **注**: 指标 18-20 (`logit_lens_*`) 为**默认关闭**的可选项（熵/logsumexp 由 `log_logit_lens_entropy=True`
 > 开启，交叉熵由 `log_logit_lens_cross_entropy=True` 开启）。

--- a/docs/massive_activation.md
+++ b/docs/massive_activation.md
@@ -1,6 +1,6 @@
 # Massive Activation Monitor
 
-**Residual Stream Massive Activation 健康监控模块**，监控 21 个核心指标。
+**Residual Stream Massive Activation 健康监控模块**，覆盖通道异常、模块输出与 residual 写入尺度。
 
 基于论文发现实现：
 
@@ -149,6 +149,29 @@ activation_rms = sqrt(mean(H_i^2))
 - 用于观察整体激活量级，而不是只看最大 channel
 - 与 `channel_p95/p99`、`channel_count_gt_*` 配合判断 broad scale growth
 - 对量化训练很有参考价值：RMS 上升意味着更多通道进入较高动态范围
+
+---
+
+### Module Positions and Residual Writes
+
+PaddleFleet 在五个真实执行位置记录 `rms`、`abs_max`、`abs_p99` 和 `outlier_ratio`：
+
+```text
+layer_input
+attn_out
+post_attn_residual
+ffn_or_moe_out
+post_ffn_residual
+```
+
+其中 `outlier_ratio = mean(|x| > 10 * RMS(x))`。`attn_out` 与 `ffn_or_moe_out` 是模块直接输出；两个
+post-residual 值从 forward 的真实边界采样，不通过手工相加重建。实际写入比例定义为：
+
+```text
+update_rms_ratio = RMS(residual_after - residual_before) / RMS(residual_before)
+```
+
+因此该比例同时覆盖 bias、dropout、BDA，以及 mHC 中 residual mixing 对实际 residual stream 的影响。
 
 ---
 

--- a/docs/massive_activation.md
+++ b/docs/massive_activation.md
@@ -172,6 +172,7 @@ update_rms_ratio = RMS(residual_after - residual_before) / RMS(residual_before)
 ```
 
 因此该比例同时覆盖 bias、dropout、BDA，以及 mHC 中 residual mixing 对实际 residual stream 的影响。
+若前后 residual 形状不一致（例如某些 MTP 打包路径），该比例不会输出，以避免比较不匹配的张量。
 
 ---
 
@@ -454,6 +455,7 @@ von Neumann）熵。`p_i` 是把奇异值平方归一化成的分布（合法，
 - **TP per-channel 聚合**：Megatron/PaddleFleet TP 切通道维时会在 hook 内对 per-channel max 做一次 `MAX all_reduce`，这是正确性所需
 - **Post-norm 指标**：需要额外一次 RMSNorm forward（无梯度），开销约等于一个 norm 层
 - **Cosine stability**：采样 256 对，O(256×H)，通常较小
+- **Module-position 指标**：每个位置执行 O(S×H) 的尺度/tail 统计，其中精确 `abs_p99` 需要 quantile；大模型建议配合 `monitor_interval` 或 `sample_layers`
 - **Logit-lens entropy + logsumexp + cross-entropy**（可选，默认关）：每监控层每监控步一次 LM-head 前向，复杂度约 O(S×H×vocab)，是本 monitor 中**最重**的指标；熵、`log Z`、CE 共用同一次投影（logsumexp 与 CE 均近零额外开销，CE 只多一次 `gather`）。按 token 分块把峰值显存限制在一个 `[chunk, vocab]` tile，但计算量仍显著，建议配合大 `monitor_interval` 与 `logit_lens_layers` 使用
 - **Hidden spectral entropy**（可选，默认关）：一次 Gram matmul（O(n·d²)）加 `eigvalsh`（O(min(n,d)³)），无 LM head、无 full SVD、无 host sync，比 logit-lens 轻很多；大 batch 下 `eigvalsh` 的立方项可观，建议配合 `monitor_interval`
 

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -241,8 +241,8 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
 
                 with paddle.no_grad():
                     self._position_cache[layer_idx] = {"layer_input": hidden_states.detach()}
-                    self._record_position(layer_idx, "layer_input", hidden_states, attn_type)
                     self._compute_and_log(layer_idx, hidden_states.detach(), module, attn_type=attn_type)
+                    self._record_position(layer_idx, "layer_input", hidden_states, attn_type)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[MassiveActMonitor] Error at layer {layer_idx}: {e}")
@@ -278,11 +278,15 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         def hook_fn(module, _inputs, outputs):
             if not module.training or not self._should_monitor():
                 return
-            output = self._extract_output_tensor(outputs)
-            if output is None:
-                return
-            with paddle.no_grad():
-                self._record_position(layer_idx, position, output, attn_type)
+            try:
+                output = self._extract_output_tensor(outputs)
+                if output is None:
+                    return
+                with paddle.no_grad():
+                    self._record_position(layer_idx, position, output, attn_type)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MassiveActMonitor] Error at layer {layer_idx} position {position}: {e}")
 
         return hook_fn
 
@@ -290,20 +294,24 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         def hook_fn(module, inputs):
             if not module.training or not self._should_monitor():
                 return
-            post_attn = self._extract_hidden_states(inputs)
-            cache = self._position_cache.get(layer_idx)
-            if post_attn is None or cache is None:
-                return
-            with paddle.no_grad():
-                self._record_position(layer_idx, "post_attn_residual", post_attn, attn_type)
-                self._record_update_ratio(
-                    layer_idx,
-                    "attn_update_rms_ratio",
-                    cache["layer_input"],
-                    post_attn,
-                    attn_type,
-                )
-                cache["post_attn_residual"] = post_attn.detach()
+            try:
+                post_attn = self._extract_hidden_states(inputs)
+                cache = self._position_cache.get(layer_idx)
+                if post_attn is None or cache is None:
+                    return
+                with paddle.no_grad():
+                    cache["post_attn_residual"] = post_attn.detach()
+                    self._record_position(layer_idx, "post_attn_residual", post_attn, attn_type)
+                    self._record_update_ratio(
+                        layer_idx,
+                        "attn_update_rms_ratio",
+                        cache["layer_input"],
+                        post_attn,
+                        attn_type,
+                    )
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MassiveActMonitor] Error at layer {layer_idx} position post_attn_residual: {e}")
 
         return hook_fn
 
@@ -311,21 +319,25 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         def hook_fn(module, _inputs, outputs):
             if not module.training or not self._should_monitor():
                 return
-            layer_output = self._extract_output_tensor(outputs)
-            cache = self._position_cache.pop(layer_idx, None)
-            if layer_output is None or cache is None:
-                return
-            with paddle.no_grad():
-                self._record_position(layer_idx, "post_ffn_residual", layer_output, attn_type)
-                post_attn = cache.get("post_attn_residual")
-                if post_attn is not None:
-                    self._record_update_ratio(
-                        layer_idx,
-                        "ffn_update_rms_ratio",
-                        post_attn,
-                        layer_output,
-                        attn_type,
-                    )
+            try:
+                cache = self._position_cache.pop(layer_idx, None)
+                layer_output = self._extract_output_tensor(outputs)
+                if layer_output is None or cache is None:
+                    return
+                with paddle.no_grad():
+                    self._record_position(layer_idx, "post_ffn_residual", layer_output, attn_type)
+                    post_attn = cache.get("post_attn_residual")
+                    if post_attn is not None:
+                        self._record_update_ratio(
+                            layer_idx,
+                            "ffn_update_rms_ratio",
+                            post_attn,
+                            layer_output,
+                            attn_type,
+                        )
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MassiveActMonitor] Error at layer {layer_idx} position post_ffn_residual: {e}")
 
         return hook_fn
 
@@ -475,7 +487,7 @@ def setup_massive_activation_monitor(
         absolute_thresholds=absolute_thresholds,
     )
     monitor.register_hooks(model)
-    logger.info(f"[MassiveActMonitor] Setup complete. Monitoring {len(monitor.hooks)} layers.")
+    logger.info(f"[MassiveActMonitor] Setup complete with {len(monitor.hooks)} hooks.")
     if monitor_dict is not None:
         monitor_dict["massive_act"] = monitor
     return model

--- a/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/massive_activation_monitor.py
@@ -48,6 +48,21 @@ from .massive_activation_metrics import (
 
 logger = logging.getLogger(__name__)
 
+_POSITIONS = ("layer_input", "attn_out", "post_attn_residual", "ffn_or_moe_out", "post_ffn_residual")
+_POSITION_METRICS = ("rms", "abs_max", "abs_p99", "outlier_ratio")
+
+
+def _position_stats(tensor: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    value = tensor.detach().astype("float32")
+    absolute = value.abs()
+    rms = paddle.sqrt(value.square().mean())
+    return {
+        "rms": rms,
+        "abs_max": absolute.max(),
+        "abs_p99": paddle.quantile(absolute.reshape([-1]), 0.99),
+        "outlier_ratio": (absolute > 10.0 * rms.clip(min=1e-10)).astype("float32").mean(),
+    }
+
 
 class PaddleMassiveActivationMonitor(PaddleProbe):
     """Monitor massive activations in the residual stream.
@@ -66,7 +81,7 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         "topk_channel_norm",
         "activation_rms",
         "massive_act_channel_count",
-    }
+    } | {f"{position}_{metric}" for position in _POSITIONS for metric in ("rms", "abs_max", "abs_p99")}
 
     def __init__(
         self,
@@ -103,6 +118,11 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
         self._warned_per_channel_aggregate = False
         self._post_norm_failed_layers: set[int] = set()
         self._hc_aggregate_failed_layers: set[int] = set()
+        self._position_cache: dict[int, dict[str, paddle.Tensor]] = {}
+
+    def step(self):
+        super().step()
+        self._position_cache.clear()
 
     def register_hooks(self, model: nn.Layer):
         try:
@@ -159,12 +179,14 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             "post_norm_sparsity",
             "post_norm_cosine",
         ] + [f"channel_count_gt_{_threshold_key(t)}" for t in self.absolute_thresholds]
+        position_metric_names = [f"{position}_{metric}" for position in _POSITIONS for metric in _POSITION_METRICS]
+        update_metric_names = ["attn_update_rms_ratio", "ffn_update_rms_ratio"]
 
         registered = 0
         for item in monitor_layers:
             if self.sample_layers and item.idx not in self.sample_layers:
                 continue
-            for m in metric_names:
+            for m in metric_names + position_metric_names + update_metric_names:
                 self.declare_layer_metric(item.idx, m, attn_type=item.attn_type)
             registered += 1
 
@@ -176,7 +198,35 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             hook = item.layer.register_forward_pre_hook(self._make_residual_hook(item.idx, item.attn_type))
             self.hooks.append(hook)
 
-        logger.info(f"[MassiveActMonitor] Registered {registered} hooks.")
+            attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
+            if attn is not None:
+                self.hooks.append(
+                    attn.register_forward_post_hook(self._make_branch_output_hook(item.idx, "attn_out", item.attn_type))
+                )
+
+            post_attn_boundary = getattr(item.layer, "mlp_hyper_connection", None)
+            if post_attn_boundary is None:
+                post_attn_boundary = getattr(item.layer, "post_attention_layernorm", None)
+            if post_attn_boundary is not None:
+                self.hooks.append(
+                    post_attn_boundary.register_forward_pre_hook(
+                        self._make_post_attn_residual_hook(item.idx, item.attn_type)
+                    )
+                )
+
+            ffn = getattr(item.layer, "mlp", None) or getattr(item.layer, "moe", None)
+            if ffn is not None:
+                self.hooks.append(
+                    ffn.register_forward_post_hook(
+                        self._make_branch_output_hook(item.idx, "ffn_or_moe_out", item.attn_type)
+                    )
+                )
+
+            self.hooks.append(
+                item.layer.register_forward_post_hook(self._make_layer_output_hook(item.idx, item.attn_type))
+            )
+
+        logger.info(f"[MassiveActMonitor] Registered {len(self.hooks)} hooks across {registered} layers.")
 
     def _make_residual_hook(self, layer_idx: int, attn_type: str | None = None):
         def hook_fn(module, inputs):
@@ -190,10 +240,92 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
                     return
 
                 with paddle.no_grad():
+                    self._position_cache[layer_idx] = {"layer_input": hidden_states.detach()}
+                    self._record_position(layer_idx, "layer_input", hidden_states, attn_type)
                     self._compute_and_log(layer_idx, hidden_states.detach(), module, attn_type=attn_type)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[MassiveActMonitor] Error at layer {layer_idx}: {e}")
+
+        return hook_fn
+
+    def _record_position(
+        self,
+        layer_idx: int,
+        position: str,
+        tensor: paddle.Tensor,
+        attn_type: str | None,
+    ) -> None:
+        for metric, value in _position_stats(tensor).items():
+            self.record_layer_metric(layer_idx, f"{position}_{metric}", value, attn_type=attn_type)
+
+    def _record_update_ratio(
+        self,
+        layer_idx: int,
+        metric_name: str,
+        before: paddle.Tensor,
+        after: paddle.Tensor,
+        attn_type: str | None,
+    ) -> None:
+        if tuple(before.shape) != tuple(after.shape):
+            return
+        before_fp32 = before.detach().astype("float32")
+        update_fp32 = after.detach().astype("float32") - before_fp32
+        ratio = paddle.sqrt(update_fp32.square().mean()) / paddle.sqrt(before_fp32.square().mean()).clip(min=1e-30)
+        self.record_layer_metric(layer_idx, metric_name, ratio, attn_type=attn_type)
+
+    def _make_branch_output_hook(self, layer_idx: int, position: str, attn_type: str | None):
+        def hook_fn(module, _inputs, outputs):
+            if not module.training or not self._should_monitor():
+                return
+            output = self._extract_output_tensor(outputs)
+            if output is None:
+                return
+            with paddle.no_grad():
+                self._record_position(layer_idx, position, output, attn_type)
+
+        return hook_fn
+
+    def _make_post_attn_residual_hook(self, layer_idx: int, attn_type: str | None):
+        def hook_fn(module, inputs):
+            if not module.training or not self._should_monitor():
+                return
+            post_attn = self._extract_hidden_states(inputs)
+            cache = self._position_cache.get(layer_idx)
+            if post_attn is None or cache is None:
+                return
+            with paddle.no_grad():
+                self._record_position(layer_idx, "post_attn_residual", post_attn, attn_type)
+                self._record_update_ratio(
+                    layer_idx,
+                    "attn_update_rms_ratio",
+                    cache["layer_input"],
+                    post_attn,
+                    attn_type,
+                )
+                cache["post_attn_residual"] = post_attn.detach()
+
+        return hook_fn
+
+    def _make_layer_output_hook(self, layer_idx: int, attn_type: str | None):
+        def hook_fn(module, _inputs, outputs):
+            if not module.training or not self._should_monitor():
+                return
+            layer_output = self._extract_output_tensor(outputs)
+            cache = self._position_cache.pop(layer_idx, None)
+            if layer_output is None or cache is None:
+                return
+            with paddle.no_grad():
+                self._record_position(layer_idx, "post_ffn_residual", layer_output, attn_type)
+                post_attn = cache.get("post_attn_residual")
+                if post_attn is not None:
+                    self._record_update_ratio(
+                        layer_idx,
+                        "ffn_update_rms_ratio",
+                        post_attn,
+                        layer_output,
+                        attn_type,
+                    )
 
         return hook_fn
 
@@ -212,6 +344,16 @@ class PaddleMassiveActivationMonitor(PaddleProbe):
             return first.get("hidden_states")
         if isinstance(first, paddle.Tensor):
             return first
+        return None
+
+    @staticmethod
+    def _extract_output_tensor(outputs):
+        if isinstance(outputs, paddle.Tensor):
+            return outputs
+        if isinstance(outputs, dict):
+            return outputs.get("hidden_states")
+        if isinstance(outputs, tuple | list) and outputs:
+            return PaddleMassiveActivationMonitor._extract_output_tensor(outputs[0])
         return None
 
     def _compute_and_log(

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -904,6 +904,95 @@ class PaddleMassiveActivationMonitorTest(unittest.TestCase):
         self.assertEqual(latest["massive_act/global_channel_count_gt_2"], 3.0)
         self.assertEqual(latest["massive_act/global_channel_count_gt_3"], 1.0)
 
+    def test_module_position_metrics_follow_actual_residual_path(self):
+        class Branch(nn.Layer):
+            def __init__(self, scale, bias):
+                super().__init__()
+                self.scale = scale
+                self.bias = bias
+
+            def forward(self, hidden_states):
+                output = hidden_states * self.scale
+                bias = paddle.full_like(hidden_states, self.bias)
+                return output, bias
+
+        class TransformerLayer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layer_idx = 0
+                self.input_layernorm = nn.Identity()
+                self.self_attn = Branch(scale=2.0, bias=1.0)
+                self.post_attention_layernorm = nn.Identity()
+                self.mlp = Branch(scale=-0.5, bias=-2.0)
+
+            def forward(self, hidden_states):
+                attn_out, attn_bias = self.self_attn(hidden_states)
+                post_attn = hidden_states + attn_out + attn_bias
+                mlp_input = self.post_attention_layernorm(post_attn)
+                ffn_out, ffn_bias = self.mlp(mlp_input)
+                return post_attn + ffn_out + ffn_bias
+
+        class Model(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.LayerList([TransformerLayer()])
+
+        hidden_states = paddle.to_tensor([[[1.0, 2.0], [-1.0, 0.5]]], dtype="float32")
+        expected_attn_out = 2.0 * hidden_states
+        expected_post_attn = hidden_states + expected_attn_out + 1.0
+        expected_ffn_out = -0.5 * expected_post_attn
+        expected_output = expected_post_attn + expected_ffn_out - 2.0
+        expected_attn_ratio = paddle.sqrt(((expected_post_attn - hidden_states) ** 2).mean()) / paddle.sqrt(
+            (hidden_states**2).mean()
+        )
+        expected_ffn_ratio = paddle.sqrt(((expected_output - expected_post_attn) ** 2).mean()) / paddle.sqrt(
+            (expected_post_attn**2).mean()
+        )
+
+        training_logs.reset()
+        model = Model()
+        monitor = PaddleMassiveActivationMonitor(cosine_sample_pairs=2)
+        monitor.register_hooks(model)
+        actual_output = model.layers[0](hidden_states)
+        monitor.step()
+
+        self.assertTrue(paddle.allclose(actual_output, expected_output).item())
+        metrics = training_logs.get_latest(prefix="massive_act/layer_0/")
+        for position in (
+            "layer_input",
+            "attn_out",
+            "post_attn_residual",
+            "ffn_or_moe_out",
+            "post_ffn_residual",
+        ):
+            for metric_name in ("rms", "abs_max", "abs_p99", "outlier_ratio"):
+                self.assertIn(f"massive_act/layer_0/{position}_{metric_name}", metrics)
+        self.assertAlmostEqual(
+            metrics["massive_act/layer_0/attn_out_rms"],
+            float(paddle.sqrt((expected_attn_out**2).mean())),
+            places=6,
+        )
+        self.assertAlmostEqual(
+            metrics["massive_act/layer_0/post_attn_residual_abs_max"],
+            float(expected_post_attn.abs().max()),
+            places=6,
+        )
+        self.assertAlmostEqual(
+            metrics["massive_act/layer_0/ffn_or_moe_out_rms"],
+            float(paddle.sqrt((expected_ffn_out**2).mean())),
+            places=6,
+        )
+        self.assertAlmostEqual(
+            metrics["massive_act/layer_0/post_ffn_residual_abs_max"],
+            float(expected_output.abs().max()),
+            places=6,
+        )
+        self.assertAlmostEqual(
+            metrics["massive_act/layer_0/attn_update_rms_ratio"], float(expected_attn_ratio), places=6
+        )
+        self.assertAlmostEqual(metrics["massive_act/layer_0/ffn_update_rms_ratio"], float(expected_ffn_ratio), places=6)
+        monitor.remove_hooks()
+
 
 class PaddleQKMonitorTest(unittest.TestCase):
     def test_resolve_layer_idx_uses_shared_base_logic(self):

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -993,6 +993,149 @@ class PaddleMassiveActivationMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(metrics["massive_act/layer_0/ffn_update_rms_ratio"], float(expected_ffn_ratio), places=6)
         monitor.remove_hooks()
 
+    def test_new_position_hooks_fail_closed(self):
+        hidden_states = paddle.randn([2, 3, 4], dtype="float32")
+
+        def fail(*_args, **_kwargs):
+            raise RuntimeError("injected monitor failure")
+
+        for hook_kind in ("branch_output", "post_attn_residual", "layer_output"):
+            with self.subTest(hook_kind=hook_kind):
+                monitor = PaddleMassiveActivationMonitor()
+                monitor._record_position = fail
+                layer = nn.Identity()
+                if hook_kind == "branch_output":
+                    handle = layer.register_forward_post_hook(monitor._make_branch_output_hook(0, "attn_out", None))
+                elif hook_kind == "post_attn_residual":
+                    monitor._position_cache[0] = {"layer_input": hidden_states.detach()}
+                    handle = layer.register_forward_pre_hook(monitor._make_post_attn_residual_hook(0, None))
+                else:
+                    monitor._position_cache[0] = {"layer_input": hidden_states.detach()}
+                    handle = layer.register_forward_post_hook(monitor._make_layer_output_hook(0, None))
+
+                actual = layer(hidden_states)
+
+                self.assertTrue(paddle.allclose(actual, hidden_states).item())
+                if hook_kind == "layer_output":
+                    self.assertNotIn(0, monitor._position_cache)
+                handle.remove()
+
+    def test_update_ratio_hooks_fail_closed(self):
+        hidden_states = paddle.randn([2, 3, 4], dtype="float32")
+
+        def fail(*_args, **_kwargs):
+            raise RuntimeError("injected update-ratio failure")
+
+        monitor = PaddleMassiveActivationMonitor()
+        monitor._record_position = lambda *_args, **_kwargs: None
+        monitor._record_update_ratio = fail
+        monitor._position_cache[0] = {"layer_input": hidden_states.detach()}
+        layer = nn.Identity()
+        handle = layer.register_forward_pre_hook(monitor._make_post_attn_residual_hook(0, None))
+
+        actual = layer(hidden_states)
+
+        self.assertTrue(paddle.allclose(actual, hidden_states).item())
+        self.assertIn("post_attn_residual", monitor._position_cache[0])
+        handle.remove()
+
+        monitor._position_cache[0] = {
+            "layer_input": hidden_states.detach(),
+            "post_attn_residual": hidden_states.detach(),
+        }
+        handle = layer.register_forward_post_hook(monitor._make_layer_output_hook(0, None))
+
+        actual = layer(hidden_states)
+
+        self.assertTrue(paddle.allclose(actual, hidden_states).item())
+        self.assertNotIn(0, monitor._position_cache)
+        handle.remove()
+
+    def test_output_extraction_failures_do_not_interrupt_forward(self):
+        hidden_states = paddle.randn([2, 3, 4], dtype="float32")
+
+        def fail(*_args, **_kwargs):
+            raise RuntimeError("injected output extraction failure")
+
+        for hook_kind in ("branch_output", "layer_output"):
+            with self.subTest(hook_kind=hook_kind):
+                monitor = PaddleMassiveActivationMonitor()
+                monitor._extract_output_tensor = fail
+                layer = nn.Identity()
+                if hook_kind == "branch_output":
+                    handle = layer.register_forward_post_hook(monitor._make_branch_output_hook(0, "attn_out", None))
+                else:
+                    monitor._position_cache[0] = {"layer_input": hidden_states.detach()}
+                    handle = layer.register_forward_post_hook(monitor._make_layer_output_hook(0, None))
+
+                actual = layer(hidden_states)
+
+                self.assertTrue(paddle.allclose(actual, hidden_states).item())
+                if hook_kind == "layer_output":
+                    self.assertNotIn(0, monitor._position_cache)
+                handle.remove()
+
+    def test_module_position_metrics_support_mhc_residual_streams(self):
+        class Branch(nn.Layer):
+            def __init__(self, scale):
+                super().__init__()
+                self.scale = scale
+
+            def forward(self, hidden_states):
+                return hidden_states * self.scale, None
+
+        class HyperConnection(nn.Layer):
+            def __init__(self, num_streams):
+                super().__init__()
+                self.num_streams = num_streams
+
+            def forward(self, hidden_states):
+                stream_width = hidden_states.shape[-1] // self.num_streams
+                streams = hidden_states.reshape([*hidden_states.shape[:-1], self.num_streams, stream_width])
+                return streams.mean(axis=-2), None, None
+
+        class TransformerLayer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layer_idx = 0
+                self.input_layernorm = nn.Identity()
+                self.post_attention_layernorm = nn.Identity()
+                self.self_attention_hyper_connection = HyperConnection(num_streams=2)
+                self.mlp_hyper_connection = HyperConnection(num_streams=2)
+                self.self_attn = Branch(scale=0.5)
+                self.mlp = Branch(scale=-0.25)
+
+            def forward(self, hidden_states):
+                attn_input, _, _ = self.self_attention_hyper_connection(hidden_states)
+                attn_out, _ = self.self_attn(attn_input)
+                post_attn = hidden_states + paddle.concat([attn_out, 2.0 * attn_out], axis=-1)
+                mlp_input, _, _ = self.mlp_hyper_connection(post_attn)
+                ffn_out, _ = self.mlp(mlp_input)
+                return post_attn + paddle.concat([ffn_out, 0.5 * ffn_out], axis=-1)
+
+        class Model(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.LayerList([TransformerLayer()])
+
+        hidden_states = paddle.to_tensor([[[1.0, 2.0, 3.0, 4.0], [-1.0, 0.5, 2.0, -2.0]]])
+        model = Model()
+        monitor = PaddleMassiveActivationMonitor(cosine_sample_pairs=2)
+        monitor.register_hooks(model)
+
+        expected = model.layers[0](hidden_states)
+        monitor.step()
+
+        self.assertEqual(expected.shape, hidden_states.shape)
+        metrics = training_logs.get_latest(prefix="massive_act/layer_0/")
+        self.assertIn("massive_act/layer_0/attn_out_rms", metrics)
+        self.assertIn("massive_act/layer_0/post_attn_residual_rms", metrics)
+        self.assertIn("massive_act/layer_0/ffn_or_moe_out_rms", metrics)
+        self.assertIn("massive_act/layer_0/post_ffn_residual_rms", metrics)
+        self.assertIn("massive_act/layer_0/attn_update_rms_ratio", metrics)
+        self.assertIn("massive_act/layer_0/ffn_update_rms_ratio", metrics)
+        monitor.remove_hooks()
+
 
 class PaddleQKMonitorTest(unittest.TestCase):
     def test_resolve_layer_idx_uses_shared_base_logic(self):


### PR DESCRIPTION
## Summary

- Record activation statistics at five executed module positions:
  - layer input
  - attention output
  - post-attention residual
  - FFN/MoE output
  - post-FFN residual
- Report RMS, absolute maximum, absolute p99, and outlier ratio at each position.
- Add attention and FFN residual-update RMS ratios based on actual forward boundaries.
- Document the new metrics and their definitions.

## Motivation

Layer-level activation statistics alone cannot determine whether an outlier originates from Attention, FFN/MoE, or residual accumulation. The new positions provide module-level localization and measure the branch contribution actually written into the residual stream.

The implementation observes executed boundaries instead of reconstructing outputs manually, covering bias, dropout, BDA, and hyper-connection residual mixing.

## Validation

- Relevant PaddleFleet monitor suite: 120 passed.
- Covered standard residual and mHC-compatible execution boundaries, metric values, and hook cleanup.