### PR TITLE
fix(paddlefleet): normalize monitor selection and fail closed on setup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ for step in range(num_steps):
         monitor.step()
 ```
 
+`monitors` 同时接受名称列表和逗号分隔字符串，例如
+`"qk_stats,moe_health"`。未知名称会告警并跳过；已请求 monitor 的初始化失败会
+直接抛出异常，避免训练在诊断功能未生效时静默继续。
+
 ### 配合 NeMo Trainer 使用
 
 ```python

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -42,12 +42,26 @@ def _monitor_has_active_hooks(monitor):
     return bool(wrapped)
 
 
+def _normalize_monitor_names(monitors):
+    """Normalize list- or comma-separated monitor selections."""
+    if monitors is None:
+        return ["all"]
+    if isinstance(monitors, str):
+        monitors = [monitors]
+
+    names = []
+    for value in monitors:
+        if not isinstance(value, str):
+            raise TypeError("monitor names must be strings")
+        names.extend(name.strip() for name in value.split(",") if name.strip())
+    return list(dict.fromkeys(names))
+
+
 def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, verbose=False, **kwargs):
     """Setup all requested monitors on a PaddleFleet model."""
     install_gather_fn()
 
-    if monitors is None:
-        monitors = ["all"]
+    monitors = _normalize_monitor_names(monitors)
     if "all" in monitors:
         monitors = list(_MONITOR_MAP.keys())
     if monitor_dict is None:
@@ -87,8 +101,13 @@ def setup_monitors(model, monitors=None, monitor_dict=None, monitor_interval=1, 
                 setattr(monitor, _MONITOR_CONFIG_ATTR, expected_config)
                 model_monitor_dict[name] = monitor
             logger.info(f"[InternalMedicine/paddlefleet] Enabled monitor: {name}")
-        except Exception as e:
-            logger.error(f"[InternalMedicine/paddlefleet] Failed to setup {name}: {e}")
+        except Exception:
+            partial_monitor = monitor_dict.pop(name, None)
+            if partial_monitor is not None:
+                partial_monitor.remove_hooks()
+            model_monitor_dict.pop(name, None)
+            logger.exception(f"[InternalMedicine/paddlefleet] Failed to setup {name}")
+            raise
 
     return model
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -104,6 +104,48 @@ class PaddleFleetSetupTest(unittest.TestCase):
         self.assertTrue(first["dummy"].removed)
         self.assertIs(second["dummy"], created[1])
 
+    def test_setup_monitors_accepts_comma_separated_names(self):
+        enabled = []
+
+        def setup_dummy(_model, monitor_dict=None, monitor_name=None, **_kwargs):
+            enabled.append(monitor_name)
+            monitor_dict[monitor_name] = DummyMonitor()
+
+        paddlefleet_backend._MONITOR_MAP.clear()
+        paddlefleet_backend._MONITOR_MAP.update(
+            {
+                "first": lambda model, **kwargs: setup_dummy(model, monitor_name="first", **kwargs),
+                "second": lambda model, **kwargs: setup_dummy(model, monitor_name="second", **kwargs),
+            }
+        )
+
+        paddlefleet_backend.setup_monitors(
+            SimpleNamespace(),
+            monitors=" first, second, first ",
+            monitor_dict={},
+        )
+
+        self.assertEqual(enabled, ["first", "second"])
+
+    def test_setup_monitors_propagates_and_cleans_setup_failure(self):
+        partial = DummyMonitor()
+
+        def setup_broken(_model, monitor_dict=None, **_kwargs):
+            monitor_dict["broken"] = partial
+            raise RuntimeError("setup failed")
+
+        paddlefleet_backend._MONITOR_MAP.clear()
+        paddlefleet_backend._MONITOR_MAP["broken"] = setup_broken
+        model = SimpleNamespace()
+        monitors = {}
+
+        with self.assertRaisesRegex(RuntimeError, "setup failed"):
+            paddlefleet_backend.setup_monitors(model, monitors=["broken"], monitor_dict=monitors)
+
+        self.assertTrue(partial.removed)
+        self.assertNotIn("broken", monitors)
+        self.assertNotIn("broken", getattr(model, paddlefleet_backend._MODEL_MONITOR_ATTR))
+
 
 class PaddleLayerDiscoveryTest(unittest.TestCase):
     def test_get_decoder_layers_flattens_virtual_pipeline_chunks(self):
@@ -187,17 +229,14 @@ class PaddleLayerDiscoveryTest(unittest.TestCase):
         self.assertEqual(layer_discovery.resolve_layer_idx(plain, 0, 4), 5)
 
         # Explicit logical attrs win and are never offset.
-        self.assertEqual(
-            layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9
-        )
+        self.assertEqual(layer_discovery.resolve_layer_idx(SimpleNamespace(layer_idx=9, config=config), 0, 4), 9)
 
     def test_mtp_layer_idx_is_absolute_not_max_of_local_main_layers(self):
         """On a PP stage holding a partial stack, MTP must not be numbered max(local)+1."""
         config = SimpleNamespace(num_hidden_layers=43)
         # Last pipeline stage: only layers 36..37 of a 43-layer model, plus MTP.
         main_layers = [
-            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config)
-            for n in (36, 37)
+            SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), layer_number=n, config=config) for n in (36, 37)
         ]
         mtp_wrapper = SimpleNamespace(
             transformer_layer=SimpleNamespace(self_attn=SimpleNamespace(is_swa=False), config=config),


### PR DESCRIPTION
## Summary

- Normalize monitor selection from either lists or comma-separated strings.
- Deduplicate monitor names while preserving their order.
- Remove partially registered hooks when monitor initialization fails.
- Re-raise setup errors instead of silently continuing with a disabled monitor.

## Motivation

A monitor configuration error could previously be logged and ignored, allowing training to continue without the requested diagnostics. Partial setup could also leave hooks registered on the model.

Failing closed makes configuration problems immediately visible and prevents partially initialized monitoring state.

## Validation

- Relevant PaddleFleet monitor suite: 121 passed.
- Covered list and comma-separated selection, deduplication, invalid input, partial-hook cleanup, and exception propagation.