### PR TITLE
feat(moe_health): add assignment-load and gate-mass routing diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ setup_internal_medicine()
 | 17 | `load_balance_entropy_norm` | `moe_health/.../load_balance_entropy_norm` | `H(p) / log(E)` | 每层+全局 | 归一化负载熵 (均衡=1, 坍缩=0) |
 | 18 | `load_effective_experts` | `moe_health/.../load_effective_experts` | `exp(H)` | 每层+全局 | 有效专家数 (均衡=E, 坍缩=1) |
 
+PaddleFleet 后端还会直接从每次 router forward 的实际选择结果输出以下指标：
+
+| 指标组 | 公式 | 诊断意义 |
+|--------|------|----------|
+| `router_input_{rms,abs_max,abs_p99}` | Router 输入的 RMS、绝对最大值和绝对值 P99 | 区分输入整体放大与局部 outlier |
+| `router_entropy_norm` | `router_entropy / log(E)` | 跨不同专家数比较路由亲和度的尖锐程度 |
+| `router_margin_{mean,min,p10,p01}` | 最弱已选专家分数减最强未选专家分数 | 衡量 Top-K 决策边界的稳健程度 |
+| `assignment_load_*` | 对各专家实际 hard assignment 数量的分布统计 | 衡量 token 数量负载是否均衡 |
+| `gate_mass_*` | 对各专家已选正亲和度总量的分布统计 | 衡量专家获得的连续门控质量是否均衡 |
+
+`assignment_load_*` 和 `gate_mass_*` 均包含 `cv`、`entropy_norm`、
+`kl_uniform`、`max_frac`、`min_frac` 与 `max_min_ratio`。它们分别回答
+“每个专家接收多少 token”和“每个专家接收多少正门控质量”，不可互相替代。
+
 > **注**: 指标 14-18 (`load_*`) 在满足以下**任一**条件时输出, 优先使用前者:
 > 1. `global_aux_loss` 已开启 (`get_aux_loss_coeff("global_aux_loss") > 0`): 复用
 >    router 的 `global_tokens_per_expert` 缓冲区 (已跨 TPxDPxCP all-reduce 并在
@@ -500,7 +514,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 
 ## 附录: 完整指标速查表
 
-共 50 个指标键 (13 MoE + 9 QK + 21 MassiveAct + 7 PLE)。
+指标按后端和模型能力动态输出；以下列出各监控器的核心指标。
 
 | Monitor | 指标 | 公式 | SmoothedValue 模式 | 健康信号 |
 |---------|------|------|--------------------|----------|

--- a/docs/moe_specialist.md
+++ b/docs/moe_specialist.md
@@ -1,0 +1,64 @@
+# MoE Health Monitor
+
+`moe_health` 监控 Router 输入与决策、专家负载、门控质量、专家参数和
+共享/路由专家激活。指标由模型实际暴露的能力决定，不支持的指标不会伪造。
+
+## PaddleFleet 路由指标
+
+设 Router 对一个 batch 中第 $t$ 个 token、专家 $e$ 的非负亲和度为
+$p_{t,e}$，实际 Top-K 选择掩码为 $a_{t,e}\in\{0,1\}$，专家数为 $E$。
+
+| 指标 | 定义 | 含义 |
+|------|------|------|
+| `router_input_rms` | $\sqrt{\operatorname{mean}(x^2)}$ | Router 输入整体尺度 |
+| `router_input_abs_max` | $\max \lvert x\rvert$ | Router 输入峰值 |
+| `router_input_abs_p99` | $P_{99}(\lvert x\rvert)$ | Router 输入尾部尺度 |
+| `router_entropy` | $\operatorname{mean}_t[-\sum_e \bar p_{t,e}\log\bar p_{t,e}]$ | 每个 token 的路由亲和度熵 |
+| `router_entropy_norm` | `router_entropy / log(E)` | 可跨专家数比较的归一化熵 |
+| `score_sum_{mean,min,max}` | $\sum_{e\in\operatorname{TopK}(p_t)}p_{t,e}$ 的统计量 | Top-K 原始亲和度总量 |
+| `router_margin_*` | $\min_{a=1}s_{t,e}-\max_{a=0}s_{t,e}$ | 已选/未选边界的稳健程度 |
+
+`router_margin_*` 包含 `mean`、`min`、`p10` 和 `p01`。当 Router 使用
+correction bias 时，$s$ 包含该 bias；group-limited 或 hash routing 的候选集合
+不是简单全局 Top-K，因此不会输出可能误导的 margin。
+
+## 负载与门控质量
+
+Hard assignment 负载为
+
+$$
+n_e=\sum_t a_{t,e},\qquad q_e=\frac{n_e}{\sum_j n_j}.
+$$
+
+正门控质量为
+
+$$
+m_e=\sum_t p_{t,e}a_{t,e},\qquad r_e=\frac{m_e}{\sum_j m_j}.
+$$
+
+分别以 `assignment_load_` 和 `gate_mass_` 为前缀输出下列分布统计：
+
+| 后缀 | 定义 | 健康方向 |
+|------|------|----------|
+| `cv` | $\operatorname{std}(q)/(1/E)$ | 越接近 0 越均衡 |
+| `entropy_norm` | $-\sum_e q_e\log q_e/\log E$ | 越接近 1 越均衡 |
+| `kl_uniform` | $\sum_e q_e\log(Eq_e)$ | 越接近 0 越均衡 |
+| `max_frac` | $\max_e q_e$ | 识别最忙专家占比 |
+| `min_frac` | $\min_e q_e$ | 识别冷专家或未使用专家 |
+| `max_min_ratio` | $\max_e q_e/\max(\min_e q_e,10^{-12})$ | 识别负载极差 |
+
+`gate_mass_*` 使用 $r$ 代替 $q$。它基于 Router 的正亲和度和实际选择掩码，
+不读取可能包含后续可学习缩放的最终 combine weight，避免把负缩放误解释为
+负的路由质量。
+
+## 其他指标
+
+- `bias_affinity_jaccard`：加入 correction bias 前后 Top-K 专家集合的 Jaccard。
+- `expert_bias_{mean,std,min,max}`：correction bias 分布。
+- `router_scalar_{mean,std,min,max,ratio}`：可学习 routed scaling 的分布。
+- `expert_norm_{mean,std,min,max}`：路由专家参数 L2 范数分布。
+- `shared_expert_norm`、`shared_routed_ratio`：共享专家参数范数及其相对尺度。
+- `shared_act_*`、`routed_act_*`、`shared_routed_act_ratio`：共享/路由专家输出激活。
+
+所有 forward-hook 指标先保留在设备端，沿统一的 `step()` 聚合与日志链路输出；
+hook 中不引入额外的跨 rank collective。

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -16,6 +16,7 @@ return tuple. Currently adapted for StandardMoEGate (PaddleFormers).
 """
 
 import logging
+import math
 
 import paddle
 import paddle.distributed as dist
@@ -33,6 +34,66 @@ def _compute_router_entropy(probs):
     probs = probs / probs.sum(axis=-1, keepdim=True)
     entropy = -(probs * probs.log()).sum(axis=-1)
     return entropy.mean()
+
+
+def _distribution_metrics(mass: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Summarize a non-negative expert-mass vector without leaving the GPU."""
+    mass = mass.astype("float32").reshape([-1]).clip(min=0.0)
+    total = mass.sum()
+    fraction = mass / total.clip(min=1e-30)
+    num_experts = int(fraction.shape[0])
+    uniform = 1.0 / max(num_experts, 1)
+    safe_fraction = fraction.clip(min=1e-12)
+    entropy = -(fraction * safe_fraction.log()).sum()
+    zero = total * 0.0
+    has_mass = total > 0
+    entropy_norm = entropy / math.log(num_experts) if num_experts > 1 else zero + 1.0
+    minimum = fraction.min()
+    metrics = {
+        "cv": paddle.sqrt(((fraction - uniform) ** 2).mean()) / uniform,
+        "entropy_norm": entropy_norm,
+        "kl_uniform": (fraction * (safe_fraction * num_experts).log()).sum(),
+        "max_frac": fraction.max(),
+        "min_frac": minimum,
+        "max_min_ratio": fraction.max() / minimum.clip(min=1e-12),
+    }
+    return {name: paddle.where(has_mass, value, zero) for name, value in metrics.items()}
+
+
+def _assignment_mask(
+    probabilities: paddle.Tensor,
+    outputs,
+    k: int,
+) -> paddle.Tensor | None:
+    """Return the router's actual hard assignment mask as ``[tokens, experts]``."""
+    num_experts = int(probabilities.shape[-1])
+    if isinstance(outputs, tuple | list) and len(outputs) > 4 and isinstance(outputs[4], paddle.Tensor):
+        mask = outputs[4]
+        if int(mask.shape[-1]) == num_experts:
+            return mask.detach().astype("float32").reshape([-1, num_experts]).clip(min=0.0, max=1.0)
+
+    if not (isinstance(outputs, tuple | list) and len(outputs) > 2 and isinstance(outputs[2], paddle.Tensor)):
+        return None
+    indices = outputs[2].detach().astype("int64").reshape([-1, k])
+    valid = (indices >= 0) & (indices < num_experts)
+    safe_indices = indices.clip(min=0, max=num_experts - 1)
+    one_hot = paddle.nn.functional.one_hot(safe_indices, num_classes=num_experts).astype("float32")
+    return (one_hot * valid.unsqueeze(-1).astype("float32")).sum(axis=1).clip(max=1.0)
+
+
+def _routing_margin(selection_scores: paddle.Tensor, assignment_mask: paddle.Tensor) -> paddle.Tensor:
+    """Return selected-boundary margins for an ungrouped top-k router."""
+    selected = paddle.where(
+        assignment_mask > 0,
+        selection_scores,
+        paddle.full_like(selection_scores, float("inf")),
+    ).min(axis=-1)
+    unselected = paddle.where(
+        assignment_mask > 0,
+        paddle.full_like(selection_scores, float("-inf")),
+        selection_scores,
+    ).max(axis=-1)
+    return selected - unselected
 
 
 def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=1, topk_group=1):
@@ -150,13 +211,27 @@ def _act_stats(act, name_prefix):
 class PaddleMoEMonitor(PaddleProbe):
     METRIC_PREFIX = "moe_health"
     MAX_AGGREGATED = {
-        "score_sum_max", "expert_norm_max", "expert_bias_max",
-        "shared_act_abs_max", "routed_act_abs_max",
+        "score_sum_max",
+        "expert_norm_max",
+        "expert_bias_max",
+        "shared_act_abs_max",
+        "routed_act_abs_max",
         "router_scalar_max",
+        "router_input_abs_max",
+        "router_input_abs_p99",
+        "assignment_load_max_frac",
+        "assignment_load_max_min_ratio",
+        "gate_mass_max_frac",
+        "gate_mass_max_min_ratio",
     }
     MIN_AGGREGATED = {
-        "score_sum_min", "expert_norm_min", "expert_bias_min",
+        "score_sum_min",
+        "expert_norm_min",
+        "expert_bias_min",
         "router_scalar_min",
+        "assignment_load_min_frac",
+        "gate_mass_min_frac",
+        "router_margin_min",
     }
 
     def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
@@ -186,7 +261,25 @@ class PaddleMoEMonitor(PaddleProbe):
 
         # Declare metric schema
         for layer_idx, moe_layer in moe_layers:
-            gate_metrics = ["router_entropy", "score_sum_mean", "score_sum_min", "score_sum_max"]
+            gate_metrics = [
+                "router_input_rms",
+                "router_input_abs_max",
+                "router_input_abs_p99",
+                "router_entropy",
+                "router_entropy_norm",
+                "score_sum_mean",
+                "score_sum_min",
+                "score_sum_max",
+                "router_margin_mean",
+                "router_margin_min",
+                "router_margin_p10",
+                "router_margin_p01",
+            ]
+            for prefix in ("assignment_load", "gate_mass"):
+                gate_metrics += [
+                    f"{prefix}_{suffix}"
+                    for suffix in ("cv", "entropy_norm", "kl_uniform", "max_frac", "min_frac", "max_min_ratio")
+                ]
             if hasattr(moe_layer, "gate") and hasattr(moe_layer.gate, "e_score_correction_bias"):
                 gate_metrics += [
                     "bias_affinity_jaccard",
@@ -216,7 +309,9 @@ class PaddleMoEMonitor(PaddleProbe):
                 act_metrics += ["shared_act_norm", "shared_act_abs_max", "shared_act_mean"]
             if hasattr(moe_layer, "_post_routed_output"):
                 act_metrics += [
-                    "routed_act_norm", "routed_act_abs_max", "routed_act_mean",
+                    "routed_act_norm",
+                    "routed_act_abs_max",
+                    "routed_act_mean",
                     "shared_routed_act_ratio",
                 ]
             for m in gate_metrics + expert_metrics + act_metrics:
@@ -232,9 +327,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 self.hooks.append(hook)
             # Shared expert activation hook
             if hasattr(moe_layer, "shared_experts") and moe_layer.shared_experts is not None:
-                hook = moe_layer.shared_experts.register_forward_post_hook(
-                    self._make_shared_expert_hook(layer_idx)
-                )
+                hook = moe_layer.shared_experts.register_forward_post_hook(self._make_shared_expert_hook(layer_idx))
                 self.hooks.append(hook)
             # Routed expert activation: patch _post_routed_output (called right
             # after routed experts, before adding shared output — no D2H).
@@ -433,7 +526,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 return
             try:
                 with paddle.no_grad():
-                    self._compute_gate_metrics(layer_idx, layer, outputs, moe_layer)
+                    self._compute_gate_metrics(layer_idx, layer, inputs, outputs, moe_layer)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMoEMonitor] Gate hook error layer {layer_idx}: {e}")
@@ -484,7 +577,7 @@ class PaddleMoEMonitor(PaddleProbe):
             for layer_idx, routed_sq, shared_sq, _ in pending:
                 self._record_expert_metrics(layer_idx, routed_sq, shared_sq)
 
-    def _compute_gate_metrics(self, layer_idx, gate, outputs, moe_layer):
+    def _compute_gate_metrics(self, layer_idx, gate, inputs, outputs, moe_layer):
         """Compute router metrics from gate forward output."""
         cached_gates = getattr(gate, "_cached_gates", None)
         k = getattr(gate, "num_experts_per_tok", None)
@@ -494,13 +587,56 @@ class PaddleMoEMonitor(PaddleProbe):
                 logger.warning(f"[PaddleMoEMonitor] layer {layer_idx}: _cached_gates is None, gate patch may not work")
             return
 
-        self.record_layer_metric(layer_idx, "router_entropy", _compute_router_entropy(cached_gates))
+        cached_gates = cached_gates.reshape([-1, cached_gates.shape[-1]])
+        router_input = inputs[0] if inputs and isinstance(inputs[0], paddle.Tensor) else None
+        if router_input is not None:
+            router_input = router_input.detach().astype("float32")
+            absolute = router_input.abs()
+            self.record_layer_metric(layer_idx, "router_input_rms", paddle.sqrt(router_input.square().mean()))
+            self.record_layer_metric(layer_idx, "router_input_abs_max", absolute.max())
+            self.record_layer_metric(
+                layer_idx,
+                "router_input_abs_p99",
+                paddle.quantile(absolute.reshape([-1]), 0.99),
+            )
+
+        router_entropy = _compute_router_entropy(cached_gates)
+        self.record_layer_metric(layer_idx, "router_entropy", router_entropy)
+        num_experts = int(cached_gates.shape[-1])
+        entropy_norm = router_entropy / math.log(num_experts) if num_experts > 1 else router_entropy * 0.0 + 1.0
+        self.record_layer_metric(layer_idx, "router_entropy_norm", entropy_norm)
         if k is not None:
+            k = int(k)
             topk_vals, _ = paddle.topk(cached_gates, k, axis=-1)
             score_sum = topk_vals.sum(axis=-1)
             self.record_layer_metric(layer_idx, "score_sum_mean", score_sum.mean())
             self.record_layer_metric(layer_idx, "score_sum_min", score_sum.min())
             self.record_layer_metric(layer_idx, "score_sum_max", score_sum.max())
+
+            assignment_mask = _assignment_mask(cached_gates, outputs, k)
+            if assignment_mask is not None and int(assignment_mask.shape[0]) == int(cached_gates.shape[0]):
+                assignment = assignment_mask.sum(axis=0)
+                selected_affinity = cached_gates.astype("float32") * assignment_mask
+                if bool(getattr(gate, "norm_topk_prob", False)):
+                    selected_affinity = selected_affinity / selected_affinity.sum(axis=-1, keepdim=True).clip(min=1e-12)
+                gate_mass = selected_affinity.sum(axis=0)
+                for prefix, mass in (("assignment_load", assignment), ("gate_mass", gate_mass)):
+                    for name, value in _distribution_metrics(mass).items():
+                        self.record_layer_metric(layer_idx, f"{prefix}_{name}", value)
+
+                if (
+                    k < num_experts
+                    and int(getattr(gate, "n_group", 1)) == 1
+                    and not bool(getattr(gate, "is_hash_layer", False))
+                ):
+                    selection_scores = cached_gates.astype("float32")
+                    if hasattr(gate, "e_score_correction_bias"):
+                        selection_scores = selection_scores + gate.e_score_correction_bias.detach().astype("float32")
+                    margin = _routing_margin(selection_scores, assignment_mask)
+                    self.record_layer_metric(layer_idx, "router_margin_mean", margin.mean())
+                    self.record_layer_metric(layer_idx, "router_margin_min", margin.min())
+                    self.record_layer_metric(layer_idx, "router_margin_p10", paddle.quantile(margin, 0.10))
+                    self.record_layer_metric(layer_idx, "router_margin_p01", paddle.quantile(margin, 0.01))
 
         if hasattr(gate, "e_score_correction_bias"):
             top_idx_with_bias = None
@@ -526,9 +662,7 @@ class PaddleMoEMonitor(PaddleProbe):
             self.record_layer_metric(layer_idx, "router_scalar_std", scalar.std())
             self.record_layer_metric(layer_idx, "router_scalar_max", scalar.max())
             self.record_layer_metric(layer_idx, "router_scalar_min", scalar.min())
-            self.record_layer_metric(
-                layer_idx, "router_scalar_ratio", scalar.max() / scalar.min().clip(min=1e-8)
-            )
+            self.record_layer_metric(layer_idx, "router_scalar_ratio", scalar.max() / scalar.min().clip(min=1e-8))
 
     def _collect_expert_sumsq(self, moe_layer):
         """Per-expert / shared-expert sums of squares for one MoE layer.
@@ -553,9 +687,7 @@ class PaddleMoEMonitor(PaddleProbe):
             # single module whose up_gate_proj/down_proj weights carry a leading
             # expert dim [num_experts, ...]. Vectorize over that dim.
             if hasattr(experts, "up_gate_proj") and hasattr(experts, "down_proj"):
-                routed_sq = _per_expert_stacked_sumsq(
-                    experts.up_gate_proj.weight, experts.down_proj.weight
-                )
+                routed_sq = _per_expert_stacked_sumsq(experts.up_gate_proj.weight, experts.down_proj.weight)
                 shard_group = _intermediate_shard_group(experts)
             elif isinstance(experts, (list, nn.LayerList)) or hasattr(experts, "__iter__"):
                 # Non-fused layout: LayerList of per-expert modules. One sum-sq

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 import sys
 import unittest
 from pathlib import Path
@@ -187,17 +188,14 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertEqual(layer_discovery.resolve_layer_idx(plain, 0, 4), 5)
 
         # Explicit logical attrs win and are never offset.
-        self.assertEqual(
-            layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9
-        )
+        self.assertEqual(layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9)
 
     def test_mtp_layer_idx_is_absolute_not_max_of_local_main_layers(self):
         """On a PP stage holding a partial stack, MTP must not be numbered max(local)+1."""
         config = SimpleNamespace(num_hidden_layers=43)
         # Last pipeline stage: only layers 36..37 of a 43-layer model, plus MTP.
         main_layers = [
-            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config)
-            for n in (36, 37)
+            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config) for n in (36, 37)
         ]
         mtp_wrapper = SimpleNamespace(
             transformer_layer=SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config),
@@ -250,6 +248,100 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         latest = training_logs.get_latest(prefix="moe_health")
         self.assertAlmostEqual(latest["moe_health/layer_0/router_entropy"], 2.0, places=4)
         self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 2.0, places=4)
+
+    def test_distribution_metrics_distinguish_balanced_and_collapsed_load(self):
+        balanced = moe_monitor_module._distribution_metrics(paddle.to_tensor([2.0, 2.0, 2.0, 2.0]))
+        collapsed = moe_monitor_module._distribution_metrics(paddle.to_tensor([8.0, 0.0, 0.0, 0.0]))
+        empty = moe_monitor_module._distribution_metrics(paddle.zeros([4]))
+
+        self.assertAlmostEqual(float(balanced["cv"]), 0.0, places=6)
+        self.assertAlmostEqual(float(balanced["entropy_norm"]), 1.0, places=6)
+        self.assertAlmostEqual(float(balanced["max_frac"]), 0.25, places=6)
+        self.assertGreater(float(collapsed["cv"]), float(balanced["cv"]))
+        self.assertLess(float(collapsed["entropy_norm"]), float(balanced["entropy_norm"]))
+        self.assertAlmostEqual(float(collapsed["max_frac"]), 1.0, places=6)
+        self.assertTrue(all(math.isfinite(float(value)) for value in empty.values()))
+        self.assertTrue(all(float(value) == 0.0 for value in empty.values()))
+
+    def test_gate_hook_records_actual_assignment_and_positive_gate_mass(self):
+        class Gate(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.num_experts_per_tok = 2
+                self.n_group = 1
+                self.topk_group = 1
+                self.norm_topk_prob = False
+
+            def gate_score_func(self, scores):
+                return scores
+
+            def forward(self, scores):
+                gates = self.gate_score_func(scores)
+                top_gate, top_idx = paddle.topk(gates, self.num_experts_per_tok, axis=-1)
+                mask = paddle.nn.functional.one_hot(top_idx, num_classes=gates.shape[-1]).sum(axis=1)
+                combine_weights = gates * mask.astype("float32")
+                signed = paddle.where(
+                    paddle.arange(gates.shape[-1]).reshape([1, -1]) == 3,
+                    -combine_weights,
+                    combine_weights,
+                )
+                return None, top_gate, top_idx, signed, mask, None, None, None
+
+        class MoE(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.gate = Gate()
+
+        class TransformerLayer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layer_idx = 0
+                self.mlp = MoE()
+
+        class Model(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.LayerList([TransformerLayer()])
+
+        router_input = paddle.to_tensor(
+            [
+                [0.60, 0.40, 0.10, 0.05],
+                [0.10, 0.05, 0.60, 0.40],
+                [0.60, 0.10, 0.40, 0.05],
+                [0.10, 0.60, 0.05, 0.40],
+            ],
+            dtype="float32",
+        )
+        model = Model()
+        monitor = PaddleMoEMonitor()
+        monitor.register_hooks(model)
+        model.layers[0].mlp.gate(router_input)
+        monitor.step()
+
+        metrics = training_logs.get_latest(prefix="moe_health/layer_0/")
+        self.assertAlmostEqual(metrics["moe_health/layer_0/assignment_load_cv"], 0.0, places=6)
+        self.assertAlmostEqual(metrics["moe_health/layer_0/assignment_load_entropy_norm"], 1.0, places=6)
+        self.assertAlmostEqual(metrics["moe_health/layer_0/assignment_load_max_frac"], 0.25, places=6)
+        self.assertAlmostEqual(metrics["moe_health/layer_0/gate_mass_max_frac"], 0.30, places=6)
+        self.assertAlmostEqual(metrics["moe_health/layer_0/gate_mass_min_frac"], 0.20, places=6)
+        self.assertGreater(metrics["moe_health/layer_0/router_margin_min"], 0.0)
+        self.assertAlmostEqual(
+            metrics["moe_health/layer_0/router_input_rms"],
+            float(paddle.sqrt((router_input**2).mean())),
+            places=6,
+        )
+        self.assertGreaterEqual(metrics["moe_health/layer_0/router_entropy_norm"], 0.0)
+        self.assertLessEqual(metrics["moe_health/layer_0/router_entropy_norm"], 1.0)
+        monitor.remove_hooks()
+
+    def test_assignment_mask_ignores_invalid_expert_ids(self):
+        probabilities = paddle.to_tensor([[0.7, 0.2, 0.1], [0.1, 0.3, 0.6]], dtype="float32")
+        invalid_indices = paddle.to_tensor([[-1, 3], [4, -2]], dtype="int64")
+        outputs = (None, None, invalid_indices)
+
+        assignment_mask = moe_monitor_module._assignment_mask(probabilities, outputs, k=2)
+
+        self.assertEqual(float(assignment_mask.sum()), 0.0)
 
     def test_mtp_layer_marker_is_encoded_in_metric_key(self):
         monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)


### PR DESCRIPTION
## Summary

- Add Router-input RMS, absolute maximum, and absolute p99 statistics.
- Add normalized Router entropy and selected/unselected routing margins.
- Report separate expert distributions for:
  - hard assignment load
  - selected positive gate mass
- Summarize both distributions using CV, normalized entropy, KL-to-uniform, maximum/minimum fraction, and max/min ratio.
- Document metric definitions and capability-dependent behavior.

## Motivation

Hard expert counts and Router probabilities describe different aspects of MoE health. Separating assignment load from gate mass distinguishes dispatch imbalance from confidence or affinity imbalance and makes routing behavior easier to diagnose across model configurations.

Unsupported margins are omitted for grouped or hash routing rather than approximated with misleading values.

## Validation

- Relevant PaddleFleet monitor suite: 122 passed.
- Covered actual assignment extraction, distribution statistics, correction-bias routing, grouped-routing exclusions, and zero-mass handling.
- Forward hooks introduce no additional cross-rank collectives.