### PR TITLE
feat: Stable Rank & Singular Entropy Monitor for Attn & MLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 - **Attn Update** — QK 乘积增量 `Δ₂ = ΔW_q W_kᵗ + W_q ΔW_kᵗ` / `Δ₃ = ΔW_q ΔW_kᵗ` 的谱监控 (每项 3 指标；仅权重，不挂 forward hook)
-- **MLP Update** — MoE 专家 MLP 的参数增量 `ΔW_m`，按 (层 × 专家 × gate/up/down) 分开测再按层汇总 (每层 33 指标；仅权重)
+- **MLP Update** — MoE 专家 MLP 的参数增量 `ΔW_m`，按 (层 × 专家 × gate/up/down) 分开测再按层汇总 (每层 36 指标；仅权重)
 
 以及一个挂在**优化器**而不是模型上的模块，**始终装上**（无需点名，调用方零改动；上报频率同样受 `monitor_interval` 门控）：
 - **[Optimizer Update](./docs/optim_update.md)** — `optim/update_rms`、`optim/param_rms`、`optim/update_param_ratio`，与 grad norm 并排看
@@ -606,7 +606,9 @@ RMSNorm / QK-norm 的可学习 scale 在 QK 电路内部，故折进 `W_q` / `W_
 | 9 | `update_zmax_{max,p90,min}` | `mlp_update/layer_{i}/update_zmax_max` | `S^(l,e) = max_m z(r_m^(l,e))` | 每层+全局 | 专家级汇总分数 |
 | 10 | `shared_{m}_rel_update` | 同上 | `r_m` of shared expert | 每层+全局 | 共享专家，作路由专家的对照组 |
 
-`{m}` 取 `gate` / `up` / `down`。每层 33 个键（开 `log_spectrum` 后 42）。
+`{m}` 取 `gate` / `up` / `down`。每层 36 个键 = `update_zmax` 3 个 + 三块矩阵各 11 个（`rel_update` 6 + `delta_norm_mean` 1 + `stable_rank` 3 + `shared_{m}_rel_update` 1）；开 `log_spectrum` 后每块再加 3 个熵，共 45 个。
+
+> 逐层键落在 `mlp_update/layer_{i}/…`，全局聚合落在 `mlp_update/global_…`。dense 层（无 MoE）不声明指标，所以 18 层 MoE + 1 组 global = 684 个键。
 
 **专家级汇总分数**用 `max_m z(r_m)` 而不是平均：平均会让某一块矩阵的异常被另两块健康的摊薄，
 而平均原始范数会让尺度最大的那块矩阵决定结论。先在**同层专家间**做标准化把三块拉到同一尺度，

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 训练时模型健康的实时监控框架，通过 forward hook 零侵入式采集指标，不影响训练梯度。
 
-包含五大监控模块：
+包含八大监控模块：
 - **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (13 指标)
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
+- **Attn Update** — QK 乘积增量 `Δ₂ = ΔW_q W_kᵗ + W_q ΔW_kᵗ` / `Δ₃ = ΔW_q ΔW_kᵗ` 的谱监控 (每项 3 指标；仅权重，不挂 forward hook)
+- **MLP Update** — MoE 专家 MLP 的参数增量 `ΔW_m`，按 (层 × 专家 × gate/up/down) 分开测再按层汇总 (每层 33 指标；仅权重)
 
 以及一个挂在**优化器**而不是模型上的模块，**始终装上**（无需点名，调用方零改动；上报频率同样受 `monitor_interval` 门控）：
 - **[Optimizer Update](./docs/optim_update.md)** — `optim/update_rms`、`optim/param_rms`、`optim/update_param_ratio`，与 grad norm 并排看
@@ -136,7 +138,7 @@ setup_internal_medicine()
 {monitor_name}/global_{metric_name}                     # 全局聚合指标
 ```
 
-- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health` | `attn_update`
+- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health` | `attn_update` | `mlp_update`
 - `global_idx`: 全局层索引。优先取模块自带的 `layer.layer_number`（0-based 全局编号）；取不到时回退到
   `pp_rank × local_layers + local_idx`。`num_empty_layers_add_in_head > 0` 时所有层号整体偏移该值，看板对号要减掉
 - `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路
@@ -573,6 +575,91 @@ RMSNorm / QK-norm 的可学习 scale 在 QK 电路内部，故折进 `W_q` / `W_
 
 ---
 
+## 八、MLP Update Monitor (mlp_update)
+
+监控 MoE 专家 MLP 的参数增量。记采样间隔 δ 内
+
+```
+ΔW_m^(l,e) = W_m,t^(l,e) − W_m,t−δ^(l,e),     m ∈ {gate, up, down}
+```
+
+`attn_update` 的 MoE 对应物：同样只读权重、不挂 forward hook，基准点是上一次被监控的读数。
+
+**三块矩阵分开算，绝不拼在一起。** 因为它们在 `f_e(x) = W_down[SiLU(W_gate x) ⊙ (W_up x)]` 里
+职能、维度、梯度尺度都不同——gate 控制哪些中间通道被激活，up 生成中间特征，down 把中间特征映射回模型维度。
+拼起来算谱会让尺度大的那块主导结果，也无法定位异常来自哪一块。PaddleFleet 把 gate/up 融合存在
+`weight1 [E, in, 2·inter]` 里，本实现沿**中间维**（最后一维）切成两半，前一半是过 SiLU 的 gate
+（依据 `moe_expert.py` 的 `glu(x): hidden_act(x[0]) * x[1]`）；down 是 `weight2`，单独算。
+
+**归约顺序**：每个 (层, 专家, 矩阵) 三元组各自算完，再在层内对专家汇总，永不跨专家拼矩阵。
+
+| # | 指标 | 键 | 公式 | 粒度 | 含义 |
+|---|------|-----|------|------|------|
+| 1 | `{m}_rel_update_mean` | `mlp_update/layer_{i}/{m}_rel_update_mean` | `mean_e(r_m)`, `r_m = ‖ΔW_m‖_F/(‖W_m‖_F+ε)` | 每层+全局 | 该投影的整体更新水平 |
+| 2 | `{m}_rel_update_median` | 同上 | `median_e(r_m)` | 每层+全局 | 抗异常专家干扰的中心值 |
+| 3 | `{m}_rel_update_p10` / `_p90` | 同上 | `quantile_e(r_m, .1/.9)` | 每层+全局 | 专家间离散程度，`p90−p10` 拉大 = 学习速度不均衡 |
+| 4 | `{m}_rel_update_max` | 同上 | `max_e(r_m)` | 每层+全局 | 捕捉更新突然异常增大的专家 |
+| 5 | `{m}_rel_update_min` | 同上 | `min_e(r_m)` | 每层+全局 | 捕捉几乎不更新的「沉睡专家」 |
+| 6 | `{m}_delta_norm_mean` | 同上 | `mean_e(‖ΔW_m‖_F)` | 每层+全局 | 绝对幅度，看全局尺度漂移（LR / grad scale） |
+| 7 | `{m}_stable_rank_{mean,min,max}` | 同上 | `‖ΔW_m‖_F²/‖ΔW_m‖₂²` | 每层+全局 | 更新是否集中到少数奇异方向 |
+| 8 | `{m}_singular_entropy_{mean,min,max}` | 同上 | `−Σ pᵢ log pᵢ, pᵢ = σᵢ²/Σσⱼ²` | 每层+全局 | 全谱利用率，需 `log_spectrum=True` |
+| 9 | `update_zmax_{max,p90,min}` | `mlp_update/layer_{i}/update_zmax_max` | `S^(l,e) = max_m z(r_m^(l,e))` | 每层+全局 | 专家级汇总分数 |
+| 10 | `shared_{m}_rel_update` | 同上 | `r_m` of shared expert | 每层+全局 | 共享专家，作路由专家的对照组 |
+
+`{m}` 取 `gate` / `up` / `down`。每层 33 个键（开 `log_spectrum` 后 42）。
+
+**专家级汇总分数**用 `max_m z(r_m)` 而不是平均：平均会让某一块矩阵的异常被另两块健康的摊薄，
+而平均原始范数会让尺度最大的那块矩阵决定结论。先在**同层专家间**做标准化把三块拉到同一尺度，
+再对 m 取 max，任意一个投影出问题都不会被吃掉。`_max` 是该层最异常的专家；`_min` 是在三块投影上
+**同时**都低于同侪的专家，是这里能给出的最锐利的沉睡专家读数。
+
+> `update_zmax` 有上界 `(E−1)/√E`（每 rank 32 个本地专家时是 5.48），会饱和——它是异常探测器，不是幅值计。
+> 另外若某块矩阵在专家间完全没有差异（如整块零更新），其 z 恒为 0，而 S 取 max 会被 0 托住，
+> 此时 `update_zmax_min` 失效；真实训练中三块都有离散度，不会触发，但看到它长期恰好为 0 要想到这个退化情况。
+
+**`σ₁/‖ΔW‖_F` 没有单独记**：它恒等于 `1/√stable_rank`，是纯派生量。
+
+配置参数：
+
+- `sample_interval` (默认 `None`)：采样间隔 δ，`None` 时用全局 `monitor_interval`。
+- `log_spectrum` (默认 `False`)：是否算奇异值熵。这是唯一需要完整特征分解的指标。
+- `spectrum_interval` (默认 `1`)：谱走的更粗的时钟——相对更新量每个采样点都算，谱每
+  `spectrum_interval` 个采样点算一次。
+
+成本（实测，4B-A500M 形状，每 EP rank 32 专家，`weight1 [32,512,1024]` + `weight2 [32,512,512]`，单卡 H800）：
+
+```
+范数 + 幂迭代 σ₁          11.3 ms/层  →  0.20 s / 18 层     ← 默认档
+完整 Gram + eigvalsh      500.9 ms/层 →  9.02 s / 18 层     ← log_spectrum=True
+基准快照显存              48 MB/层    →  0.84 GB / 18 层    （fp32 会翻倍到 1.69 GB）
+```
+
+`σ₁` 走幂迭代而非特征分解，因为 stable rank 只需要 `σ₁`。收敛速度是 `(σ₂/σ₁)^(2k)`，30 次迭代下
+`σ₂/σ₁ = 0.25` 的秩主导更新精确到 5e-8，`σ₂/σ₁ = 0.99` 的平谱更新 `σ₁` 差约 1.2%、stable rank 差约 2.4%。
+不准的恰好是 stable rank 很大、精确值不改变判读的那一档；准的恰好是要检测的坍缩。误差单向偏低，
+因此 stable rank 偏高。
+
+两个必须知道的局限：
+
+- 基准快照按参数原 dtype 克隆，bf16 权重下 ΔW 相对「可读到的东西」是精确的，但被量化在 bf16 网格上：
+  **小于权重量级约 2⁻⁹ 的更新看不见，读出来就是 `r = 0`**。所以「沉睡专家」的准确含义是
+  「在 δ 步内、在可表示权重上没动」，δ 越大越可靠。要突破需读优化器的 fp32 master weight。
+- `_mean` / `_min` / `_max` 跨 EP rank 归约精确（每 rank 专家数整除），但 **`_median` / `_p10` / `_p90`
+  以及 `update_zmax_*` 落到日志里的是各 rank 的值再平均，不是全局分位数**；标准化也是相对本 rank 的分片。
+
+> **ΔW 小不等于功能没变。** 专家收到的 token 数不同，更新小可能只是路由给它的 token 少。
+> 请对着 `moe_health` 已有的路由负载分布一起读：`assignment_load_cv`、`assignment_load_min_frac`、
+> `assignment_load_max_min_ratio`、`gate_mass_*`，本 monitor 不重复实现这些。
+> 真正的功能漂移度量（固定 probe batch 上的专家输出位移 `D_e`）需要把旧权重留在显存里再跑一次
+> expert forward，超出纯权重探针的范围，未实现。
+
+> 时序约束：快照必须在 **step begin** 读。开启 `offline_quant_expert_weight` 时
+> `FP8QuantWeightCallback.on_step_begin` 会清掉 bf16 专家权重，所以本 monitor 的采集入口是
+> `collect_expert_norms()`——那是 `InternalMedicineCallback.on_step_begin` 的契约方法名（不是描述），
+> 且该 callback 注册在 FP8 callback 之前。放到 step end 会读到已清空的存储。
+
+---
+
 ## 基础设施
 
 ### TrainingLogs
@@ -714,6 +801,13 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **AttnUpdate** | `delta3_norm` | `‖Δ₃‖_F` | mean | 二阶耦合项幅度，应远小于 `delta2_norm` |
 | **AttnUpdate** | `delta3_stable_rank` | `‖Δ₃‖_F²/‖Δ₃‖₂²` | mean | Q/K 更新耦合的 top-1 主导程度 |
 | **AttnUpdate** | `delta3_singular_spectrum` | 同上，作用在 Δ₃ 的谱上 | mean | Q/K 更新耦合变 coherent 时下降 |
+| **MLPUpdate** | `{m}_rel_update_mean` | `mean_e(‖ΔW_m‖_F/‖W_m‖_F)` | mean | 该投影整体更新水平，`m`=gate/up/down |
+| **MLPUpdate** | `{m}_rel_update_max` | `max_e(...)` | max | 更新突然异常增大的专家 |
+| **MLPUpdate** | `{m}_rel_update_min` | `min_e(...)` | min | 沉睡专家（注意 bf16 网格下限） |
+| **MLPUpdate** | `{m}_rel_update_p10` / `_p90` | `quantile_e(...)` | mean | 专家间离散度；跨 rank 是近似 |
+| **MLPUpdate** | `{m}_stable_rank_mean` | `‖ΔW_m‖_F²/‖ΔW_m‖₂²` | mean | 更新是否集中到少数方向 |
+| **MLPUpdate** | `update_zmax_max` | `max_e max_m z(r_m)` | max | 层内最异常专家，上界 `(E−1)/√E` |
+| **MLPUpdate** | `shared_{m}_rel_update` | `r_m` of shared expert | mean | 路由专家的对照组 |
 | **Optim** | `update_rms` | `sqrt(mean((θ_new−θ_old)²))` | 已全局归约 | 本 step 参数更新幅度 (始终装上, 受 monitor_interval 门控) |
 | **Optim** | `param_rms` | `sqrt(mean(θ_new²))` | 已全局归约 | 更新后参数尺度 (始终装上, 受 monitor_interval 门控) |
 | **Optim** | `update_param_ratio` | `update_rms / param_rms` | 已全局归约 | trust ratio, ~1e-3 健康 (始终装上, 受 monitor_interval 门控) |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ setup_internal_medicine()
 | 16 | `load_cv` | `moe_health/.../load_cv` | `std(tokens) / mean(tokens)` | 每层+全局 | 专家负载变异系数 (均衡=0) |
 | 17 | `load_balance_entropy_norm` | `moe_health/.../load_balance_entropy_norm` | `H(p) / log(E)` | 每层+全局 | 归一化负载熵 (均衡=1, 坍缩=0) |
 | 18 | `load_effective_experts` | `moe_health/.../load_effective_experts` | `exp(H)` | 每层+全局 | 有效专家数 (均衡=E, 坍缩=1) |
+| 19 | `expert_gate_stable_rank_mean` | `moe_health/.../expert_gate_stable_rank_mean` | `mean_e(‖W_g‖_F² / ‖W_g‖_2²)` | 每层+全局 | 路由专家 SwiGLU 门控矩阵谱宽度均值 |
+| 20 | `expert_gate_stable_rank_min` | `moe_health/.../expert_gate_stable_rank_min` | `min_e(...)` | 每层+全局 | 最先塌缩的专家 (秩退化预警) |
+| 21 | `expert_gate_stable_rank_max` | `moe_health/.../expert_gate_stable_rank_max` | `max_e(...)` | 每层+全局 | 谱最宽的专家 (专家分化程度) |
+| 22 | `expert_gate_singular_entropy_mean` | `moe_health/.../expert_gate_singular_entropy_mean` | `mean_e(-Σ pᵢ log pᵢ), pᵢ = σᵢ/Σσⱼ` | 每层+全局 | 门控矩阵整谱利用率均值 |
+| 23 | `expert_gate_singular_entropy_min` | `moe_health/.../expert_gate_singular_entropy_min` | `min_e(...)` | 每层+全局 | 全谱枯竭最严重的专家 |
+| 24 | `expert_gate_singular_entropy_max` | `moe_health/.../expert_gate_singular_entropy_max` | `max_e(...)` | 每层+全局 | 全谱最均匀的专家 |
+| 25 | `shared_gate_stable_rank` | `moe_health/.../shared_gate_stable_rank` | `‖W_g‖_F² / ‖W_g‖_2²` | 每层+全局 | 共享专家门控矩阵谱宽度 |
+| 26 | `shared_gate_singular_entropy` | `moe_health/.../shared_gate_singular_entropy` | `-Σ pᵢ log pᵢ` | 每层+全局 | 共享专家门控矩阵全谱利用率 |
+
+> 19-26 针对的是**专家 MLP 的 SwiGLU 门控投影** (`fc1` 前一半输出，即经过 SiLU 的那一半)，不是 router 的 `gate.weight`。
+> 奇异值经 Gram 矩阵特征分解得到 (`W Wᵀ` 或 `WᵀW` 取较小方阵)，比 `svdvals` 快约 40 倍；路由专家与共享专家的 Gram 拼成一个批次求解，避免 cuSOLVER 因批次形状变化重建 workspace。
+> 随机初始化下 stable rank ≈ `mn/(√m+√n)²` 而非 `min(m,n)`（方阵约为 `n/4`），所以初值偏大是正常基线，有意义的是相对基线的下降幅度。
 
 > **注**: 指标 14-18 (`load_*`) 在满足以下**任一**条件时输出, 优先使用前者:
 > 1. `global_aux_loss` 已开启 (`get_aux_loss_coeff("global_aux_loss") > 0`): 复用
@@ -504,7 +516,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 
 ## 附录: 完整指标速查表
 
-共 50 个指标键 (13 MoE + 9 QK + 21 MassiveAct + 7 PLE)。
+共 82 个指标键 (26 MoE + 10 QK + 21 MassiveAct + 7 PLE + 15 VHA + 3 Optim)。
 
 | Monitor | 指标 | 公式 | SmoothedValue 模式 | 健康信号 |
 |---------|------|------|--------------------|----------|
@@ -526,6 +538,14 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **MoE** | `load_cv` | `std/mean(tokens)` | mean | 越接近 0 越均衡 (global_aux_loss 或 expert_bias) |
 | **MoE** | `load_balance_entropy_norm` | `H(p)/log(E)` | mean | 越接近 1 越均衡 (global_aux_loss 或 expert_bias) |
 | **MoE** | `load_effective_experts` | `exp(H)` | mean | 越接近专家数 E 越均衡 (global_aux_loss 或 expert_bias) |
+| **MoE** | `expert_gate_stable_rank_mean` | `mean_e(srank(W_g))` | mean | 稳定，不应持续下滑 |
+| **MoE** | `expert_gate_stable_rank_min` | `min_e(srank(W_g))` | min | 不应萎缩 (秩塌缩预警) |
+| **MoE** | `expert_gate_stable_rank_max` | `max_e(srank(W_g))` | max | 上升 = 专家分化 |
+| **MoE** | `expert_gate_singular_entropy_mean` | `mean_e(H(σ))` | mean | 接近 `log k` |
+| **MoE** | `expert_gate_singular_entropy_min` | `min_e(H(σ))` | min | 不应显著低于均值 |
+| **MoE** | `expert_gate_singular_entropy_max` | `max_e(H(σ))` | max | 接近 `log k` |
+| **MoE** | `shared_gate_stable_rank` | `srank(W_g)` | mean | 稳定 |
+| **MoE** | `shared_gate_singular_entropy` | `H(σ)` | mean | 接近 `log k` |
 | **QK** | `max` | `max(QK^T/√d)` | max | 不应暴增 |
 | **QK** | `mean` | `mean(logits)` | mean | 稳定 |
 | **QK** | `entropy_avg` | `-Σ(p log p)` avg | mean | 适中 |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ setup_internal_medicine()
 {monitor_name}/global_{metric_name}                     # 全局聚合指标
 ```
 
-- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health`
+- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health` | `attn_update`
 - `global_idx`: 全局层索引。优先取模块自带的 `layer.layer_number`（0-based 全局编号）；取不到时回退到
   `pp_rank × local_layers + local_idx`。`num_empty_layers_add_in_head > 0` 时所有层号整体偏移该值，看板对号要减掉
 - `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路
@@ -464,6 +464,97 @@ premix 的指标集由权重形状决定（方阵 → 10~12；非方阵 → 12~1
 
 ---
 
+## 七、Attn Update Monitor (attn_update)
+
+监控 QK 乘积增量（arXiv:2606.28116 §3.4）。记采样间隔 δ 内 `ΔW = W_t − W_{t−δ}`，
+QK 乘积的变化可精确拆成 `Δ₁ = Δ₂ + Δ₃`，本 monitor 监控其中两项：
+
+```
+Δ₂ = ΔW_q W_kᵀ + W_q ΔW_kᵀ = [ΔW_q, W_q][W_k, ΔW_k]ᵀ     (一阶，秩 ≤ 2·head_dim)
+Δ₃ = ΔW_q ΔW_kᵀ                                            (二阶，秩 ≤ head_dim)
+```
+
+**Δ₁ 故意不监控**：论文 Eq (5) 给出 `‖Δ₂‖_F = O(‖W‖_F‖ΔW‖_F)` 而 `‖Δ₃‖_F = O(‖ΔW‖_F²)`，
+早中期 `‖ΔW‖_F ≪ ‖W‖_F` 时 `Δ₁ ≈ Δ₂`，再花一个完整的 `2·head_dim` 核去重复测 Δ₂ 不值。
+**Δ₃ 保留**是因为它是唯一活在 Q/K 更新**耦合**空间里的项（论文：`can become visible before spectral
+concentration is obvious in the separate factor updates ΔW_q, ΔW_k`）。但要清楚它比 Δ₂ **晚**报警
+（论文实测排序 `Δ₁ ≈ Δ₂ < Δ₃ < ΔW`），买到的是一个新维度加一级便宜的确认，不是更早的预警。
+
+当因子宽度小于 `hidden` 时把谱计算挪到 thin-QR 核 `R_A R_Bᵀ` 上，`hidden × hidden` 的稠密乘积从不物化。
+
+三个指标都只是 `σ²` 的函数，所以用 Gram + `eigvalsh` 取谱，并且**所有层所有项拼成一次批量调用**
+（先按 shape 分桶——Δ₂ 的核是 `2·head_dim` 宽、Δ₃ 是 `head_dim`，只有同形状能共享一次批量求解；
+再按 `_MAX_BATCH_BYTES` 分块，`hidden=1024` 时每批 64 个）。
+
+实测（H 系列单卡，`hidden=1024`、`head_dim=128`、18 层 × 1 head）：
+
+- 逐层 `svd` 2054 ms → 逐层 Gram+`eigvalsh` 420 ms → 批量 Gram+`eigvalsh` 277 ms
+- 只算 Δ₂ 138 ms；只算 Δ₃ 72 ms（Δ₂ 的 0.52×）；两项分桶合算 211 ms
+- 即**加上 Δ₃ 是 ~1.5×，不是 ~1.1×** —— thin-QR 是 `O(d·r²)`，在这个尺寸上盖过了 `O(r³)` 的特征分解，
+  所以核宽减半并不等于成本降到 1/8
+- 端到端一个采样步 ~0.7 s，δ=10 摊到 4.0 s 的训练步上约 **1.8%**（只有 Δ₂ 时约 1.2%）
+
+绝对值会随 GPU 争用浮动约 2×，看比例即可。
+
+> Gram 平方会损失 `σ < sqrt(eps)·σ_max` 那部分奇异值的精度，但 α=2 下这些分量权重为 ~0；
+> 单元测试把三个指标都对着 float64 稠密 SVD 钉住，相对误差 ≤ 3e-5。若把 `spectrum_alpha` 调小到 1，
+> 小奇异值权重变大，这条论证不再成立。
+
+本 monitor **不注册 forward hook**：它在 `step()` 边界直接读 QK 权重，把上一次读数作为基准点，
+因此采样间隔 δ = 本 monitor 自己的间隔（`sample_interval`，未设置时回退到 `monitor_interval`），
+且**第一个采样步只建立基准点、不产出指标**。
+
+| # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
+|---|------|--------|------|------|----------|
+| 1 | `delta2_norm` | `attn_update/layer_{i}/delta2_norm` | `‖Δ₂‖_F` | 每层+全局 | 一阶增量的整体幅度 |
+| 2 | `delta2_stable_rank` | `attn_update/layer_{i}/delta2_stable_rank` | `‖Δ₂‖_F² / ‖Δ₂‖₂²` | 每层+全局 | top-1 奇异值主导程度的倒数 |
+| 3 | `delta2_singular_spectrum` | `attn_update/layer_{i}/delta2_singular_spectrum` | `S₂ = exp(−Σ pᵢ log pᵢ), pᵢ = σᵢ²/Σσⱼ²` | 每层+全局 | 全谱有效秩，论文中最灵敏的坍缩前兆 |
+| 4 | `delta3_norm` | `attn_update/layer_{i}/delta3_norm` | `‖Δ₃‖_F` | 每层+全局 | 二阶耦合项幅度，正常时应远小于 `delta2_norm` |
+| 5 | `delta3_stable_rank` | `attn_update/layer_{i}/delta3_stable_rank` | `‖Δ₃‖_F² / ‖Δ₃‖₂²` | 每层+全局 | Q/K 更新耦合的 top-1 主导程度 |
+| 6 | `delta3_singular_spectrum` | `attn_update/layer_{i}/delta3_singular_spectrum` | 同上，作用在 Δ₃ 的谱上 | 每层+全局 | Q/K 更新耦合变得 coherent 时下降 |
+
+`resolve_qk_factors` 只从权重重建每个 head 的 QK 电路，支持四种布局，按从特殊到通用的顺序匹配：
+
+- **DSv4-hybrid**：`linear_q_down_proj → q_layernorm → linear_q_up_proj`，`linear_kv_proj → kv_layernorm`，
+  单个共享 KV head。
+- **MLA**：`q_proj` 或 `q_a_proj → q_a_layernorm → q_b_proj`；K 只经由
+  `kv_a_proj_with_mqa → kv_a_layernorm → kv_b_proj` 依赖 hidden。只有 NoPE 半边参与内容项，
+  所以这里的电路宽度是 `qk_nope_head_dim` 而非 `q_head_dim`。切片先做、再与 latent 相乘，
+  否则完整乘积是 `[hidden, num_heads × q_head_dim]`，在 128 head 上会是数百 MB。
+- **融合 `qkv_proj` / `linear_qkv`**：输出按 KV head 分组为 `Q|(gate)|K|V`，分组算术会先与真实权重宽度
+  对账，不符就整层跳过而不是错切。
+- **独立 `q_proj` / `k_proj`**（含 GQA/MQA、VHA）：head 数从权重宽度推出，因此 TP 分片下每卡报自己实际持有的 head。
+
+RMSNorm / QK-norm 的可学习 scale 在 QK 电路内部，故折进 `W_q` / `W_k`（per-head 与 per-layer 两种形状都认，
+形状对不上时宁可不折也不猜）；输入相关的 `1/rms` 不是权重、不参与。不匹配任何布局的层直接跳过，不声明指标。
+同一模型里混用布局时电路宽度可能不同，`_spectrum_metrics_over_pairs` 会先按 shape 分桶再各自批量求解。
+
+配置参数：
+
+- `sample_interval` (默认 `None`)：本 monitor 的采样间隔 δ，单位训练步；`None` 时用全局 `monitor_interval`。
+  单独设置的意义在于这里的成本是每层每次采样一次特征分解，与 forward 无关，可以比 hook 类 monitor 采得更稀。
+  另外 δ 不宜太小：论文 Observation 1 靠的是窗口内累积（coherent 分量按 `n` 线性增长、残差按 `√n`），
+  δ=1 时 n=1，信号会被噪声压住。
+- `num_heads_monitored` (默认 `1`)：每层取前若干 head，逐层指标为这些 head 的均值。每个 head 需要两次
+  对称特征分解（Δ₂ 的 `2·head_dim` 核 + Δ₃ 的 `head_dim` 核），成本随该值线性增长。
+- `spectrum_alpha` (默认 `2.0`)：`S_α` 的权重指数，论文推荐 2（即 "singular spectrum"）。
+
+> 判读方式：**故障凭证是曲线相对健康基线的偏移，而不是低秩本身**——健康训练的更新本就带低秩结构
+> （LoRA / GaLore / Muon 正是利用这一点），所以需要与 baseline run 对比，而非单看绝对值。
+
+> **论文的绝对提前量不可直接搬用。** 论文报的「Δ₂ 比 loss 发散早 ~17,000 步、比 ΔW 谱早 ~8,000 步」
+> 是在 plain MHA 上测的。§6 Limitations 明确说 MLA/GQA/MQA/DSA 的 QK 算子被压缩投影和共享 head 中介，
+> `Δ₂ 代理需要为每个变体重新推导`，检测阈值是 variant-specific 的。本实现的代数对任意 `W_q`/`W_k`
+> 都精确（`A_tB_tᵀ − ABᵀ = ΔA·Bᵀ + A·ΔBᵀ + ΔA·ΔBᵀ` 是恒等式，不要求它们是原始参数），
+> 但 Observation 1 的机制是在**参数级** ΔW 上陈述的；MLA/DSv4-hybrid 下 `W_q^eff` 是多个参数的复合，
+> 低精度 FA 打进各参数更新的 coherent 结构穿过 latent 之后还剩多少，论文没有回答。
+> 结论：只与同架构的 baseline run 对比，不要拿论文数字当阈值。
+
+> 尚未实现：§3.2 的 raw ΔW 谱指标（`ΔW_q` / `ΔW_k` 各自的 norm / stable rank / singular spectrum）。
+> 它是比 Δ₂ 晚约 8,000 步的**第二级确认信号**，缺了它时 Δ₂ 单独波动无法交叉验证。
+
+---
+
 ## 基础设施
 
 ### TrainingLogs
@@ -516,7 +607,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 
 ## 附录: 完整指标速查表
 
-共 82 个指标键 (26 MoE + 10 QK + 21 MassiveAct + 7 PLE + 15 VHA + 3 Optim)。
+共 88 个指标键 (26 MoE + 10 QK + 21 MassiveAct + 7 PLE + 15 VHA + 6 AttnUpdate + 3 Optim)。mHC 的指标随 hc 模块数量而变，见上文单独章节。
 
 | Monitor | 指标 | 公式 | SmoothedValue 模式 | 健康信号 |
 |---------|------|------|--------------------|----------|
@@ -599,6 +690,12 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **VHA** | `premix_group_div_ratio` | `mean‖W_g−W_g'‖²/mean‖W_g−I‖²` | mean | 0=各组同一变换, 2=完全独立 |
 | **VHA** | `premix_sigma_max` | `σ_max(W)` | max | premix 谱范数 (需 use_vha_premix) |
 | **VHA** | `premix_orth_dev` | `‖WᵀW − I‖_F` | mean | 仅非方阵 premix (正交初始化) |
+| **AttnUpdate** | `delta2_norm` | `‖Δ₂‖_F` | mean | 一阶 QK 增量幅度 |
+| **AttnUpdate** | `delta2_stable_rank` | `‖Δ₂‖_F²/‖Δ₂‖₂²` | mean | 偏离健康基线 = 谱坍缩前兆 |
+| **AttnUpdate** | `delta2_singular_spectrum` | `S₂ = exp(-Σ p log p), p=σ²/Σσ²` | mean | 同上，全谱、更灵敏 |
+| **AttnUpdate** | `delta3_norm` | `‖Δ₃‖_F` | mean | 二阶耦合项幅度，应远小于 `delta2_norm` |
+| **AttnUpdate** | `delta3_stable_rank` | `‖Δ₃‖_F²/‖Δ₃‖₂²` | mean | Q/K 更新耦合的 top-1 主导程度 |
+| **AttnUpdate** | `delta3_singular_spectrum` | 同上，作用在 Δ₃ 的谱上 | mean | Q/K 更新耦合变 coherent 时下降 |
 | **Optim** | `update_rms` | `sqrt(mean((θ_new−θ_old)²))` | 已全局归约 | 本 step 参数更新幅度 (始终装上, 受 monitor_interval 门控) |
 | **Optim** | `param_rms` | `sqrt(mean(θ_new²))` | 已全局归约 | 更新后参数尺度 (始终装上, 受 monitor_interval 门控) |
 | **Optim** | `update_param_ratio` | `update_rms / param_rms` | 已全局归约 | trust ratio, ~1e-3 健康 (始终装上, 受 monitor_interval 门控) |

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ setup_internal_medicine()
 | 19 | `expert_gate_stable_rank_mean` | `moe_health/.../expert_gate_stable_rank_mean` | `mean_e(‖W_g‖_F² / ‖W_g‖_2²)` | 每层+全局 | 路由专家 SwiGLU 门控矩阵谱宽度均值 |
 | 20 | `expert_gate_stable_rank_min` | `moe_health/.../expert_gate_stable_rank_min` | `min_e(...)` | 每层+全局 | 最先塌缩的专家 (秩退化预警) |
 | 21 | `expert_gate_stable_rank_max` | `moe_health/.../expert_gate_stable_rank_max` | `max_e(...)` | 每层+全局 | 谱最宽的专家 (专家分化程度) |
-| 22 | `expert_gate_singular_entropy_mean` | `moe_health/.../expert_gate_singular_entropy_mean` | `mean_e(-Σ pᵢ log pᵢ), pᵢ = σᵢ/Σσⱼ` | 每层+全局 | 门控矩阵整谱利用率均值 |
+| 22 | `expert_gate_singular_entropy_mean` | `moe_health/.../expert_gate_singular_entropy_mean` | `mean_e(-Σ pᵢ log pᵢ), pᵢ = σᵢ²/Σσⱼ²` | 每层+全局 | 门控矩阵整谱利用率均值 |
 | 23 | `expert_gate_singular_entropy_min` | `moe_health/.../expert_gate_singular_entropy_min` | `min_e(...)` | 每层+全局 | 全谱枯竭最严重的专家 |
 | 24 | `expert_gate_singular_entropy_max` | `moe_health/.../expert_gate_singular_entropy_max` | `max_e(...)` | 每层+全局 | 全谱最均匀的专家 |
 | 25 | `shared_gate_stable_rank` | `moe_health/.../shared_gate_stable_rank` | `‖W_g‖_F² / ‖W_g‖_2²` | 每层+全局 | 共享专家门控矩阵谱宽度 |
-| 26 | `shared_gate_singular_entropy` | `moe_health/.../shared_gate_singular_entropy` | `-Σ pᵢ log pᵢ` | 每层+全局 | 共享专家门控矩阵全谱利用率 |
+| 26 | `shared_gate_singular_entropy` | `moe_health/.../shared_gate_singular_entropy` | `-Σ pᵢ log pᵢ, pᵢ = σᵢ²/Σσⱼ²` | 每层+全局 | 共享专家门控矩阵全谱利用率 |
 
 > 19-26 针对的是**专家 MLP 的 SwiGLU 门控投影** (`fc1` 前一半输出，即经过 SiLU 的那一半)，不是 router 的 `gate.weight`。
 > 奇异值经 Gram 矩阵特征分解得到 (`W Wᵀ` 或 `WᵀW` 取较小方阵)，比 `svdvals` 快约 40 倍；路由专家与共享专家的 Gram 拼成一个批次求解，避免 cuSOLVER 因批次形状变化重建 workspace。
@@ -650,11 +650,11 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **MoE** | `expert_gate_stable_rank_mean` | `mean_e(srank(W_g))` | mean | 稳定，不应持续下滑 |
 | **MoE** | `expert_gate_stable_rank_min` | `min_e(srank(W_g))` | min | 不应萎缩 (秩塌缩预警) |
 | **MoE** | `expert_gate_stable_rank_max` | `max_e(srank(W_g))` | max | 上升 = 专家分化 |
-| **MoE** | `expert_gate_singular_entropy_mean` | `mean_e(H(σ))` | mean | 接近 `log k` |
-| **MoE** | `expert_gate_singular_entropy_min` | `min_e(H(σ))` | min | 不应显著低于均值 |
-| **MoE** | `expert_gate_singular_entropy_max` | `max_e(H(σ))` | max | 接近 `log k` |
+| **MoE** | `expert_gate_singular_entropy_mean` | `mean_e(H(σ²))` | mean | 初始约 `0.92·log k`，不应持续下滑 |
+| **MoE** | `expert_gate_singular_entropy_min` | `min_e(H(σ²))` | min | 不应显著低于均值 |
+| **MoE** | `expert_gate_singular_entropy_max` | `max_e(H(σ²))` | max | 上限 `log k`，平谱时取等 |
 | **MoE** | `shared_gate_stable_rank` | `srank(W_g)` | mean | 稳定 |
-| **MoE** | `shared_gate_singular_entropy` | `H(σ)` | mean | 接近 `log k` |
+| **MoE** | `shared_gate_singular_entropy` | `H(σ²)` | mean | 初始约 `0.96·log k`，不应持续下滑 |
 | **QK** | `max` | `max(QK^T/√d)` | max | 不应暴增 |
 | **QK** | `mean` | `mean(logits)` | mean | 稳定 |
 | **QK** | `entropy_avg` | `-Σ(p log p)` avg | mean | 适中 |

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -7,6 +7,7 @@ from .base import PaddleProbe
 from .gather import install_gather_fn
 from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_massive_activation_monitor
 from .mhc_monitor import PaddleMHCHealthMonitor, setup_mhc_monitor
+from .mlp_update_monitor import PaddleMLPUpdateMonitor, setup_mlp_update_monitor
 from .moe_monitor import PaddleMoEMonitor, setup_moe_monitor
 from .qk_monitor import PaddleQKStatsMonitor, setup_qk_monitor
 from .vha_monitor import PaddleVHAHealthMonitor, setup_vha_monitor
@@ -20,6 +21,7 @@ _MONITOR_MAP = {
     "mhc_health": setup_mhc_monitor,
     "vha_health": setup_vha_monitor,
     "attn_update": setup_attn_update_monitor,
+    "mlp_update": setup_mlp_update_monitor,
 }
 
 _MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
@@ -129,4 +131,6 @@ __all__ = [
     "setup_vha_monitor",
     "PaddleAttnUpdateMonitor",
     "setup_attn_update_monitor",
+    "PaddleMLPUpdateMonitor",
+    "setup_mlp_update_monitor",
 ]

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from .attn_update_monitor import PaddleAttnUpdateMonitor, setup_attn_update_monitor
 from .base import PaddleProbe
 from .gather import install_gather_fn
 from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_massive_activation_monitor
@@ -18,6 +19,7 @@ _MONITOR_MAP = {
     "massive_act": setup_massive_activation_monitor,
     "mhc_health": setup_mhc_monitor,
     "vha_health": setup_vha_monitor,
+    "attn_update": setup_attn_update_monitor,
 }
 
 _MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
@@ -106,4 +108,6 @@ __all__ = [
     "setup_mhc_monitor",
     "PaddleVHAHealthMonitor",
     "setup_vha_monitor",
+    "PaddleAttnUpdateMonitor",
+    "setup_attn_update_monitor",
 ]

--- a/src/internal_medicine/backends/paddlefleet/attn_update_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/attn_update_monitor.py
@@ -1,0 +1,705 @@
+"""Attention update monitoring for PaddleFleet.
+
+QK-product increment monitor from "Mechanism-Driven Monitors for Preemptive
+Detection of LLM Training Instability" (arXiv:2606.28116) Section 3.4.
+
+With the query/key factors sampled at two steps ``t`` and ``t - delta``, writing
+``dWq = Wq_t - Wq_base``, ``dWk = Wk_t - Wk_base`` and evaluating the
+un-subscripted factors at the base point ``t - delta``:
+
+    delta1 = Wq_t Wk_t^T - Wq_base Wk_base^T = delta2 + delta3
+    delta2 = dWq Wk^T + Wq dWk^T        (first order)
+    delta3 = dWq dWk^T                  (second order)
+
+Both monitored terms factorise exactly (eq. 4) — ``delta2 = [dWq, Wq][Wk, dWk]^T``
+with factors ``[d, 2*head_dim]``, ``delta3 = dWq dWk^T`` with factors
+``[d, head_dim]`` — so when the factor width is below ``d`` their nonzero
+singular values are those of the small core ``R_A R_B^T`` built from thin QR
+factors and the ``d x d`` product is never materialised.
+
+``delta1`` is deliberately not monitored: eq. (5) gives
+``||delta2||_F = O(||W||_F ||dW||_F)`` against ``||delta3||_F = O(||dW||_F^2)``,
+so the early-to-mid regime ``||dW||_F << ||W||_F`` makes ``delta1 ~= delta2``,
+and re-measuring it would cost another full ``2*head_dim`` core. ``delta3`` is
+kept because it is the only term living in Q/K update-*coupling* space. Its core
+is half as wide, but that buys less than the ``r^3`` eigensolve scaling suggests:
+measured on one H-series GPU at ``hidden=1024, head_dim=128`` over 18 layers,
+delta2 alone is 138 ms, delta3 alone 72 ms (0.52x), and both bucketed into one
+driver call 211 ms — so adding delta3 costs ~1.5x, not ~1.1x. The thin QRs are
+``O(d r^2)`` and dominate the ``O(r^3)`` eigensolve at these shapes.
+
+Per layer and per term this reports the Frobenius norm, the stable rank
+``||.||_F^2 / ||.||_2^2`` and the singular-spectrum effective rank
+``exp(-sum_i p_i log p_i)`` with ``p_i = sigma_i^alpha / sum_j sigma_j^alpha``
+(alpha = 2, the value the paper reports as the sensitivity/noise trade-off).
+
+All three metrics are functions of ``sigma^2`` only, so the spectrum comes from
+``eigvalsh`` on the Gram matrix and every layer goes through one batched call.
+The decomposition is ~99% of the cost; snapshotting, stacking and the two
+matmuls together measure ~10 ms. Same-run comparison at
+``d = 2*head_dim = 1024`` over 18 layers, alongside a live training job:
+looped ``svd`` 2054 ms, looped Gram+``eigvalsh`` 420 ms, batched
+Gram+``eigvalsh`` 277 ms. Absolute numbers move by ~2x with GPU contention, so
+treat them as ratios.
+
+The fault certificate is the deviation of these curves from a healthy baseline
+run, not low rank on its own: healthy updates already carry low-rank structure
+that LoRA/GaLore/Muon exploit. The paper's absolute lead times are measured on
+plain MHA and do not transfer: Section 6 notes that for MLA/GQA/MQA the QK
+operator is mediated by compression projections and shared heads, so detection
+thresholds stay variant-specific even though the algebra below is exact.
+
+``resolve_qk_factors`` recovers the per-head circuit from weights alone for four
+layouts — DSv4-hybrid, MLA (content/NoPE half only), a fused ``qkv_proj``, and
+independent q/k projections — and skips any layer it cannot read. Adding a
+layout means adding one resolver to ``_LAYOUT_RESOLVERS``.
+"""
+
+import logging
+import math
+from collections import defaultdict
+
+import paddle
+
+from .base import PaddleProbe
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
+
+logger = logging.getLogger(__name__)
+
+# Spectral quantities computed per monitored term (Section 3.2).
+_SPECTRUM_KEYS = ("norm", "stable_rank", "singular_spectrum")
+# Terms of the bilinear decomposition that are actually monitored. delta1 is
+# omitted on purpose: eq. (5) gives ||delta2||_F = O(||W||_F ||dW||_F) against
+# ||delta3||_F = O(||dW||_F^2), so in the early-to-mid regime delta1 ~= delta2
+# and it would cost a full 2*head_dim core to re-measure delta2.
+TERM_NAMES = ("delta2", "delta3")
+METRIC_NAMES = tuple(f"{term}_{key}" for term in TERM_NAMES for key in _SPECTRUM_KEYS)
+
+# Cap on the transient stacked product / Gram tensors of one batched call.
+_MAX_BATCH_BYTES = 256 << 20
+
+
+def _squared_singular_values(a, b):
+    """``sigma^2`` of ``a @ b.T`` for ``[..., d, r]`` factor pairs.
+
+    ``sigma^2`` are the eigenvalues of the Gram matrix, so one symmetric
+    ``eigvalsh`` replaces the SVD. Squaring costs precision on singular values
+    below ``sqrt(eps) * sigma_max``, but every metric here weights by
+    ``sigma^2`` (alpha = 2), so those components carry no weight — the unit
+    tests pin all three against a dense float64 SVD to <= 3e-5 relative.
+
+    When ``r < d`` the thin-QR identity ``a b^T = Qa (Ra Rb^T) Qb^T`` shrinks
+    the work to the ``[r, r]`` core and the ``[d, d]`` product is never formed;
+    at ``r >= d`` the core is no smaller, so the two QRs would be pure overhead.
+    Leading axes are batch axes, which is what keeps this to one kernel launch
+    per chunk instead of one per layer.
+    """
+    d, r = a.shape[-2], a.shape[-1]
+    if r < d:
+        a = paddle.linalg.qr(a, mode="r")
+        b = paddle.linalg.qr(b, mode="r")
+    product = paddle.matmul(a, b, transpose_y=True)
+    gram = paddle.matmul(product, product, transpose_y=True)
+    return paddle.linalg.eigvalsh(gram).clip(min=0.0)
+
+
+def _spectrum_metrics(squared, alpha=2.0):
+    """Frobenius norm, stable rank and singular-spectrum effective rank.
+
+    ``squared`` holds ``sigma^2`` along the last axis; leading axes are batch
+    axes and are preserved in every returned tensor. Keys are the bare
+    :data:`_SPECTRUM_KEYS`; the caller prefixes them with the term it measured.
+    """
+    total = paddle.sum(squared, axis=-1)
+    weights = squared if alpha == 2.0 else squared ** (alpha / 2.0)
+    p = (weights / paddle.sum(weights, axis=-1, keepdim=True).clip(min=1e-24)).clip(min=1e-12)
+    return {
+        "norm": paddle.sqrt(total),
+        "stable_rank": total / paddle.max(squared, axis=-1).clip(min=1e-24),
+        "singular_spectrum": paddle.exp(-paddle.sum(p * p.log(), axis=-1)),
+    }
+
+
+def _spectrum_metrics_for_shape(pairs, alpha=2.0):
+    """Metrics for equally-shaped ``(a, b)`` factor pairs, batched into few calls.
+
+    Chunked so the transient stacked product and Gram stay near
+    ``_MAX_BATCH_BYTES`` each; at ``d = 1024`` that is 64 pairs per call. The
+    chunks are made equal-sized rather than "fill then remainder" because
+    cuSOLVER re-initializes its eigensolver workspace whenever the batch size
+    changes between calls, which a short trailing chunk would trigger every step.
+    """
+    d = pairs[0][0].shape[-2]
+    budget = max(1, _MAX_BATCH_BYTES // (d * d * 4))
+    rows = math.ceil(len(pairs) / math.ceil(len(pairs) / budget))
+    chunks = [
+        _spectrum_metrics(
+            _squared_singular_values(
+                paddle.stack([item[0] for item in pairs[start : start + rows]]),
+                paddle.stack([item[1] for item in pairs[start : start + rows]]),
+            ),
+            alpha,
+        )
+        for start in range(0, len(pairs), rows)
+    ]
+    if len(chunks) == 1:
+        return chunks[0]
+    return {key: paddle.concat([chunk[key] for chunk in chunks]) for key in _SPECTRUM_KEYS}
+
+
+def _spectrum_metrics_over_pairs(pairs, alpha=2.0):
+    """Metrics for ``(a, b)`` factor pairs of possibly differing shapes.
+
+    Only equally-shaped pairs can share a batched call, and the pair list mixes
+    shapes on two axes: a model may mix attention layouts (or head_dims) across
+    layers, and delta3's core is ``head_dim`` wide against delta2's
+    ``2*head_dim``. Pairs are therefore bucketed by shape and the per-bucket
+    results scattered back into the caller's order.
+    """
+    buckets: dict[tuple, list[tuple[int, tuple]]] = defaultdict(list)
+    for position, pair in enumerate(pairs):
+        buckets[(tuple(pair[0].shape), tuple(pair[1].shape))].append((position, pair))
+    if len(buckets) == 1:
+        return _spectrum_metrics_for_shape(pairs, alpha)
+
+    slots: dict[str, list] = {key: [None] * len(pairs) for key in _SPECTRUM_KEYS}
+    for bucket in buckets.values():
+        metrics = _spectrum_metrics_for_shape([pair for _position, pair in bucket], alpha)
+        for offset, (position, _pair) in enumerate(bucket):
+            for key in _SPECTRUM_KEYS:
+                slots[key][position] = metrics[key][offset]
+    return {key: paddle.stack(slots[key]) for key in _SPECTRUM_KEYS}
+
+
+def _weight(module):
+    """``module.weight``, or None when the module is absent or weightless."""
+    return getattr(module, "weight", None) if module is not None else None
+
+
+def _weight_shape(module):
+    weight = _weight(module)
+    return None if weight is None else list(weight.shape)
+
+
+def _fp32(weight):
+    """Detached float32 view of a parameter, for use inside an expression."""
+    return weight.detach().astype("float32")
+
+
+def _frozen(matrix):
+    """Independent copy of a snapshot matrix.
+
+    ``detach()`` shares storage and ``astype()`` is a no-op when the dtype
+    already matches, so a returned slice can alias the live parameter. The base
+    point has to survive the next optimizer step, hence the explicit copy.
+    """
+    return matrix.clone()
+
+
+def _scale_vector(module):
+    """Learnable norm scale as a flat float32 vector, or None."""
+    weight = _weight(module)
+    return None if weight is None else _fp32(weight).reshape([-1])
+
+
+def _fold_scale(matrix, scale, index=0):
+    """Fold a norm scale into the columns of ``matrix`` ``[in, d]``.
+
+    A per-head norm carries ``d`` entries and applies to every head; a per-layer
+    norm covers all heads, so head ``index`` takes its own ``d``-wide slice.
+    Anything else cannot be read as a diagonal on these columns and is dropped
+    rather than guessed at — the scale sits inside the QK circuit, so folding
+    the wrong slice would be worse than folding nothing.
+    """
+    if scale is None:
+        return matrix
+    width = matrix.shape[-1]
+    if scale.shape[0] == width:
+        return matrix * scale.reshape([1, -1])
+    start = index * width
+    if scale.shape[0] >= start + width:
+        return matrix * scale[start : start + width].reshape([1, -1])
+    return matrix
+
+
+def _first_module(attn, names):
+    """First attribute in ``names`` that carries a 2-D ``weight``."""
+    for name in names:
+        module = getattr(attn, name, None)
+        shape = _weight_shape(module)
+        if shape is not None and len(shape) == 2:
+            return module
+    return None
+
+
+def _head_counts(attn):
+    """``(query_heads, kv_heads)`` as seen by this rank; either may be None.
+
+    Prefers the ``*_per_partition`` names so a TP-sharded module reports local
+    counts, which is what the sharded weight widths agree with.
+    """
+
+    def first_int(names):
+        for name in names:
+            value = getattr(attn, name, None)
+            if isinstance(value, int) and value > 0:
+                return value
+        return None
+
+    heads = first_int(("num_attention_heads_per_partition", "num_attention_heads", "n_local_heads"))
+    kv_heads = first_int(("num_query_groups_per_partition", "num_key_value_heads", "num_query_groups"))
+    return heads, kv_heads
+
+
+def _resolve_dsv4_hybrid(attn):
+    """``hidden -> q_down -> q_layernorm -> q_up`` with a single shared KV head.
+
+    K is ``hidden -> kv_proj -> kv_layernorm``, so the per-head circuit is
+    ``(Wqd diag(gq) Wqu_h) (Wkv diag(gk))^T``.
+    """
+    q_down = getattr(attn, "linear_q_down_proj", None)
+    q_up = getattr(attn, "linear_q_up_proj", None)
+    kv = getattr(attn, "linear_kv_proj", None)
+    shapes = [_weight_shape(module) for module in (q_down, q_up, kv)]
+    if any(shape is None or len(shape) != 2 for shape in shapes):
+        return None
+    if shapes[0][-1] != shapes[1][0]:
+        return None
+    head_dim = shapes[2][-1]
+    if head_dim < 1 or shapes[1][-1] % head_dim != 0:
+        return None
+    return {
+        "kind": "dsv4_hybrid",
+        "q_down": q_down,
+        "q_up": q_up,
+        "kv": kv,
+        "q_layernorm": getattr(attn, "q_layernorm", None),
+        "kv_layernorm": getattr(attn, "kv_layernorm", None),
+        "head_dim": head_dim,
+        "num_heads": shapes[1][-1] // head_dim,
+        "num_kv_heads": 1,
+        "heads_per_group": shapes[1][-1] // head_dim,
+    }
+
+
+def _resolve_mla(attn):
+    """MLA latent compression on both sides, with a RoPE/NoPE split of head_dim.
+
+    Q is ``q_proj`` or ``q_a_proj -> q_a_layernorm -> q_b_proj``; K reaches the
+    hidden state only through ``kv_a_proj_with_mqa -> kv_a_layernorm ->
+    kv_b_proj``. Only the NoPE half of each head participates in the content
+    term, so ``head_dim`` here is ``qk_nope_head_dim``.
+    """
+    kv_a = getattr(attn, "kv_a_proj_with_mqa", None)
+    kv_b = getattr(attn, "kv_b_proj", None)
+    q_b = getattr(attn, "q_b_proj", None)
+    q_a = getattr(attn, "q_a_proj", None) if q_b is not None else None
+    if q_b is None:
+        q_b = getattr(attn, "q_proj", None)
+    kv_a_shape, kv_b_shape, q_shape = (_weight_shape(m) for m in (kv_a, kv_b, q_b))
+    if any(shape is None or len(shape) != 2 for shape in (kv_a_shape, kv_b_shape, q_shape)):
+        return None
+    q_a_shape = _weight_shape(q_a)
+    if q_a is not None and (q_a_shape is None or q_a_shape[-1] != q_shape[0]):
+        return None
+    kv_lora_rank = kv_b_shape[0]
+    if not 0 < kv_lora_rank <= kv_a_shape[-1]:
+        return None
+    heads, _ = _head_counts(attn)
+    if heads is None or q_shape[-1] % heads or kv_b_shape[-1] % heads:
+        return None
+    q_head_dim = q_shape[-1] // heads
+    kv_head_width = kv_b_shape[-1] // heads
+    nope = getattr(attn, "qk_nope_head_dim", None)
+    if not isinstance(nope, int) or nope < 1:
+        rope = getattr(attn, "qk_rope_head_dim", None)
+        if not isinstance(rope, int) or rope < 0:
+            rope = kv_a_shape[-1] - kv_lora_rank
+        nope = q_head_dim - rope
+    if not 0 < nope <= min(q_head_dim, kv_head_width):
+        return None
+    return {
+        "kind": "mla",
+        "q_a": q_a,
+        "q_a_layernorm": getattr(attn, "q_a_layernorm", None),
+        "q_b": q_b,
+        "kv_a": kv_a,
+        "kv_a_layernorm": getattr(attn, "kv_a_layernorm", None),
+        "kv_b": kv_b,
+        "kv_lora_rank": kv_lora_rank,
+        "q_head_dim": q_head_dim,
+        "kv_head_width": kv_head_width,
+        "head_dim": nope,
+        "num_heads": heads,
+        "num_kv_heads": heads,
+        "heads_per_group": 1,
+    }
+
+
+def _resolve_fused_qkv(attn):
+    """One ``qkv_proj`` whose output is grouped per KV head as ``Q|(gate)|K|V``.
+
+    The group arithmetic is verified against the real weight width before the
+    layout is accepted, so a stack that packs qkv differently is rejected
+    instead of being sliced wrongly.
+    """
+    qkv = _first_module(attn, ("qkv_proj", "linear_qkv"))
+    shape = _weight_shape(qkv)
+    if shape is None:
+        return None
+    heads, kv_heads = _head_counts(attn)
+    if heads is None:
+        return None
+    kv_heads = heads if kv_heads is None else kv_heads
+    if kv_heads < 1 or heads % kv_heads:
+        return None
+    head_dim = getattr(attn, "hidden_size_per_attention_head", None)
+    if not isinstance(head_dim, int) or head_dim < 1:
+        return None
+    value_head_dim = getattr(attn, "value_hidden_size_per_attention_head", None)
+    if not isinstance(value_head_dim, int) or value_head_dim < 1:
+        value_head_dim = head_dim
+    heads_per_group = heads // kv_heads
+    q_dim = heads_per_group * head_dim
+    gate_dim = heads_per_group * value_head_dim if getattr(attn, "gated_attention", False) else 0
+    group_dim = q_dim + gate_dim + head_dim + value_head_dim
+    if kv_heads * group_dim != shape[-1]:
+        return None
+    return {
+        "kind": "fused_qkv",
+        "qkv": qkv,
+        "q_norm": getattr(attn, "q_norm", None),
+        "k_norm": getattr(attn, "k_norm", None),
+        "head_dim": head_dim,
+        "num_heads": heads,
+        "num_kv_heads": kv_heads,
+        "heads_per_group": heads_per_group,
+        "q_dim": q_dim,
+        "gate_dim": gate_dim,
+        "group_dim": group_dim,
+    }
+
+
+def _resolve_split_qk(attn):
+    """Independent Q and K projections, GQA/MQA included.
+
+    Head counts come from the weight widths rather than the module attributes so
+    a TP-sharded projection reports the heads this rank actually holds.
+    """
+    q = _first_module(attn, ("q_proj", "linear_q_proj", "wq"))
+    k = _first_module(attn, ("k_proj", "linear_k_proj", "shared_kv_proj", "wk"))
+    q_shape, k_shape = _weight_shape(q), _weight_shape(k)
+    if q_shape is None or k_shape is None or q_shape[0] != k_shape[0]:
+        return None
+    head_dim = getattr(attn, "hidden_size_per_attention_head", None)
+    if not isinstance(head_dim, int) or head_dim < 1:
+        heads, _ = _head_counts(attn)
+        if heads is None or q_shape[-1] % heads:
+            return None
+        head_dim = q_shape[-1] // heads
+    if head_dim < 1 or q_shape[-1] % head_dim or k_shape[-1] % head_dim:
+        return None
+    heads = q_shape[-1] // head_dim
+    kv_heads = k_shape[-1] // head_dim
+    if kv_heads < 1 or heads % kv_heads:
+        return None
+    return {
+        "kind": "split_qk",
+        "q": q,
+        "k": k,
+        "q_norm": getattr(attn, "q_norm", None),
+        "k_norm": getattr(attn, "k_norm", None),
+        "head_dim": head_dim,
+        "num_heads": heads,
+        "num_kv_heads": kv_heads,
+        "heads_per_group": heads // kv_heads,
+    }
+
+
+# Most specific layout first: MLA and DSv4-hybrid both expose projections whose
+# names overlap with the generic ones, so the generic resolvers must come last.
+_LAYOUT_RESOLVERS = (_resolve_dsv4_hybrid, _resolve_mla, _resolve_fused_qkv, _resolve_split_qk)
+
+
+def resolve_qk_factors(attn):
+    """Query/key factors of one attention module, or None if unrecognised.
+
+    Tries every known layout in :data:`_LAYOUT_RESOLVERS` and returns a dict
+    describing the winner: ``kind``, the projection *modules*, ``head_dim`` (the
+    width of the content circuit), ``num_heads`` / ``num_kv_heads`` /
+    ``heads_per_group``, plus whatever slicing arithmetic that layout needs.
+
+    Norm scales sitting between the projections are folded into the weights
+    because they are inside the QK circuit; the input-dependent ``1/rms`` factor
+    is not a weight and is left out.
+
+    The *modules* are captured rather than their ``weight`` tensors so a weight
+    object swapped out from under us (master-weight sync, quant callbacks) is
+    still picked up on the next read.
+    """
+    for resolver in _LAYOUT_RESOLVERS:
+        factors = resolver(attn)
+        if factors is not None:
+            return factors
+    return None
+
+
+def effective_wq(factors, head):
+    """Effective ``[hidden, head_dim]`` query matrix of one head."""
+    kind = factors["kind"]
+    head_dim = factors["head_dim"]
+    if kind == "dsv4_hybrid":
+        latent = _fold_scale(_fp32(_weight(factors["q_down"])), _scale_vector(factors["q_layernorm"]))
+        start = head * head_dim
+        return _frozen(latent @ _fp32(_weight(factors["q_up"]))[:, start : start + head_dim])
+    if kind == "mla":
+        # Slice the head out of the up-projection before composing: the full
+        # product would be [hidden, num_heads * q_head_dim], which is huge.
+        start = head * factors["q_head_dim"]
+        cols = _fp32(_weight(factors["q_b"]))[:, start : start + head_dim]
+        q_a = factors["q_a"]
+        if q_a is None:
+            return _frozen(cols)
+        latent = _fold_scale(_fp32(_weight(q_a)), _scale_vector(factors["q_a_layernorm"]))
+        return _frozen(latent @ cols)
+    if kind == "fused_qkv":
+        group, within = divmod(head, factors["heads_per_group"])
+        start = group * factors["group_dim"] + within * head_dim
+        block = _fp32(_weight(factors["qkv"]))[:, start : start + head_dim]
+    else:
+        start = head * head_dim
+        block = _fp32(_weight(factors["q"]))[:, start : start + head_dim]
+    return _frozen(_fold_scale(block, _scale_vector(factors["q_norm"]), head))
+
+
+def effective_wk(factors, head=0):
+    """Effective ``[hidden, head_dim]`` key matrix for the group of ``head``."""
+    kind = factors["kind"]
+    head_dim = factors["head_dim"]
+    if kind == "dsv4_hybrid":
+        # One shared KV head, so every query head sees the same key matrix.
+        return _frozen(_fold_scale(_fp32(_weight(factors["kv"])), _scale_vector(factors["kv_layernorm"])))
+    if kind == "mla":
+        start = head * factors["kv_head_width"]
+        cols = _fp32(_weight(factors["kv_b"]))[:, start : start + head_dim]
+        latent = _fold_scale(
+            _fp32(_weight(factors["kv_a"]))[:, : factors["kv_lora_rank"]],
+            _scale_vector(factors["kv_a_layernorm"]),
+        )
+        return _frozen(latent @ cols)
+    group = head // factors["heads_per_group"]
+    if kind == "fused_qkv":
+        start = group * factors["group_dim"] + factors["q_dim"] + factors["gate_dim"]
+        block = _fp32(_weight(factors["qkv"]))[:, start : start + head_dim]
+    else:
+        start = group * head_dim
+        block = _fp32(_weight(factors["k"]))[:, start : start + head_dim]
+    return _frozen(_fold_scale(block, _scale_vector(factors["k_norm"]), group))
+
+
+class PaddleAttnUpdateMonitor(PaddleProbe):
+    """Tracks the QK-product increment terms ``delta2`` / ``delta3`` per layer.
+
+    No forward hooks are needed: the monitor reads query/key weights at step
+    boundaries and keeps the previous reading as the base point, so the sampling
+    interval ``delta`` is this monitor's own interval — ``sample_interval`` when
+    given, otherwise the shared ``monitor_interval``. Sampling independently is
+    useful because the cost here is one eigensolve per layer per sample, unlike
+    the hook-driven monitors whose cost rides along with the forward pass.
+    """
+
+    METRIC_PREFIX = "attn_update"
+
+    def __init__(
+        self,
+        log_per_layer=True,
+        log_global=True,
+        monitor_interval=1,
+        verbose=False,
+        num_heads_monitored=1,
+        spectrum_alpha=2.0,
+        sample_interval=None,
+    ):
+        interval = monitor_interval if sample_interval is None else int(sample_interval)
+        if interval < 1:
+            raise ValueError(f"sample_interval must be >= 1, got {sample_interval}")
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=interval,
+            verbose=verbose,
+        )
+        if int(num_heads_monitored) < 1:
+            raise ValueError(f"num_heads_monitored must be >= 1, got {num_heads_monitored}")
+        self.num_heads_monitored = int(num_heads_monitored)
+        self.spectrum_alpha = float(spectrum_alpha)
+        # [(layer_idx, attn_type, factors)] and layer_idx -> (per-head Wq, Wk)
+        self._layers = []
+        self._snapshots = {}
+
+    def register_hooks(self, model):
+        try:
+            from paddlefleet.parallel_state import get_pipeline_model_parallel_rank
+
+            self.pp_rank = get_pipeline_model_parallel_rank()
+        except Exception:
+            pass
+
+        def has_attention(layer):
+            return hasattr(layer, "self_attn") or hasattr(layer, "self_attention")
+
+        layers = get_decoder_layers(model)
+        if layers is None:
+            discovered = [m for _name, m in model.named_sublayers() if has_attention(m)]
+            layers = discovered or None
+        if layers is None:
+            logger.warning("[PaddleAttnUpdateMonitor] No decoder layers found!")
+            return
+
+        monitor_layers = iter_monitor_layers(layers, has_attention, pp_rank=self.pp_rank)
+        self.mark_mtp_layers(item.idx for item in monitor_layers if item.is_mtp)
+
+        self._layers = []
+        for item in monitor_layers:
+            attn = getattr(item.layer, "self_attn", None) or getattr(item.layer, "self_attention", None)
+            factors = resolve_qk_factors(attn) if attn is not None else None
+            if factors is None:
+                if self.verbose:
+                    logger.warning(
+                        "[PaddleAttnUpdateMonitor] layer %s: unsupported QK layout, skipped",
+                        item.idx,
+                    )
+                continue
+            self._layers.append((item.idx, item.attn_type, factors))
+
+        if not self._layers:
+            logger.warning("[PaddleAttnUpdateMonitor] No supported attention layouts found!")
+            return
+
+        for layer_idx, attn_type, _factors in self._layers:
+            for name in METRIC_NAMES:
+                self.declare_layer_metric(layer_idx, name, attn_type=attn_type)
+        self.allocate_buffers()
+
+        logger.info(
+            "[PaddleAttnUpdateMonitor] Tracking %s on %d layers (%s), %d head(s) per layer, alpha=%s, delta=%d steps.",
+            "/".join(TERM_NAMES),
+            len(self._layers),
+            ", ".join(sorted({factors["kind"] for _idx, _type, factors in self._layers})),
+            self.num_heads_monitored,
+            self.spectrum_alpha,
+            self.monitor_interval,
+        )
+
+    def _prepare_layer(self, layer_idx, factors):
+        """Re-snapshot one layer and return ``{term: [(a, b), ...]}`` factor pairs.
+
+        Empty on the first reading, which only establishes the base point
+        ``t - delta``. Both terms come out of the same four snapshot matrices, so
+        delta3 costs no extra weight reads — only an eigensolve on a ``head_dim``
+        core against delta2's ``2*head_dim`` one.
+
+        K is read per head rather than once per layer: under GQA/MQA several
+        query heads share one key matrix, but under MLA each head has its own,
+        and ``effective_wk`` resolves that per layout.
+        """
+        heads = min(self.num_heads_monitored, factors["num_heads"])
+        wq_now = [effective_wq(factors, head) for head in range(heads)]
+        wk_now = [effective_wk(factors, head) for head in range(heads)]
+
+        previous = self._snapshots.get(layer_idx)
+        self._snapshots[layer_idx] = (wq_now, wk_now)
+        if previous is None:
+            return {}
+
+        wq_base, wk_base = previous
+        shapes = [[m.shape for m in group] for group in (wq_base, wq_now, wk_base, wk_now)]
+        if shapes[0] != shapes[1] or shapes[2] != shapes[3]:
+            if self.verbose:
+                logger.warning(
+                    "[PaddleAttnUpdateMonitor] layer %s: snapshot shape changed, rebasing",
+                    layer_idx,
+                )
+            return {}
+
+        delta2, delta3 = [], []
+        for q_base, q_now, k_base, k_now in zip(wq_base, wq_now, wk_base, wk_now, strict=True):
+            dq, dk = q_now - q_base, k_now - k_base
+            # eq. (4): delta2 = [dWq, Wq][Wk, dWk]^T and delta3 = dWq dWk^T.
+            delta2.append((paddle.concat([dq, q_base], axis=-1), paddle.concat([k_base, dk], axis=-1)))
+            delta3.append((dq, dk))
+        return {"delta2": delta2, "delta3": delta3}
+
+    def _record_all_layers(self):
+        """Snapshot every layer, then take every term's spectrum in one batch."""
+        pairs = []
+        groups = []  # [(layer_idx, attn_type, term, head_count)] parallel to ``pairs``
+        for layer_idx, attn_type, factors in self._layers:
+            try:
+                per_term = self._prepare_layer(layer_idx, factors)
+            except Exception as exc:
+                if self.verbose:
+                    logger.error(
+                        "[PaddleAttnUpdateMonitor] QK snapshot failed on layer %s: %s",
+                        layer_idx,
+                        exc,
+                    )
+                continue
+            for term in TERM_NAMES:
+                term_pairs = per_term.get(term)
+                if term_pairs:
+                    groups.append((layer_idx, attn_type, term, len(term_pairs)))
+                    pairs.extend(term_pairs)
+
+        if not pairs:
+            return
+
+        metrics = _spectrum_metrics_over_pairs(pairs, self.spectrum_alpha)
+        offset = 0
+        for layer_idx, attn_type, term, count in groups:
+            for key in _SPECTRUM_KEYS:
+                head_mean = metrics[key][offset : offset + count].mean()
+                self.record_layer_metric(layer_idx, f"{term}_{key}", head_mean, attn_type=attn_type)
+            offset += count
+
+    def step(self):
+        if self._buffers_allocated and self._should_monitor():
+            with paddle.no_grad():
+                try:
+                    self._record_all_layers()
+                except Exception as exc:
+                    if self.verbose:
+                        logger.error("[PaddleAttnUpdateMonitor] QK increment failed: %s", exc)
+        super().step()
+
+    def remove_hooks(self):
+        super().remove_hooks()
+        self._layers = []
+        self._snapshots = {}
+
+
+def setup_attn_update_monitor(
+    model,
+    log_per_layer=True,
+    log_global=True,
+    monitor_interval=1,
+    verbose=False,
+    monitor_dict=None,
+    num_heads_monitored=1,
+    spectrum_alpha=2.0,
+    sample_interval=None,
+):
+    monitor = PaddleAttnUpdateMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+        num_heads_monitored=num_heads_monitored,
+        spectrum_alpha=spectrum_alpha,
+        sample_interval=sample_interval,
+    )
+    monitor.register_hooks(model)
+    logger.info("[PaddleAttnUpdateMonitor] Setup complete on %d layers.", len(monitor._layers))
+    if monitor_dict is not None:
+        monitor_dict["attn_update"] = monitor
+    return model

--- a/src/internal_medicine/backends/paddlefleet/mlp_update_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mlp_update_monitor.py
@@ -1,0 +1,496 @@
+"""MoE expert update monitoring for PaddleFleet.
+
+Tracks the parameter increment of the expert MLPs,
+
+    dW[l, e, m] = W[l, e, m]_t - W[l, e, m]_{t - delta},
+
+for layer ``l``, local expert ``e`` and matrix ``m`` in gate / up / down, then
+reduces it to per-layer statistics over the experts. This is the MoE counterpart
+of ``attn_update``: same "read weights at step boundaries, keep the previous
+reading as the base point" scheme, no forward hooks.
+
+The headline metric is the RELATIVE update
+
+    r[l, e, m] = ||dW[l, e, m]||_F / (||W[l, e, m]||_F + eps),
+
+which is comparable across layers and experts in a way ``||dW||_F`` alone is not.
+Each matrix also reports the stable rank ``||dW||_F^2 / ||dW||_2^2``, i.e. how
+many directions the update actually spans.
+
+Per the diagnostic intent the reduction order matters: every (layer, expert,
+matrix) triple is measured on its own and only then summarised per layer, never
+by concatenating experts into one matrix. The summaries are mean / median /
+p10 / p90 / min / max, which is what separates the four failure modes this is
+for -- one expert updating far too much (max), experts that barely move at all
+(min, p10), uneven learning speed across experts (p90 - p10), and an update that
+narrows onto a few singular directions (stable rank).
+
+``sigma_1 / ||dW||_F`` is deliberately not reported: it equals
+``1 / sqrt(stable_rank)`` exactly, so it carries no information the stable rank
+does not already carry.
+
+Cost and precision, measured on the 4B-A500M shapes (32 local experts per EP
+rank, weight1 ``[32, 512, 1024]``, weight2 ``[32, 512, 512]``), one H800:
+
+* Norms plus a batched power iteration for ``sigma_1``: 11.3 ms/layer, 0.20 s
+  over 18 layers. This is the default tier.
+* The full Gram + ``eigvalsh`` spectrum needed for the singular entropy:
+  500.9 ms/layer, 9.02 s over 18 layers. Off unless ``log_spectrum=True``.
+
+``sigma_1`` comes from a power iteration rather than an eigensolve, and its error
+profile happens to favour the thing being detected: convergence goes as
+``(sigma_2 / sigma_1)^(2k)``, so at 30 iterations a rank-dominated update
+(``sigma_2 / sigma_1 = 0.25``) is exact to 5e-8 while a flat random update
+(``0.99``) carries ~1.2% on ``sigma_1`` and ~2.4% on the stable rank. The
+imprecise case is the one where the stable rank is large and its exact value does
+not change the reading; the precise case is the collapse being monitored. The
+error is one-sided -- an underestimated ``sigma_1`` inflates the stable rank.
+
+Two limits worth knowing before reading the curves:
+
+* The base snapshot is a clone in the parameter's own dtype, so for bf16 expert
+  weights ``dW`` is exact with respect to what is readable, but it is quantised
+  to the bf16 grid: an update below ~2^-9 of the weight magnitude is invisible
+  and reads as ``r = 0``. A "sleeping expert" verdict therefore means "not moving
+  in the representable weights over ``delta`` steps", which is what a longer
+  ``sample_interval`` buys. Reading the optimizer's fp32 master weights instead
+  would lift this, at the price of reaching into the optimizer.
+* ``_mean``, ``_min`` and ``_max`` reduce correctly across EP ranks (each rank
+  holds its own expert shard, and the expert count divides evenly across the
+  group). ``_median`` / ``_p10`` / ``_p90`` do not: what lands in the log is the
+  mean of the per-rank quantiles, not the global quantile. That is accepted here
+  as a spread signal, the same trade the megatron-side spectral entropy makes.
+
+A small update is not by itself a functional verdict: an expert routed few tokens
+has little to learn from. Read these against the routed-token distribution that
+``moe_health`` already reports (``assignment_load_cv``, ``assignment_load_min_frac``,
+``assignment_load_max_min_ratio``, ``gate_mass_*``) rather than duplicating it
+here. A true functional drift measure -- expert output displacement on a fixed
+probe batch -- needs the old weights kept live and an extra expert forward, so it
+is out of scope for a weights-only probe.
+"""
+
+import logging
+
+import paddle
+
+from .base import PaddleProbe
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
+from .moe_monitor import _expert_fc1_weight, _singular_value_entropy, _swiglu_gate_half
+
+logger = logging.getLogger(__name__)
+
+# Expert projections monitored, in the order they appear in the MLP.
+MATRIX_NAMES = ("gate", "up", "down")
+# Per-layer summaries of a per-expert statistic.
+_SPREAD_KEYS = ("mean", "median", "p10", "p90", "min", "max")
+# Reduced summary set for the spectral statistics.
+_RANK_KEYS = ("mean", "min", "max")
+# Power-iteration steps for sigma_1. 30 keeps a rank-dominated update exact and a
+# flat one inside ~1.2%; see the module docstring for the measured table.
+_POWER_ITERS = 30
+_EPS = 1e-12
+
+
+def metric_names(log_spectrum: bool = False, with_shared: bool = True) -> tuple[str, ...]:
+    """Full per-layer metric schema, in declaration order.
+
+    ``log_spectrum`` adds the singular-entropy keys, which are the only ones that
+    need a full eigensolve. ``with_shared`` is off for a layer that has no shared
+    expert, so it does not declare a key it will never record.
+    """
+    names: list[str] = [f"update_zmax_{key}" for key in ("max", "p90", "min")]
+    for matrix in MATRIX_NAMES:
+        names += [f"{matrix}_rel_update_{key}" for key in _SPREAD_KEYS]
+        names.append(f"{matrix}_delta_norm_mean")
+        names += [f"{matrix}_stable_rank_{key}" for key in _RANK_KEYS]
+        if log_spectrum:
+            names += [f"{matrix}_singular_entropy_{key}" for key in _RANK_KEYS]
+        if with_shared:
+            names.append(f"shared_{matrix}_rel_update")
+    return tuple(names)
+
+
+def _swiglu_up_half(fc1_weight):
+    """The ungated "up" half of a fused SwiGLU fc1 weight.
+
+    Counterpart of :func:`moe_monitor._swiglu_gate_half`: paddle lays fc1 out as
+    ``[..., in, 2 * inter]`` and ``glu()`` applies SiLU to the first chunk, so the
+    linear half is the second one.
+    """
+    return fc1_weight[..., fc1_weight.shape[-1] // 2 :]
+
+
+def _expert_fc2_weight(moe_layer):
+    """Routed-expert fc2 (down) weight with a leading expert dim, or None.
+
+    Mirrors the layouts :func:`moe_monitor._expert_fc1_weight` handles:
+    grouped-gemm ``weight2``, a fused ``down_proj.weight``, and the non-fused
+    ``LayerList`` of per-expert MLPs (stacked here).
+    """
+    ggm = getattr(moe_layer, "grouped_gemm_experts", None)
+    if ggm is not None and hasattr(ggm, "weight2"):
+        return ggm.weight2
+    experts = getattr(moe_layer, "experts", None)
+    if experts is None:
+        return None
+    if hasattr(experts, "down_proj"):
+        return experts.down_proj.weight
+    per_expert = [e.down_proj.weight for e in experts if e is not None and hasattr(e, "down_proj")]
+    return paddle.stack(per_expert) if per_expert else None
+
+
+def _shared_weights(moe_layer):
+    """``(fc1, fc2)`` of the shared expert, either entry possibly None."""
+    shared = getattr(moe_layer, "shared_experts", None)
+    if shared is None:
+        return None, None
+    fc1 = getattr(getattr(shared, "up_gate_proj", None), "weight", None)
+    fc2 = getattr(getattr(shared, "down_proj", None), "weight", None)
+    return fc1, fc2
+
+
+def _as_stack(weight):
+    """Detached float32 view of a weight with a guaranteed leading expert axis.
+
+    A fused grouped-gemm weight already carries ``[E, in, out]``; the shared
+    expert is a plain ``[in, out]`` matrix and gets a length-1 axis so both go
+    through the same batched code path.
+    """
+    matrices = weight.detach().astype("float32")
+    return matrices if len(matrices.shape) > 2 else matrices.unsqueeze(0)
+
+
+def _frobenius(matrices):
+    """``||.||_F`` of every matrix in a ``[..., m, n]`` stack -> ``[...]``."""
+    return paddle.sqrt((matrices * matrices).sum(axis=[-2, -1]))
+
+
+def _deterministic_start(width: int):
+    """Unit start vector for the power iteration, drawn without the global RNG.
+
+    ``paddle.randn`` would consume the global generator and shift every
+    downstream draw (dropout, router noise) on monitored steps only, which would
+    make the run irreproducible against an unmonitored one. A fixed irrational
+    stride gives a vector with no particular relation to the weight layout, which
+    is all the iteration needs.
+    """
+    index = paddle.arange(width, dtype="float32")
+    vector = paddle.sin(index * 0.7071067811865476 + 1.0).reshape([width, 1])
+    return vector / paddle.linalg.norm(vector).clip(min=_EPS)
+
+
+def _sigma_max(matrices, iters: int = _POWER_ITERS):
+    """Largest singular value of every matrix in a ``[E, m, n]`` stack -> ``[E]``.
+
+    Power iteration on ``A^T A``, which needs only matrix-vector products: at
+    these shapes it is ~45x cheaper than the eigensolve that would give the whole
+    spectrum, and the stable rank needs nothing but ``sigma_1``. Converges as
+    ``(sigma_2 / sigma_1)^(2 * iters)``; error is one-sided (low), so the stable
+    rank it feeds is biased high.
+    """
+    vector = paddle.broadcast_to(
+        _deterministic_start(matrices.shape[-1]).unsqueeze(0),
+        [matrices.shape[0], matrices.shape[-1], 1],
+    )
+    for _ in range(iters):
+        vector = paddle.matmul(matrices, paddle.matmul(matrices, vector), transpose_x=True)
+        vector = vector / paddle.linalg.norm(vector, axis=-2, keepdim=True).clip(min=_EPS)
+    return paddle.linalg.norm(paddle.matmul(matrices, vector), axis=-2).squeeze(-1)
+
+
+def _spread(values):
+    """The six per-layer summaries of a ``[E]`` per-expert statistic.
+
+    ``_mean`` / ``_min`` / ``_max`` survive the cross-rank reduction exactly; the
+    quantiles do not (see the module docstring).
+    """
+    return {
+        "mean": values.mean(),
+        "median": paddle.quantile(values, 0.5),
+        "p10": paddle.quantile(values, 0.10),
+        "p90": paddle.quantile(values, 0.90),
+        "min": values.min(),
+        "max": values.max(),
+    }
+
+
+def _gram(matrices):
+    """Smaller-side Gram matrix of a ``[E, m, n]`` stack, for the eigensolve."""
+    if matrices.shape[-2] <= matrices.shape[-1]:
+        return paddle.matmul(matrices, matrices, transpose_y=True)
+    return paddle.matmul(matrices, matrices, transpose_x=True)
+
+
+def _find_moe_layers(model, pp_rank, mark_mtp):
+    """``[(layer_idx, moe_module)]`` for every MoE layer visible on this rank.
+
+    Same discovery contract as the MoE health monitor: the expert block hangs off
+    ``layer.mlp`` on this model family, off ``layer.moe`` elsewhere, and a bare
+    ``MoELayer`` is its own module.
+    """
+
+    def has_moe(layer):
+        return (hasattr(layer, "mlp") and hasattr(layer.mlp, "gate")) or hasattr(layer, "moe") or hasattr(layer, "gate")
+
+    layers = get_decoder_layers(model)
+    if layers is None:
+        layers = [m for _name, m in model.named_sublayers() if m.__class__.__name__ == "MoELayer"] or None
+    if layers is None:
+        return []
+
+    monitor_layers = iter_monitor_layers(layers, has_moe, pp_rank=pp_rank)
+    mark_mtp(item.idx for item in monitor_layers if item.is_mtp)
+    found = []
+    for item in monitor_layers:
+        layer = item.layer
+        module = None
+        if hasattr(layer, "mlp") and hasattr(layer.mlp, "gate"):
+            module = layer.mlp
+        elif hasattr(layer, "moe"):
+            module = layer.moe
+        elif hasattr(layer, "gate"):
+            module = layer
+        if module is not None:
+            found.append((item.idx, module))
+    return found
+
+
+class PaddleMLPUpdateMonitor(PaddleProbe):
+    """Per-layer distribution of the expert MLP parameter increment.
+
+    Weights only -- no forward hooks. The base point is the previous monitored
+    reading, so the increment spans ``sample_interval`` steps (falling back to the
+    shared ``monitor_interval``).
+
+    Snapshots are taken from :meth:`collect_expert_norms`, which the trainer
+    callback calls at step begin. That name is the callback's contract, not a
+    description: it is the only step-begin slot, and it has to run there because
+    ``FP8QuantWeightCallback`` clears the bf16 expert weights later in the same
+    step. Reading them at step end would see the cleared storage.
+    """
+
+    METRIC_PREFIX = "mlp_update"
+
+    def __init__(
+        self,
+        log_per_layer=True,
+        log_global=True,
+        monitor_interval=1,
+        verbose=False,
+        sample_interval=None,
+        log_spectrum=False,
+        spectrum_interval=1,
+    ):
+        interval = monitor_interval if sample_interval is None else int(sample_interval)
+        if interval < 1:
+            raise ValueError(f"sample_interval must be >= 1, got {sample_interval}")
+        if int(spectrum_interval) < 1:
+            raise ValueError(f"spectrum_interval must be >= 1, got {spectrum_interval}")
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=interval,
+            verbose=verbose,
+        )
+        self.log_spectrum = bool(log_spectrum)
+        # The eigensolve is ~45x the cost of the rest, so it rides a coarser clock:
+        # the relative updates land on every sample, the spectrum every
+        # ``spectrum_interval``-th one.
+        self.spectrum_interval = int(spectrum_interval)
+        self._samples = 0
+        self._spectrum_due = False
+        self._metric_names = metric_names(self.log_spectrum)
+        self.MAX_AGGREGATED = {name for name in self._metric_names if name.endswith("_max")}
+        self.MIN_AGGREGATED = {name for name in self._metric_names if name.endswith("_min")}
+        # [(layer_idx, moe_module)] and layer_idx -> {"routed": (fc1, fc2), "shared": (fc1, fc2)}
+        self._layers = []
+        self._snapshots = {}
+
+    def register_hooks(self, model):
+        try:
+            from paddlefleet.parallel_state import get_pipeline_model_parallel_rank
+
+            self.pp_rank = get_pipeline_model_parallel_rank()
+        except Exception:
+            pass
+
+        self._layers = _find_moe_layers(model, self.pp_rank, self.mark_mtp_layers)
+        if not self._layers:
+            logger.warning("[PaddleMLPUpdateMonitor] No MoE layers found!")
+            return
+
+        for layer_idx, module in self._layers:
+            shared_fc1, shared_fc2 = _shared_weights(module)
+            has_shared = shared_fc1 is not None or shared_fc2 is not None
+            for name in metric_names(self.log_spectrum, with_shared=has_shared):
+                self.declare_layer_metric(layer_idx, name)
+        self.allocate_buffers()
+
+        logger.info(
+            "[PaddleMLPUpdateMonitor] Tracking %s on %d MoE layers, delta=%d steps, spectrum=%s.",
+            "/".join(MATRIX_NAMES),
+            len(self._layers),
+            self.monitor_interval,
+            f"{self.log_spectrum} (every {self.spectrum_interval} samples)",
+        )
+
+    def _live_weights(self, module):
+        """``{"routed": (fc1, fc2), "shared": (fc1, fc2)}`` of live parameters."""
+        return {
+            "routed": (_expert_fc1_weight(module), _expert_fc2_weight(module)),
+            "shared": _shared_weights(module),
+        }
+
+    @staticmethod
+    def _snapshot(group):
+        """Clone a weight pair in its own dtype.
+
+        Kept at the parameter's dtype rather than upcast: the increment is exact
+        with respect to what is readable either way, and fp32 would double an
+        already ~50 MB-per-layer resident cost for no extra resolution.
+        """
+        return tuple(None if weight is None else weight.detach().clone() for weight in group)
+
+    @staticmethod
+    def _matrix_deltas(live, base):
+        """``[(name, delta, weight)]`` for gate / up / down on one expert group.
+
+        Skips a pair whose shape moved between readings (resume, reshard) rather
+        than differencing mismatched storage; the fresh snapshot rebases it.
+        """
+        pairs = []
+        fc1_now, fc2_now = live
+        fc1_base, fc2_base = base
+        if fc1_now is not None and fc1_base is not None and list(fc1_now.shape) == list(fc1_base.shape):
+            now = _as_stack(fc1_now)
+            delta = now - _as_stack(fc1_base)
+            pairs.append(("gate", _swiglu_gate_half(delta), _swiglu_gate_half(now)))
+            pairs.append(("up", _swiglu_up_half(delta), _swiglu_up_half(now)))
+        if fc2_now is not None and fc2_base is not None and list(fc2_now.shape) == list(fc2_base.shape):
+            now = _as_stack(fc2_now)
+            pairs.append(("down", now - _as_stack(fc2_base), now))
+        return pairs
+
+    def _record_routed(self, layer_idx, name, delta, weight):
+        """Record one projection's statistics; returns its per-expert ``r`` vector."""
+        delta_norm = _frobenius(delta)
+        relative = delta_norm / (_frobenius(weight) + _EPS)
+        for key, value in _spread(relative).items():
+            self.record_layer_metric(layer_idx, f"{name}_rel_update_{key}", value)
+        self.record_layer_metric(layer_idx, f"{name}_delta_norm_mean", delta_norm.mean())
+
+        # A frozen expert has dW = 0, where the ratio is 0/0. Report the lower
+        # bound 1 so the series stays inside [1, k] instead of planting a 0 that
+        # reads as total collapse and wins every _min reduction; the sleeping
+        # expert is already unambiguous in rel_update_min / _p10.
+        sigma_max = _sigma_max(delta)
+        stable_rank = paddle.where(
+            delta_norm > 0.0,
+            (delta_norm * delta_norm) / (sigma_max * sigma_max).clip(min=_EPS),
+            paddle.ones_like(delta_norm),
+        )
+        spread = _spread(stable_rank)
+        for key in _RANK_KEYS:
+            self.record_layer_metric(layer_idx, f"{name}_stable_rank_{key}", spread[key])
+
+        if self._spectrum_due:
+            sigma = paddle.sqrt(paddle.linalg.eigvalsh(_gram(delta)).clip(min=0.0))
+            spread = _spread(_singular_value_entropy(sigma))
+            for key in _RANK_KEYS:
+                self.record_layer_metric(layer_idx, f"{name}_singular_entropy_{key}", spread[key])
+        return relative
+
+    def _record_expert_score(self, layer_idx, relatives):
+        """Expert-level summary ``S[e] = max_m z(r_m[e])`` over the layer's experts.
+
+        Averaging the three projections would let one anomalous matrix be diluted
+        by two healthy ones, and averaging raw norms would let whichever matrix
+        has the largest scale set the verdict. Standardising each projection over
+        the layer's experts first puts them on one scale; the max over ``m`` then
+        keeps a single misbehaving projection visible.
+
+        ``_max`` is the layer's most anomalous expert. ``_min`` is the expert that
+        sits furthest below its peers on *every* projection at once, which is the
+        sharpest "sleeping expert" reading available here -- a per-matrix
+        ``rel_update_min`` can be low for one matrix by chance.
+
+        The standardisation is over the experts this rank holds, not the global
+        expert set, so under EP the score is relative to the local shard.
+        """
+        scores = None
+        for relative in relatives:
+            centred = relative - relative.mean()
+            z = centred / (relative.std() + _EPS) if relative.shape[0] > 1 else paddle.zeros_like(centred)
+            scores = z if scores is None else paddle.maximum(scores, z)
+        if scores is None:
+            return
+        self.record_layer_metric(layer_idx, "update_zmax_max", scores.max())
+        self.record_layer_metric(layer_idx, "update_zmax_p90", paddle.quantile(scores, 0.90))
+        self.record_layer_metric(layer_idx, "update_zmax_min", scores.min())
+
+    def _process_layer(self, layer_idx, module):
+        live = self._live_weights(module)
+        previous = self._snapshots.get(layer_idx)
+        self._snapshots[layer_idx] = {key: self._snapshot(group) for key, group in live.items()}
+        if previous is None:
+            return
+        relatives = [
+            self._record_routed(layer_idx, name, delta, weight)
+            for name, delta, weight in self._matrix_deltas(live["routed"], previous["routed"])
+        ]
+        self._record_expert_score(layer_idx, relatives)
+        for name, delta, weight in self._matrix_deltas(live["shared"], previous["shared"]):
+            relative = _frobenius(delta) / (_frobenius(weight) + _EPS)
+            self.record_layer_metric(layer_idx, f"shared_{name}_rel_update", relative.mean())
+
+    def collect_expert_norms(self):
+        """Step-begin entry point; see the class docstring for why it is this name."""
+        if not self._buffers_allocated or not self._should_monitor():
+            return
+        measuring = bool(self._snapshots)
+        self._spectrum_due = self.log_spectrum and measuring and self._samples % self.spectrum_interval == 0
+        for layer_idx, module in self._layers:
+            try:
+                with paddle.no_grad():
+                    self._process_layer(layer_idx, module)
+            except Exception as exc:
+                if self.verbose:
+                    logger.error("[PaddleMLPUpdateMonitor] layer %s failed: %s", layer_idx, exc)
+        # Counted only once a base point exists, so the first measurement -- not the
+        # snapshot-only pass that precedes it -- is spectrum sample zero.
+        if measuring:
+            self._samples += 1
+
+    def remove_hooks(self):
+        super().remove_hooks()
+        self._layers = []
+        # The base snapshots are the monitor's whole resident cost; drop them.
+        self._snapshots = {}
+
+
+def setup_mlp_update_monitor(
+    model,
+    log_per_layer=True,
+    log_global=True,
+    monitor_interval=1,
+    verbose=False,
+    monitor_dict=None,
+    sample_interval=None,
+    log_spectrum=False,
+    spectrum_interval=1,
+):
+    monitor = PaddleMLPUpdateMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+        sample_interval=sample_interval,
+        log_spectrum=log_spectrum,
+        spectrum_interval=spectrum_interval,
+    )
+    monitor.register_hooks(model)
+    logger.info("[PaddleMLPUpdateMonitor] Setup complete on %d MoE layers.", len(monitor._layers))
+    if monitor_dict is not None:
+        monitor_dict["mlp_update"] = monitor
+    return model

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -266,18 +266,24 @@ def _stable_rank(sigma):
 
 
 def _singular_value_entropy(sigma):
-    """Shannon entropy of the normalized singular-value distribution.
+    """Shannon entropy of the squared-singular-value distribution (alpha = 2).
 
-    ``H = -sum_i(p_i log p_i)`` with ``p_i = sigma_i / sum_j(sigma_j)``, in nats,
-    over ``[0, log(k)]``: 0 means the spectrum collapsed onto one direction,
-    ``log(k)`` means a flat spectrum (all directions used equally).
+    ``H = -sum_i(p_i log p_i)`` with ``p_i = sigma_i^2 / sum_j(sigma_j^2)``, in
+    nats, over ``[0, log(k)]``: 0 means the spectrum collapsed onto one
+    direction, ``log(k)`` means a flat spectrum (all directions used equally).
     ``[..., k]`` in, ``[...]`` out.
 
-    Note the sigma (not sigma^2) weighting: the megatron-side
-    ``hidden_spectral_entropy`` normalizes by sigma^2, so the two are not
-    numerically comparable.
+    ``sigma^2`` is the energy each direction carries, so this shares its
+    distribution with :func:`_stable_rank` and the pair is read on one scale
+    (``exp(H) >= srank`` always). The megatron-side ``hidden_spectral_entropy``
+    uses the same normalization, but it reads the post-norm hidden states rather
+    than a weight matrix, so matching units do not make them one quantity.
+
+    The sum guard is ``1e-24`` rather than ``1e-12`` because squaring halves the
+    exponent range that reaches it.
     """
-    p = (sigma / sigma.sum(axis=-1, keepdim=True).clip(min=1e-12)).clip(min=1e-12)
+    sq = sigma * sigma
+    p = (sq / sq.sum(axis=-1, keepdim=True).clip(min=1e-24)).clip(min=1e-12)
     return -(p * p.log()).sum(axis=-1)
 
 

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -193,12 +193,14 @@ def _gram(weight):
     eigensolver needs at least fp32.
 
     Returns a GPU tensor, or None when ``weight`` is missing, has fewer than two
-    dims, or is empty.
+    dims, or is empty. Emptiness is read off the static shape rather than from
+    ``numel()``, which returns a 0-dim GPU tensor here and would turn the guard
+    into a host sync on every call.
     """
     if weight is None:
         return None
     w = weight.detach().astype("float32")
-    if len(w.shape) < 2 or w.numel() == 0:
+    if len(w.shape) < 2 or 0 in w.shape:
         return None
     m, n = w.shape[-2], w.shape[-1]
     return paddle.matmul(w, w, transpose_y=True) if m <= n else paddle.matmul(w, w, transpose_x=True)

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -81,8 +81,21 @@ def _assignment_mask(
     return (one_hot * valid.unsqueeze(-1).astype("float32")).sum(axis=1).clip(max=1.0)
 
 
-def _routing_margin(selection_scores: paddle.Tensor, assignment_mask: paddle.Tensor) -> paddle.Tensor:
-    """Return selected-boundary margins for an ungrouped top-k router."""
+def _routing_margin(
+    selection_scores: paddle.Tensor, assignment_mask: paddle.Tensor
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Selected-boundary margin per token for an ungrouped top-k router.
+
+    ``margin = min(selected score) - max(unselected score)``: how close the
+    top-k boundary is to flipping. Returns ``(margin, valid)``.
+
+    Tokens the router assigned to nothing have no boundary — ``_assignment_mask``
+    turns the router's ``-1`` padding (dropped / pad tokens) into an all-zero
+    row, which makes ``selected`` ``+inf`` and the raw margin ``+inf``. Those
+    rows are refilled with the batch's largest real margin so that ``min`` and
+    the low-tail quantiles (which cannot take a mask) stay finite and are not
+    dragged by non-tokens; ``valid`` lets the caller take an exact masked mean.
+    """
     selected = paddle.where(
         assignment_mask > 0,
         selection_scores,
@@ -93,7 +106,11 @@ def _routing_margin(selection_scores: paddle.Tensor, assignment_mask: paddle.Ten
         paddle.full_like(selection_scores, float("-inf")),
         selection_scores,
     ).max(axis=-1)
-    return selected - unselected
+    raw = selected - unselected
+    valid = assignment_mask.sum(axis=-1) > 0
+    largest_real = paddle.where(valid, raw, paddle.full_like(raw, -1e30)).max()
+    margin = paddle.where(valid, raw, paddle.broadcast_to(largest_real, raw.shape))
+    return margin, valid
 
 
 def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=1, topk_group=1):
@@ -763,8 +780,13 @@ class PaddleMoEMonitor(PaddleProbe):
                     selection_scores = cached_gates.astype("float32")
                     if hasattr(gate, "e_score_correction_bias"):
                         selection_scores = selection_scores + gate.e_score_correction_bias.detach().astype("float32")
-                    margin = _routing_margin(selection_scores, assignment_mask)
-                    self.record_layer_metric(layer_idx, "router_margin_mean", margin.mean())
+                    margin, margin_valid = _routing_margin(selection_scores, assignment_mask)
+                    valid_weight = margin_valid.astype("float32")
+                    self.record_layer_metric(
+                        layer_idx,
+                        "router_margin_mean",
+                        (margin * valid_weight).sum() / valid_weight.sum().clip(min=1.0),
+                    )
                     self.record_layer_metric(layer_idx, "router_margin_min", margin.min())
                     self.record_layer_metric(layer_idx, "router_margin_p10", paddle.quantile(margin, 0.10))
                     self.record_layer_metric(layer_idx, "router_margin_p01", paddle.quantile(margin, 0.01))

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -124,6 +124,117 @@ def _module_sumsq(module):
     return sq
 
 
+def _gram(weight):
+    """Gram matrix of ``weight``, shaped ``[..., k, k]`` with ``k = min(m, n)``.
+
+    ``W W^T`` or ``W^T W``, whichever is the smaller square, so the eigensolve
+    below always runs on ``k x k``. bf16 params are cast to float32 because the
+    eigensolver needs at least fp32.
+
+    Returns a GPU tensor, or None when ``weight`` is missing, has fewer than two
+    dims, or is empty.
+    """
+    if weight is None:
+        return None
+    w = weight.detach().astype("float32")
+    if len(w.shape) < 2 or w.numel() == 0:
+        return None
+    m, n = w.shape[-2], w.shape[-1]
+    return paddle.matmul(w, w, transpose_y=True) if m <= n else paddle.matmul(w, w, transpose_x=True)
+
+
+def _gram_singular_values(gram):
+    """Singular values from a Gram matrix: ``sigma_i = sqrt(lambda_i)``.
+
+    ``[..., k, k]`` in, ``[..., k]`` out. The order is unspecified (``eigvalsh``
+    returns ascending); both metrics below are order-invariant. Returns a GPU
+    tensor (no host sync), or None for None input.
+    """
+    if gram is None:
+        return None
+    return paddle.sqrt(paddle.linalg.eigvalsh(gram).clip(min=0.0))
+
+
+def _singular_values(weight):
+    """Singular values of a matrix or a batch of matrices, via the Gram spectrum.
+
+    Accepts ``[m, n]`` or ``[..., m, n]`` and returns ``[..., min(m, n)]``.
+
+    ``sigma_i = sqrt(lambda_i(W^T W))`` is the SVD spectrum, but obtained far more
+    cheaply: on one EP rank's per-expert SwiGLU gate stack ([32, 512, 512]) a
+    batched ``paddle.linalg.svdvals`` measures ~8.5 s against ~196 ms for the
+    batched Gram + ``eigvalsh`` here, agreeing to ~1e-4 relative. At 18 layers
+    per step the SVD path would cost ~150 s/step, so it is not usable at this
+    granularity.
+    """
+    return _gram_singular_values(_gram(weight))
+
+
+def _stable_rank(sigma):
+    """Stable (numerical) rank, reduced over the trailing singular-value axis.
+
+    ``srank(W) = ||W||_F^2 / ||W||_2^2 = sum_i(sigma_i^2) / max_i(sigma_i)^2``,
+    living in ``[1, rank(W)]``: 1 means a single direction carries all the energy,
+    higher means the energy spreads over more directions. Continuous, unlike the
+    hard rank, so collapse shows up as a smooth decline.
+
+    Dominated by ``sigma_max`` — pair it with :func:`_singular_value_entropy`,
+    which weighs the whole spectrum. ``[..., k]`` in, ``[...]`` out.
+    """
+    sq = sigma * sigma
+    return sq.sum(axis=-1) / sq.max(axis=-1).clip(min=1e-12)
+
+
+def _singular_value_entropy(sigma):
+    """Shannon entropy of the normalized singular-value distribution.
+
+    ``H = -sum_i(p_i log p_i)`` with ``p_i = sigma_i / sum_j(sigma_j)``, in nats,
+    over ``[0, log(k)]``: 0 means the spectrum collapsed onto one direction,
+    ``log(k)`` means a flat spectrum (all directions used equally).
+    ``[..., k]`` in, ``[...]`` out.
+
+    Note the sigma (not sigma^2) weighting: the megatron-side
+    ``hidden_spectral_entropy`` normalizes by sigma^2, so the two are not
+    numerically comparable.
+    """
+    p = (sigma / sigma.sum(axis=-1, keepdim=True).clip(min=1e-12)).clip(min=1e-12)
+    return -(p * p.log()).sum(axis=-1)
+
+
+def _swiglu_gate_half(fc1_weight):
+    """The SiLU-gated half of a fused SwiGLU fc1 weight.
+
+    ``GroupedMLPExpert`` doubles the fc1 output width for the gated unit and its
+    ``glu()`` chunks the activation in two along the last axis, applying SiLU to
+    the FIRST chunk. With paddle's ``[..., in, out]`` weight layout the gate
+    projection is therefore ``w[..., : out // 2]`` and the linear "up" projection
+    is the second half.
+    """
+    return fc1_weight[..., : fc1_weight.shape[-1] // 2]
+
+
+def _expert_fc1_weight(moe_layer):
+    """Routed-expert fc1 (fused gate+up) weight with a leading expert dim, or None.
+
+    Mirrors the layouts handled by ``_collect_expert_sumsq``: grouped-gemm
+    ``weight1``, the fused ``up_gate_proj.weight`` ([num_experts, in, 2*inter]),
+    and the non-fused ``LayerList`` of per-expert MLPs (stacked here).
+    """
+    ggm = getattr(moe_layer, "grouped_gemm_experts", None)
+    if ggm is not None and hasattr(ggm, "weight1"):
+        return ggm.weight1
+    experts = getattr(moe_layer, "experts", None)
+    if experts is None:
+        return None
+    if hasattr(experts, "up_gate_proj"):
+        return experts.up_gate_proj.weight
+    if isinstance(experts, (list, nn.LayerList)) or hasattr(experts, "__iter__"):
+        per_expert = [e.up_gate_proj.weight for e in experts if e is not None and hasattr(e, "up_gate_proj")]
+        if per_expert:
+            return paddle.stack(per_expert)
+    return None
+
+
 def _norm_stats(norms):
     """mean/std/min/max stats from a ``[num_experts]`` per-expert norm tensor (GPU tensors)."""
     if norms is None or norms.numel() == 0:
@@ -150,13 +261,22 @@ def _act_stats(act, name_prefix):
 class PaddleMoEMonitor(PaddleProbe):
     METRIC_PREFIX = "moe_health"
     MAX_AGGREGATED = {
-        "score_sum_max", "expert_norm_max", "expert_bias_max",
-        "shared_act_abs_max", "routed_act_abs_max",
+        "score_sum_max",
+        "expert_norm_max",
+        "expert_bias_max",
+        "shared_act_abs_max",
+        "routed_act_abs_max",
         "router_scalar_max",
+        "expert_gate_stable_rank_max",
+        "expert_gate_singular_entropy_max",
     }
     MIN_AGGREGATED = {
-        "score_sum_min", "expert_norm_min", "expert_bias_min",
+        "score_sum_min",
+        "expert_norm_min",
+        "expert_bias_min",
         "router_scalar_min",
+        "expert_gate_stable_rank_min",
+        "expert_gate_singular_entropy_min",
     }
 
     def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
@@ -210,13 +330,23 @@ class PaddleMoEMonitor(PaddleProbe):
                 "expert_norm_max",
                 "shared_expert_norm",
                 "shared_routed_ratio",
+                "expert_gate_stable_rank_mean",
+                "expert_gate_stable_rank_min",
+                "expert_gate_stable_rank_max",
+                "expert_gate_singular_entropy_mean",
+                "expert_gate_singular_entropy_min",
+                "expert_gate_singular_entropy_max",
+                "shared_gate_stable_rank",
+                "shared_gate_singular_entropy",
             ]
             act_metrics = []
             if hasattr(moe_layer, "shared_experts") and moe_layer.shared_experts is not None:
                 act_metrics += ["shared_act_norm", "shared_act_abs_max", "shared_act_mean"]
             if hasattr(moe_layer, "_post_routed_output"):
                 act_metrics += [
-                    "routed_act_norm", "routed_act_abs_max", "routed_act_mean",
+                    "routed_act_norm",
+                    "routed_act_abs_max",
+                    "routed_act_mean",
                     "shared_routed_act_ratio",
                 ]
             for m in gate_metrics + expert_metrics + act_metrics:
@@ -232,9 +362,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 self.hooks.append(hook)
             # Shared expert activation hook
             if hasattr(moe_layer, "shared_experts") and moe_layer.shared_experts is not None:
-                hook = moe_layer.shared_experts.register_forward_post_hook(
-                    self._make_shared_expert_hook(layer_idx)
-                )
+                hook = moe_layer.shared_experts.register_forward_post_hook(self._make_shared_expert_hook(layer_idx))
                 self.hooks.append(hook)
             # Routed expert activation: patch _post_routed_output (called right
             # after routed experts, before adding shared output — no D2H).
@@ -452,6 +580,12 @@ class PaddleMoEMonitor(PaddleProbe):
         for layer_idx, moe_layer in self._expert_norm_layers:
             try:
                 with paddle.no_grad():
+                    self._compute_gate_spectrum_metrics(layer_idx, moe_layer)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[PaddleMoEMonitor] gate-spectrum collect error layer {layer_idx}: {e}")
+            try:
+                with paddle.no_grad():
                     routed_sq, shared_sq, group = self._collect_expert_sumsq(moe_layer)
             except Exception as e:
                 if self.verbose:
@@ -526,9 +660,54 @@ class PaddleMoEMonitor(PaddleProbe):
             self.record_layer_metric(layer_idx, "router_scalar_std", scalar.std())
             self.record_layer_metric(layer_idx, "router_scalar_max", scalar.max())
             self.record_layer_metric(layer_idx, "router_scalar_min", scalar.min())
-            self.record_layer_metric(
-                layer_idx, "router_scalar_ratio", scalar.max() / scalar.min().clip(min=1e-8)
-            )
+            self.record_layer_metric(layer_idx, "router_scalar_ratio", scalar.max() / scalar.min().clip(min=1e-8))
+
+    def _compute_gate_spectrum_metrics(self, layer_idx, moe_layer):
+        """Spectrum health of the experts' SwiGLU gate projection.
+
+        One batched Gram eigensolve per layer covers every local expert plus the
+        shared expert. The per-expert stable ranks / entropies are reduced to
+        mean/min/max so the key count stays per-layer: 256 experts x 18 layers
+        would otherwise be 4608 series. Under expert parallelism each rank holds
+        its own shard of experts; the ``_max`` / ``_min`` keys reduce correctly
+        across ranks in ``training_logs.gather_and_aggregate``, and the mean is
+        exact because the expert count divides evenly across the EP group.
+
+        The shared expert rides along in the routed batch as a Gram matrix rather
+        than as a gate matrix. cuSOLVER re-initializes its ``syevj`` workspace
+        whenever the batch shape changes between calls, so alternating a
+        ``[32, k, k]`` solve with a ``[k, k]`` one costs 1287 ms/layer against
+        197 ms for the equivalent single ``[33, k, k]`` batch (measured in
+        isolated processes on the 4B-A500M shapes). Batching the gate matrices
+        directly cannot work here: this model's routed gate is ``[512, 512]``
+        while the shared one is ``[1024, 512]``. Their Grams are both ``k x k``
+        with the same ``k``, so they batch even when the sources do not.
+        """
+        fc1 = _expert_fc1_weight(moe_layer)
+        shared = getattr(moe_layer, "shared_experts", None)
+        shared_fc1 = getattr(getattr(shared, "up_gate_proj", None), "weight", None)
+        routed_gram = _gram(_swiglu_gate_half(fc1)) if fc1 is not None else None
+        shared_gram = _gram(_swiglu_gate_half(shared_fc1)) if shared_fc1 is not None else None
+
+        if routed_gram is not None and shared_gram is not None and shared_gram.shape == routed_gram.shape[1:]:
+            sigma = _gram_singular_values(paddle.concat([routed_gram, shared_gram.unsqueeze(0)], axis=0))
+            routed_sigma, shared_sigma = sigma[:-1], sigma[-1]
+        else:
+            routed_sigma = _gram_singular_values(routed_gram)
+            shared_sigma = _gram_singular_values(shared_gram)
+
+        if routed_sigma is not None:
+            for name, vals in (
+                ("stable_rank", _stable_rank(routed_sigma)),
+                ("singular_entropy", _singular_value_entropy(routed_sigma)),
+            ):
+                self.record_layer_metric(layer_idx, f"expert_gate_{name}_mean", vals.mean())
+                self.record_layer_metric(layer_idx, f"expert_gate_{name}_min", vals.min())
+                self.record_layer_metric(layer_idx, f"expert_gate_{name}_max", vals.max())
+
+        if shared_sigma is not None:
+            self.record_layer_metric(layer_idx, "shared_gate_stable_rank", _stable_rank(shared_sigma))
+            self.record_layer_metric(layer_idx, "shared_gate_singular_entropy", _singular_value_entropy(shared_sigma))
 
     def _collect_expert_sumsq(self, moe_layer):
         """Per-expert / shared-expert sums of squares for one MoE layer.
@@ -553,9 +732,7 @@ class PaddleMoEMonitor(PaddleProbe):
             # single module whose up_gate_proj/down_proj weights carry a leading
             # expert dim [num_experts, ...]. Vectorize over that dim.
             if hasattr(experts, "up_gate_proj") and hasattr(experts, "down_proj"):
-                routed_sq = _per_expert_stacked_sumsq(
-                    experts.up_gate_proj.weight, experts.down_proj.weight
-                )
+                routed_sq = _per_expert_stacked_sumsq(experts.up_gate_proj.weight, experts.down_proj.weight)
                 shard_group = _intermediate_shard_group(experts)
             elif isinstance(experts, (list, nn.LayerList)) or hasattr(experts, "__iter__"):
                 # Non-fused layout: LayerList of per-expert modules. One sum-sq

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 AVAILABLE_MONITORS = {
     "megatron": ["qk_stats", "moe_health", "ple_health", "massive_act", "mhc_health"],
-    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health"],
+    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health", "attn_update"],
 }
 
 

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 AVAILABLE_MONITORS = {
     "megatron": ["qk_stats", "moe_health", "ple_health", "massive_act", "mhc_health"],
-    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health", "attn_update"],
+    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health", "attn_update", "mlp_update"],
 }
 
 

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 import sys
 import unittest
 from pathlib import Path
@@ -284,6 +285,217 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 3.0, places=4)
         self.assertAlmostEqual(latest["moe_health/global_score_sum_max"], 0.9, places=4)
 
+    def test_singular_values_match_svd_reference(self):
+        """The Gram spectrum equals the SVD spectrum (order is unspecified)."""
+        paddle.seed(0)
+        w = paddle.randn([32, 80])
+        got = paddle.sort(moe_monitor_module._singular_values(w), descending=True)
+        reference = paddle.linalg.svd(w, full_matrices=False)[1]
+        self.assertEqual(list(got.shape), [32])
+        self.assertTrue(bool(paddle.allclose(got, reference, atol=1e-3)))
+
+    def test_singular_values_batched_matches_per_matrix(self):
+        """A batched [E, m, n] input yields one spectrum per matrix."""
+        paddle.seed(0)
+        w = paddle.randn([3, 16, 8])
+        batched = moe_monitor_module._singular_values(w)
+        self.assertEqual(list(batched.shape), [3, 8])
+        for e in range(3):
+            single = moe_monitor_module._singular_values(w[e])
+            self.assertTrue(bool(paddle.allclose(batched[e], single, atol=1e-4)))
+
+    def test_singular_values_return_none_for_unsupported_input(self):
+        self.assertIsNone(moe_monitor_module._singular_values(None))
+        self.assertIsNone(moe_monitor_module._singular_values(paddle.randn([10])))
+
+    def test_spectrum_metrics_reduce_over_trailing_axis(self):
+        """Batched sigma [E, k] reduces to one value per matrix."""
+        sigma = paddle.to_tensor([[1.0, 1.0, 1.0, 1.0], [1.0, 0.0, 0.0, 0.0]])
+        srank = moe_monitor_module._stable_rank(sigma)
+        entropy = moe_monitor_module._singular_value_entropy(sigma)
+        self.assertEqual(list(srank.shape), [2])
+        self.assertAlmostEqual(float(srank[0]), 4.0, places=4)
+        self.assertAlmostEqual(float(srank[1]), 1.0, places=4)
+        self.assertAlmostEqual(float(entropy[0]), math.log(4.0), places=4)
+        self.assertAlmostEqual(float(entropy[1]), 0.0, places=4)
+
+    def test_stable_rank_of_orthogonal_matrix_equals_full_rank(self):
+        """Flat spectrum => srank == min(m, n), the stable-rank upper bound."""
+        q, _ = paddle.linalg.qr(paddle.randn([32, 32]))
+        sigma = moe_monitor_module._singular_values(q)
+        self.assertAlmostEqual(float(moe_monitor_module._stable_rank(sigma)), 32.0, places=3)
+
+    def test_stable_rank_of_rank_one_matrix_is_one(self):
+        """One nonzero singular value => srank == 1, its lower bound."""
+        w = paddle.randn([64, 1]) @ paddle.randn([1, 128])
+        sigma = moe_monitor_module._singular_values(w)
+        self.assertAlmostEqual(float(moe_monitor_module._stable_rank(sigma)), 1.0, places=3)
+
+    def test_stable_rank_matches_frobenius_over_spectral_norm(self):
+        """srank == ||W||_F^2 / ||W||_2^2 computed straight from the SVD."""
+        paddle.seed(0)
+        w = paddle.randn([32, 80])
+        sigma = paddle.linalg.svd(w, full_matrices=False)[1]
+        reference = float((sigma**2).sum() / sigma.max() ** 2)
+        got = float(moe_monitor_module._stable_rank(moe_monitor_module._singular_values(w)))
+        self.assertAlmostEqual(got, reference, places=3)
+
+    def test_singular_value_entropy_of_orthogonal_matrix_equals_log_full_rank(self):
+        """Flat spectrum => H == log(min(m, n)), the entropy upper bound."""
+        q, _ = paddle.linalg.qr(paddle.randn([32, 32]))
+        sigma = moe_monitor_module._singular_values(q)
+        self.assertAlmostEqual(float(moe_monitor_module._singular_value_entropy(sigma)), math.log(32.0), places=3)
+
+    def test_singular_value_entropy_of_rank_one_matrix_is_near_zero(self):
+        """A single dominant singular value collapses H towards 0."""
+        w = paddle.randn([64, 1]) @ paddle.randn([1, 128])
+        sigma = moe_monitor_module._singular_values(w)
+        self.assertLess(float(moe_monitor_module._singular_value_entropy(sigma)), 0.5)
+
+    def test_singular_value_entropy_matches_svd_definition(self):
+        """H == -sum(p log p) with p = sigma / sum(sigma) from the SVD."""
+        paddle.seed(0)
+        w = paddle.randn([32, 80])
+        sigma = paddle.linalg.svd(w, full_matrices=False)[1]
+        p = sigma / sigma.sum()
+        reference = float(-(p * p.log()).sum())
+        got = float(moe_monitor_module._singular_value_entropy(moe_monitor_module._singular_values(w)))
+        self.assertAlmostEqual(got, reference, places=3)
+
+    def test_swiglu_gate_half_takes_first_half_of_output_dim(self):
+        """glu() applies SiLU to the first chunk, so the gate is w[..., :out // 2]."""
+        w = paddle.randn([2, 8, 16])
+        gate = moe_monitor_module._swiglu_gate_half(w)
+        self.assertEqual(list(gate.shape), [2, 8, 8])
+        self.assertTrue(bool(paddle.allclose(gate, w[..., :8])))
+
+    def test_expert_fc1_weight_resolves_supported_layouts(self):
+        """grouped-gemm weight1, fused up_gate_proj and LayerList all resolve."""
+        ggm_w = paddle.randn([2, 4, 8])
+        ggm_layer = SimpleNamespace(grouped_gemm_experts=SimpleNamespace(weight1=ggm_w))
+        self.assertTrue(bool(paddle.allclose(moe_monitor_module._expert_fc1_weight(ggm_layer), ggm_w)))
+
+        fused_w = paddle.randn([3, 4, 8])
+        fused_layer = SimpleNamespace(
+            grouped_gemm_experts=None,
+            experts=SimpleNamespace(up_gate_proj=SimpleNamespace(weight=fused_w)),
+        )
+        self.assertTrue(bool(paddle.allclose(moe_monitor_module._expert_fc1_weight(fused_layer), fused_w)))
+
+        per_expert = [SimpleNamespace(up_gate_proj=SimpleNamespace(weight=paddle.randn([4, 8]))) for _ in range(2)]
+        list_layer = SimpleNamespace(grouped_gemm_experts=None, experts=per_expert)
+        self.assertEqual(list(moe_monitor_module._expert_fc1_weight(list_layer).shape), [2, 4, 8])
+
+        self.assertIsNone(moe_monitor_module._expert_fc1_weight(SimpleNamespace()))
+
+    def test_compute_gate_spectrum_metrics_records_expert_and_shared_gate(self):
+        """Per-expert gate spectra reduce to mean/min/max; shared gate is scalar."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
+        for m in (
+            "expert_gate_stable_rank_mean",
+            "expert_gate_stable_rank_min",
+            "expert_gate_stable_rank_max",
+            "expert_gate_singular_entropy_mean",
+            "expert_gate_singular_entropy_min",
+            "expert_gate_singular_entropy_max",
+            "shared_gate_stable_rank",
+            "shared_gate_singular_entropy",
+        ):
+            monitor.declare_layer_metric(0, m)
+        monitor.allocate_buffers()
+
+        full_rank, _ = paddle.linalg.qr(paddle.randn([8, 8]))  # srank 8, H = log 8
+        collapsed = paddle.randn([8, 1]) @ paddle.randn([1, 8])  # srank 1, H ~ 0
+        gate = paddle.stack([full_rank, collapsed])  # [2, 8, 8]
+        fc1 = paddle.concat([gate, paddle.randn([2, 8, 8])], axis=-1)  # gate | up
+        shared_fc1 = paddle.concat([full_rank, paddle.randn([8, 8])], axis=-1)
+        moe_layer = SimpleNamespace(
+            grouped_gemm_experts=None,
+            experts=SimpleNamespace(up_gate_proj=SimpleNamespace(weight=fc1)),
+            shared_experts=SimpleNamespace(up_gate_proj=SimpleNamespace(weight=shared_fc1)),
+        )
+
+        monitor._compute_gate_spectrum_metrics(0, moe_layer)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_gate_stable_rank_max"], 8.0, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_gate_stable_rank_min"], 1.0, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_gate_stable_rank_mean"], 4.5, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_gate_singular_entropy_max"], math.log(8.0), places=3)
+        self.assertLess(latest["moe_health/layer_0/expert_gate_singular_entropy_min"], 0.5)
+        self.assertAlmostEqual(latest["moe_health/layer_0/shared_gate_stable_rank"], 8.0, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/shared_gate_singular_entropy"], math.log(8.0), places=3)
+        self.assertNotIn("moe_health/layer_0/gate_weight_stable_rank", latest)
+
+    def test_compute_gate_spectrum_metrics_batches_shared_gate_of_different_shape(self):
+        """Shared and routed gate matrices of different shape still share one eigensolve.
+
+        This is the production layout: with ``moe_split_feature_routing`` the routed
+        experts run on half the hidden features, so their gate is ``[512, 512]`` while
+        the shared expert's is ``[1024, 512]``. Batching the gate matrices is
+        impossible, but their Grams are both ``k x k``, so exactly one
+        ``_gram_singular_values`` call must cover both -- alternating batch shapes
+        makes cuSOLVER re-initialize its workspace and costs ~8x.
+        """
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
+        for m in (
+            "expert_gate_stable_rank_mean",
+            "expert_gate_stable_rank_min",
+            "expert_gate_stable_rank_max",
+            "expert_gate_singular_entropy_mean",
+            "expert_gate_singular_entropy_min",
+            "expert_gate_singular_entropy_max",
+            "shared_gate_stable_rank",
+            "shared_gate_singular_entropy",
+        ):
+            monitor.declare_layer_metric(0, m)
+        monitor.allocate_buffers()
+
+        full_rank, _ = paddle.linalg.qr(paddle.randn([8, 8]))  # srank 8, H = log 8
+        collapsed = paddle.randn([8, 1]) @ paddle.randn([1, 8])  # srank 1, H ~ 0
+        fc1 = paddle.concat([paddle.stack([full_rank, collapsed]), paddle.randn([2, 8, 8])], axis=-1)
+        # Shared expert sees twice as many input features: gate half is [16, 8], and
+        # orthonormal columns again put every singular value at 1 -> srank 8, H = log 8.
+        tall_gate, _ = paddle.linalg.qr(paddle.randn([16, 8]))
+        shared_fc1 = paddle.concat([tall_gate, paddle.randn([16, 8])], axis=-1)
+        self.assertNotEqual(tall_gate.shape, fc1.shape[1:])
+        moe_layer = SimpleNamespace(
+            grouped_gemm_experts=None,
+            experts=SimpleNamespace(up_gate_proj=SimpleNamespace(weight=fc1)),
+            shared_experts=SimpleNamespace(up_gate_proj=SimpleNamespace(weight=shared_fc1)),
+        )
+
+        real_solve = moe_monitor_module._gram_singular_values
+        calls = []
+
+        def counting_solve(gram):
+            calls.append(None if gram is None else tuple(gram.shape))
+            return real_solve(gram)
+
+        moe_monitor_module._gram_singular_values = counting_solve
+        try:
+            monitor._compute_gate_spectrum_metrics(0, moe_layer)
+        finally:
+            moe_monitor_module._gram_singular_values = real_solve
+        monitor.step()
+
+        self.assertEqual(calls, [(3, 8, 8)], "routed and shared Grams must batch into one solve")
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_gate_stable_rank_max"], 8.0, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_gate_stable_rank_min"], 1.0, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/shared_gate_stable_rank"], 8.0, places=3)
+        self.assertAlmostEqual(latest["moe_health/layer_0/shared_gate_singular_entropy"], math.log(8.0), places=3)
+
+    def test_compute_gate_spectrum_metrics_skips_layer_without_experts(self):
+        """A layer with no expert weights must not raise and records nothing."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
+        monitor.declare_layer_metric(0, "expert_gate_stable_rank_mean")
+        monitor.allocate_buffers()
+
+        monitor._compute_gate_spectrum_metrics(0, SimpleNamespace())
+        self.assertEqual(monitor._gpu_cnt["moe_health/layer_0/expert_gate_stable_rank_mean"], 0)
+
     def test_attn_type_tag_produces_typed_keys_and_split_global_aggregation(self):
         """When declare/record_layer_metric receives attn_type, keys are
         ``{prefix}/layer_N/{type}_{metric}`` and ``{prefix}/global_{type}_{metric}``.
@@ -349,7 +561,7 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertIsNone(moe_monitor_mod._intermediate_shard_group(None))
 
     def test_collect_expert_norms_fused_layout_records_metrics(self):
-        """collect_expert_norms records expert + shared norms for a fused-expert MoE layer."""
+        """collect_expert_norms records expert norms + gate spectra for a fused-expert MoE layer."""
         monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True, verbose=False)
         for m in [
             "expert_norm_mean",
@@ -358,6 +570,12 @@ class PaddleMoEMonitorTest(unittest.TestCase):
             "expert_norm_max",
             "shared_expert_norm",
             "shared_routed_ratio",
+            "expert_gate_stable_rank_mean",
+            "expert_gate_stable_rank_min",
+            "expert_gate_stable_rank_max",
+            "expert_gate_singular_entropy_mean",
+            "expert_gate_singular_entropy_min",
+            "expert_gate_singular_entropy_max",
         ]:
             monitor.declare_layer_metric(0, m)
         monitor.allocate_buffers()
@@ -379,6 +597,11 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertIn("moe_health/layer_0/expert_norm_mean", latest)
         self.assertIn("moe_health/layer_0/shared_expert_norm", latest)
         self.assertGreater(latest["moe_health/layer_0/expert_norm_mean"], 0.0)
+        # Same step-begin pass also collects the SwiGLU gate spectrum: the gate
+        # half of a [3, 8, 6] fc1 is [3, 8, 3], so srank is in [1, 3].
+        self.assertIn("moe_health/layer_0/expert_gate_stable_rank_mean", latest)
+        self.assertGreaterEqual(latest["moe_health/layer_0/expert_gate_stable_rank_min"], 1.0)
+        self.assertLessEqual(latest["moe_health/layer_0/expert_gate_stable_rank_max"], 3.0)
 
     def test_collect_expert_norms_respects_monitor_interval(self):
         """Expert-norm collection is gated by the global monitor_interval."""

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -491,14 +491,24 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertLess(float(moe_monitor_module._singular_value_entropy(sigma)), 0.5)
 
     def test_singular_value_entropy_matches_svd_definition(self):
-        """H == -sum(p log p) with p = sigma / sum(sigma) from the SVD."""
+        """H == -sum(p log p) with p = sigma^2 / sum(sigma^2) from the SVD."""
         paddle.seed(0)
         w = paddle.randn([32, 80])
         sigma = paddle.linalg.svd(w, full_matrices=False)[1]
-        p = sigma / sigma.sum()
+        p = sigma**2 / (sigma**2).sum()
         reference = float(-(p * p.log()).sum())
         got = float(moe_monitor_module._singular_value_entropy(moe_monitor_module._singular_values(w)))
         self.assertAlmostEqual(got, reference, places=3)
+
+    def test_singular_value_entropy_uses_alpha_two_weighting(self):
+        """A skewed spectrum separates sigma^2 from sigma^1 weighting."""
+        sigma = paddle.to_tensor([4.0, 2.0, 1.0])
+        sq = [16.0, 4.0, 1.0]
+        alpha2 = -sum(v / sum(sq) * math.log(v / sum(sq)) for v in sq)
+        alpha1 = -sum(v / 7.0 * math.log(v / 7.0) for v in (4.0, 2.0, 1.0))
+        got = float(moe_monitor_module._singular_value_entropy(sigma))
+        self.assertAlmostEqual(got, alpha2, places=5)
+        self.assertNotAlmostEqual(got, alpha1, places=2)
 
     def test_swiglu_gate_half_takes_first_half_of_output_dim(self):
         """glu() applies SiLU to the first chunk, so the gate is w[..., :out // 2]."""

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -1946,6 +1946,32 @@ class PaddleAttnUpdateMonitorTest(unittest.TestCase):
         registry = importlib.import_module("internal_medicine.core.registry")
         self.assertIn("attn_update", registry.AVAILABLE_MONITORS["paddlefleet"])
 
+    def test_setup_entry_point_registers_a_working_monitor(self):
+        """The map holds ``setup_attn_update_monitor``, so that is what production calls.
+
+        It has to hand the monitor back through ``monitor_dict`` -- nothing else
+        keeps a reference, so ``step()`` would never be reached -- thread its
+        keyword arguments into the monitor, and return the model untouched.
+        """
+        attn = self._attn()
+        model = SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)])
+        monitors = {}
+
+        returned = attn_update_module.setup_attn_update_monitor(
+            model, monitor_dict=monitors, monitor_interval=1, num_heads_monitored=2
+        )
+
+        self.assertIs(returned, model)
+        monitor = monitors["attn_update"]
+        self.assertIsInstance(monitor, PaddleAttnUpdateMonitor)
+        self.assertEqual(monitor.num_heads_monitored, 2)
+        self.assertEqual([idx for idx, _t, _f in monitor._layers], [0])
+
+        monitor.step()  # base point
+        self._perturb(attn)
+        monitor.step()
+        self.assertIn("attn_update/layer_0/delta2_norm", training_logs.get_latest(prefix="attn_update"))
+
     # ── sampling interval ────────────────────────────────────────────────
 
     def test_sample_interval_defaults_to_monitor_interval(self):
@@ -2072,6 +2098,40 @@ class PaddleAttnUpdateMonitorTest(unittest.TestCase):
         factors = attn_update_module.resolve_qk_factors(attn)
         expected = attn.q_proj.weight[:, 4:8] * attn.q_norm.weight.reshape([1, -1])
         self.assertTrue(paddle.allclose(attn_update_module.effective_wq(factors, 1), expected, atol=1e-5).item())
+
+    def test_split_qk_slices_a_per_layer_qk_norm_by_head(self):
+        """A norm covering all heads at once must be sliced, not broadcast.
+
+        Folding head 1's columns with head 0's scale would silently corrupt the
+        QK circuit, so the head offset is checked on both heads.
+        """
+        attn = SimpleNamespace(
+            q_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            k_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            q_norm=SimpleNamespace(weight=paddle.rand([8]) + 0.5),
+            hidden_size_per_attention_head=4,
+        )
+        factors = attn_update_module.resolve_qk_factors(attn)
+        self.assertNotEqual(attn.q_norm.weight.shape[0], factors["head_dim"])
+
+        for head in (0, 1):
+            start = head * 4
+            scale = attn.q_norm.weight[start : start + 4].reshape([1, -1])
+            expected = attn.q_proj.weight[:, start : start + 4] * scale
+            got = attn_update_module.effective_wq(factors, head)
+            self.assertTrue(paddle.allclose(got, expected, atol=1e-5).item(), f"head {head}")
+
+    def test_qk_norm_of_an_unreadable_width_is_dropped_rather_than_guessed(self):
+        """Neither per-head nor per-layer: fold nothing instead of the wrong slice."""
+        attn = SimpleNamespace(
+            q_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            k_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            q_norm=SimpleNamespace(weight=paddle.rand([5]) + 0.5),
+            hidden_size_per_attention_head=4,
+        )
+        factors = attn_update_module.resolve_qk_factors(attn)
+        got = attn_update_module.effective_wq(factors, 1)
+        self.assertTrue(paddle.allclose(got, attn.q_proj.weight[:, 4:8], atol=1e-5).item())
 
     def test_mixed_layouts_in_one_model_are_bucketed_by_shape(self):
         """Different circuit widths cannot share a batched eigensolve."""

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -22,6 +22,8 @@ PaddleMassiveActivationMonitor = importlib.import_module(
 ).PaddleMassiveActivationMonitor
 PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor").PaddleMoEMonitor
 moe_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
+attn_update_module = importlib.import_module("internal_medicine.backends.paddlefleet.attn_update_monitor")
+PaddleAttnUpdateMonitor = attn_update_module.PaddleAttnUpdateMonitor
 qk_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor")
 PaddleQKStatsMonitor = qk_monitor_module.PaddleQKStatsMonitor
 paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
@@ -1558,6 +1560,457 @@ class SparseQKKernelComputeTest(unittest.TestCase):
         )
         # The sink is not a real key, so logit max/mean must be unchanged.
         self.assertTrue(paddle.allclose(with_sink["max_per_head"], no_sink["max_per_head"], atol=1e-6).item())
+
+
+class PaddleAttnUpdateMonitorTest(unittest.TestCase):
+    """delta2/delta3 = QK-product increment terms (arXiv:2606.28116 eq. 4)."""
+
+    def setUp(self):
+        training_logs.reset()
+        paddle.seed(0)
+
+    def tearDown(self):
+        training_logs.reset()
+
+    @staticmethod
+    def _dense_reference(a, b, alpha=2.0):
+        """Metrics straight off a full float64 SVD of the materialised product."""
+        sigma = paddle.linalg.svd((a @ b.T).astype("float64"), full_matrices=False)[1]
+        squared = sigma * sigma
+        total = squared.sum()
+        weights = squared if alpha == 2.0 else squared ** (alpha / 2.0)
+        p = (weights / weights.sum()).clip(min=1e-300)
+        return {
+            "norm": float(paddle.sqrt(total)),
+            "stable_rank": float(total / squared.max()),
+            "singular_spectrum": float(paddle.exp(-(p * p.log()).sum())),
+        }
+
+    def _assert_matches_dense(self, a, b, alpha=2.0, places=3):
+        got = attn_update_module._spectrum_metrics(attn_update_module._squared_singular_values(a, b), alpha)
+        reference = self._dense_reference(a, b, alpha)
+        for name, expected in reference.items():
+            self.assertAlmostEqual(
+                float(got[name]) / expected, 1.0, places=places, msg=f"{name}: {got[name]} vs {expected}"
+            )
+
+    def test_squared_singular_values_core_branch_matches_dense_svd(self):
+        """2*head_dim < hidden takes the thin-QR core path; spectrum must be identical."""
+        a = paddle.randn([64, 16])
+        b = paddle.randn([64, 16])
+        self.assertLess(a.shape[-1], a.shape[-2])
+        self._assert_matches_dense(a, b, alpha=2.0)
+        self._assert_matches_dense(a, b, alpha=1.0)
+
+    def test_squared_singular_values_direct_branch_matches_dense_svd(self):
+        """2*head_dim >= hidden makes the core no smaller than the product."""
+        a = paddle.randn([32, 32])
+        b = paddle.randn([32, 32])
+        self._assert_matches_dense(a, b, alpha=2.0)
+        self._assert_matches_dense(a, b, alpha=1.0)
+
+    def test_spectrum_metrics_on_flat_spectrum_equals_rank(self):
+        """k equal singular values: stable rank = S_alpha = k, norm = sqrt(sum of squares)."""
+        metrics = attn_update_module._spectrum_metrics(paddle.full([8], 4.0))
+        self.assertAlmostEqual(float(metrics["stable_rank"]), 8.0, places=4)
+        self.assertAlmostEqual(float(metrics["singular_spectrum"]), 8.0, places=4)
+        self.assertAlmostEqual(float(metrics["norm"]), math.sqrt(32.0), places=4)
+
+    def test_spectrum_metrics_on_collapsed_spectrum_is_one(self):
+        """All energy in one direction: both rank measures bottom out at 1."""
+        metrics = attn_update_module._spectrum_metrics(paddle.to_tensor([9.0, 0.0, 0.0, 0.0]))
+        self.assertAlmostEqual(float(metrics["stable_rank"]), 1.0, places=4)
+        self.assertAlmostEqual(float(metrics["singular_spectrum"]), 1.0, places=3)
+        self.assertAlmostEqual(float(metrics["norm"]), 3.0, places=4)
+
+    def test_singular_spectrum_uses_alpha_two_weighting(self):
+        """S_2 weights by sigma^2, so it differs from the sigma-weighted S_1."""
+        squared = paddle.to_tensor([16.0, 4.0, 1.0])
+        s2 = float(attn_update_module._spectrum_metrics(squared, 2.0)["singular_spectrum"])
+        s1 = float(attn_update_module._spectrum_metrics(squared, 1.0)["singular_spectrum"])
+
+        def entropy_rank(weights):
+            total = sum(weights)
+            return math.exp(-sum((w / total) * math.log(w / total) for w in weights))
+
+        self.assertAlmostEqual(s2, entropy_rank([16.0, 4.0, 1.0]), places=4)
+        self.assertAlmostEqual(s1, entropy_rank([4.0, 2.0, 1.0]), places=4)
+        self.assertLess(s2, s1)
+
+    def test_batched_driver_matches_pair_by_pair_metrics(self):
+        """Batching layers into one eigvalsh must not move any value."""
+        pairs = [(paddle.randn([32, 12]), paddle.randn([32, 12])) for _ in range(5)]
+        batched = attn_update_module._spectrum_metrics_over_pairs(pairs)
+        for index, (a, b) in enumerate(pairs):
+            single = attn_update_module._spectrum_metrics(attn_update_module._squared_singular_values(a, b))
+            for key in attn_update_module._SPECTRUM_KEYS:
+                self.assertAlmostEqual(float(batched[key][index]) / float(single[key]), 1.0, places=5, msg=key)
+
+    def test_batched_driver_chunks_without_changing_results(self):
+        """More pairs than fit in one chunk still line up with the flat order."""
+        original = attn_update_module._MAX_BATCH_BYTES
+        pairs = [(paddle.randn([16, 8]), paddle.randn([16, 8])) for _ in range(7)]
+        try:
+            attn_update_module._MAX_BATCH_BYTES = 16 * 16 * 4 * 2  # 2 pairs per chunk
+            chunked = attn_update_module._spectrum_metrics_over_pairs(pairs)
+        finally:
+            attn_update_module._MAX_BATCH_BYTES = original
+        flat = attn_update_module._spectrum_metrics_over_pairs(pairs)
+        for key in attn_update_module._SPECTRUM_KEYS:
+            self.assertEqual(chunked[key].shape, [7])
+            self.assertTrue(paddle.allclose(chunked[key], flat[key], atol=1e-5).item(), key)
+
+    @staticmethod
+    def _attn(hidden=24, q_lora=12, head_dim=8, num_heads=2, with_norms=True):
+        """Minimal DSv4-hybrid QK layout: q_down -> q_layernorm -> q_up, kv -> kv_layernorm."""
+        attn = SimpleNamespace(
+            linear_q_down_proj=SimpleNamespace(weight=paddle.randn([hidden, q_lora])),
+            linear_q_up_proj=SimpleNamespace(weight=paddle.randn([q_lora, head_dim * num_heads])),
+            linear_kv_proj=SimpleNamespace(weight=paddle.randn([hidden, head_dim])),
+        )
+        if with_norms:
+            attn.q_layernorm = SimpleNamespace(weight=paddle.rand([q_lora]) + 0.5)
+            attn.kv_layernorm = SimpleNamespace(weight=paddle.rand([head_dim]) + 0.5)
+        return attn
+
+    @staticmethod
+    def _perturb(attn, scale=0.05):
+        """In-place parameter update, the way an optimizer step mutates weights."""
+        for module in (attn.linear_q_down_proj, attn.linear_q_up_proj, attn.linear_kv_proj):
+            paddle.assign(module.weight + scale * paddle.randn(module.weight.shape), module.weight)
+
+    def test_resolve_qk_factors_reads_head_layout(self):
+        factors = attn_update_module.resolve_qk_factors(self._attn(head_dim=8, num_heads=2))
+        self.assertEqual(factors["head_dim"], 8)
+        self.assertEqual(factors["num_heads"], 2)
+
+    def test_resolve_qk_factors_returns_none_for_other_layouts(self):
+        self.assertIsNone(attn_update_module.resolve_qk_factors(SimpleNamespace()))
+        # q_up width not divisible by the kv head_dim -> not this circuit
+        bad = self._attn(head_dim=8, num_heads=2)
+        bad.linear_q_up_proj = SimpleNamespace(weight=paddle.randn([12, 13]))
+        self.assertIsNone(attn_update_module.resolve_qk_factors(bad))
+
+    def test_effective_wk_snapshot_does_not_alias_the_live_parameter(self):
+        """Without a kv_layernorm the fp32 read is a no-op, so it must clone."""
+        attn = self._attn(with_norms=False)
+        factors = attn_update_module.resolve_qk_factors(attn)
+        snapshot = attn_update_module.effective_wk(factors)
+        before = snapshot.clone()
+        self._perturb(attn, scale=1.0)
+        self.assertTrue(paddle.allclose(snapshot, before).item())
+
+    def test_effective_wq_folds_the_q_layernorm_scale(self):
+        attn = self._attn(head_dim=8, num_heads=2)
+        factors = attn_update_module.resolve_qk_factors(attn)
+        expected = (
+            attn.linear_q_down_proj.weight * attn.q_layernorm.weight.reshape([1, -1])
+        ) @ attn.linear_q_up_proj.weight[:, 8:16]
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wq(factors, 1), expected, atol=1e-5).item())
+
+    def _monitor_on(self, layers, **kwargs):
+        monitor = PaddleAttnUpdateMonitor(monitor_interval=1, **kwargs)
+        monitor.register_hooks(SimpleNamespace(layers=layers))
+        return monitor
+
+    def test_first_monitored_step_only_establishes_the_base_point(self):
+        """delta2 needs two samples; the first step must emit nothing."""
+        attn = self._attn()
+        monitor = self._monitor_on([SimpleNamespace(self_attn=attn)])
+        monitor.step()
+
+        self.assertEqual(training_logs.get_latest(prefix="attn_update"), {})
+        self._perturb(attn)
+        monitor.step()
+        self.assertIn("attn_update/layer_0/delta2_norm", training_logs.get_latest(prefix="attn_update"))
+
+    def test_delta2_and_delta3_match_the_dense_increment_terms(self):
+        """End-to-end: recorded metrics equal those of eq. (4)'s dense products."""
+        attn = self._attn(hidden=24, q_lora=12, head_dim=8, num_heads=2)
+        monitor = self._monitor_on([SimpleNamespace(self_attn=attn)], num_heads_monitored=1)
+        factors = attn_update_module.resolve_qk_factors(attn)
+        wq_base = attn_update_module.effective_wq(factors, 0)
+        wk_base = attn_update_module.effective_wk(factors)
+
+        monitor.step()  # base point
+        self._perturb(attn)
+        monitor.step()  # increments against the base point
+
+        wq_now = attn_update_module.effective_wq(factors, 0)
+        wk_now = attn_update_module.effective_wk(factors)
+        dq, dk = wq_now - wq_base, wk_now - wk_base
+        dense = {
+            "delta2": dq @ wk_base.T + wq_base @ dk.T,
+            "delta3": dq @ dk.T,
+        }
+
+        latest = training_logs.get_latest(prefix="attn_update")
+        for term, product in dense.items():
+            reference = self._dense_reference(product, paddle.eye(product.shape[-1]))
+            for key, expected in reference.items():
+                got = latest[f"attn_update/layer_0/{term}_{key}"]
+                self.assertAlmostEqual(got / expected, 1.0, places=3, msg=f"{term}_{key}")
+
+    def test_delta3_is_second_order_and_far_smaller_than_delta2(self):
+        """eq. (5): ||delta2||_F = O(||W|| ||dW||) vs ||delta3||_F = O(||dW||^2)."""
+        attn = self._attn(hidden=24, q_lora=12, head_dim=8, num_heads=2)
+        monitor = self._monitor_on([SimpleNamespace(self_attn=attn)])
+        monitor.step()
+        self._perturb(attn, scale=0.01)  # ||dW|| << ||W||
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="attn_update")
+        self.assertLess(latest["attn_update/layer_0/delta3_norm"], latest["attn_update/layer_0/delta2_norm"])
+
+    def test_delta3_core_is_half_as_wide_as_delta2(self):
+        """delta3's factors are [d, head_dim]; delta2 concatenates two of them."""
+        attn = self._attn(head_dim=8, num_heads=2)
+        monitor = self._monitor_on([SimpleNamespace(self_attn=attn)])
+        monitor.step()
+        self._perturb(attn)
+        per_term = monitor._prepare_layer(0, monitor._layers[0][2])
+
+        self.assertEqual(sorted(per_term), ["delta2", "delta3"])
+        self.assertEqual([list(m.shape) for m in per_term["delta2"][0]], [[24, 16], [24, 16]])
+        self.assertEqual([list(m.shape) for m in per_term["delta3"][0]], [[24, 8], [24, 8]])
+
+    def test_delta2_is_per_layer_with_global_mean_over_layers(self):
+        attn_a, attn_b = self._attn(), self._attn()
+        monitor = self._monitor_on([SimpleNamespace(self_attn=attn_a), SimpleNamespace(self_attn=attn_b)])
+        monitor.step()
+        self._perturb(attn_a)
+        self._perturb(attn_b, scale=0.5)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="attn_update")
+        for name in attn_update_module.METRIC_NAMES:
+            per_layer = [latest[f"attn_update/layer_{i}/{name}"] for i in (0, 1)]
+            self.assertAlmostEqual(latest[f"attn_update/global_{name}"], sum(per_layer) / 2.0, places=4, msg=name)
+        # A 10x larger update must show a larger increment norm.
+        self.assertLess(latest["attn_update/layer_0/delta2_norm"], latest["attn_update/layer_1/delta2_norm"])
+
+    def test_per_layer_value_is_the_mean_over_monitored_heads(self):
+        attn = self._attn(head_dim=8, num_heads=2)
+        two_heads = self._monitor_on([SimpleNamespace(self_attn=attn)], num_heads_monitored=2)
+        one_head = self._monitor_on([SimpleNamespace(self_attn=attn)], num_heads_monitored=1)
+        for monitor in (two_heads, one_head):
+            monitor.step()
+        self._perturb(attn)
+
+        one_head.step()
+        head0 = training_logs.get_latest(prefix="attn_update")["attn_update/layer_0/delta2_norm"]
+        training_logs.reset()
+        two_heads.step()
+        both = training_logs.get_latest(prefix="attn_update")["attn_update/layer_0/delta2_norm"]
+
+        # Distinct heads give distinct increments, so the 2-head mean must move.
+        self.assertNotAlmostEqual(head0, both, places=4)
+
+    def test_mtp_layer_gets_its_own_suffixed_keys(self):
+        main = SimpleNamespace(self_attn=self._attn())
+        mtp_inner = SimpleNamespace(self_attn=self._attn())
+        # An MTP id is num_hidden_layers + its local index, so the config has to be
+        # reachable from the wrapper; without it the layer is skipped rather than
+        # given an id derived from whatever main layers this rank happens to hold.
+        wrapper = SimpleNamespace(transformer_layer=mtp_inner, config=SimpleNamespace(num_hidden_layers=1))
+        monitor = self._monitor_on([main, wrapper])
+        monitor.step()
+        self._perturb(main.self_attn)
+        self._perturb(mtp_inner.self_attn)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="attn_update")
+        self.assertIn("attn_update/layer_0/delta2_norm", latest)
+        self.assertIn("attn_update/layer_1_mtp/delta2_norm", latest)
+
+    def test_unsupported_layers_are_skipped_without_declaring_metrics(self):
+        monitor = PaddleAttnUpdateMonitor(monitor_interval=1)
+        monitor.register_hooks(SimpleNamespace(layers=[SimpleNamespace(self_attn=SimpleNamespace())]))
+        monitor.step()
+
+        self.assertEqual(monitor._layers, [])
+        self.assertFalse(monitor._buffers_allocated)
+        self.assertEqual(training_logs.get_latest(prefix="attn_update"), {})
+
+    def test_monitor_interval_sets_the_sampling_distance(self):
+        """Metrics only appear on steps that are multiples of monitor_interval."""
+        attn = self._attn()
+        monitor = PaddleAttnUpdateMonitor(monitor_interval=3)
+        monitor.register_hooks(SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]))
+
+        monitor.step()  # step_count 0 -> base point
+        for _ in range(2):
+            self._perturb(attn)
+            monitor.step()
+            self.assertEqual(training_logs.get_latest(prefix="attn_update"), {})
+        self._perturb(attn)
+        monitor.step()  # step_count 3 -> first delta2, sampled 3 steps apart
+        self.assertIn("attn_update/layer_0/delta2_norm", training_logs.get_latest(prefix="attn_update"))
+
+    def test_registered_in_the_paddlefleet_monitor_map(self):
+        self.assertIn("attn_update", paddlefleet_backend._MONITOR_MAP)
+        registry = importlib.import_module("internal_medicine.core.registry")
+        self.assertIn("attn_update", registry.AVAILABLE_MONITORS["paddlefleet"])
+
+    # ── sampling interval ────────────────────────────────────────────────
+
+    def test_sample_interval_defaults_to_monitor_interval(self):
+        self.assertEqual(PaddleAttnUpdateMonitor(monitor_interval=7).monitor_interval, 7)
+
+    def test_sample_interval_overrides_monitor_interval(self):
+        """delta2 costs one eigensolve per sample, so it may sample more sparsely."""
+        monitor = PaddleAttnUpdateMonitor(monitor_interval=1, sample_interval=4)
+        self.assertEqual(monitor.monitor_interval, 4)
+
+        attn = self._attn()
+        monitor.register_hooks(SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]))
+        monitor.step()  # step_count 0 -> base point
+        for _ in range(3):
+            self._perturb(attn)
+            monitor.step()
+            self.assertEqual(training_logs.get_latest(prefix="attn_update"), {})
+        self._perturb(attn)
+        monitor.step()  # step_count 4 -> first delta2
+        self.assertIn("attn_update/layer_0/delta2_norm", training_logs.get_latest(prefix="attn_update"))
+
+    def test_sample_interval_rejects_non_positive_values(self):
+        with self.assertRaises(ValueError):
+            PaddleAttnUpdateMonitor(sample_interval=0)
+
+    # ── attention layouts beyond DSv4-hybrid ─────────────────────────────
+
+    @staticmethod
+    def _mla_attn(hidden=16, q_lora=8, kv_lora=6, nope=4, rope=2, v_head_dim=5, heads=2):
+        """MLA: q_a -> q_a_layernorm -> q_b, kv_a -> kv_a_layernorm -> kv_b."""
+        return SimpleNamespace(
+            q_a_proj=SimpleNamespace(weight=paddle.randn([hidden, q_lora])),
+            q_a_layernorm=SimpleNamespace(weight=paddle.rand([q_lora]) + 0.5),
+            q_b_proj=SimpleNamespace(weight=paddle.randn([q_lora, heads * (nope + rope)])),
+            kv_a_proj_with_mqa=SimpleNamespace(weight=paddle.randn([hidden, kv_lora + rope])),
+            kv_a_layernorm=SimpleNamespace(weight=paddle.rand([kv_lora]) + 0.5),
+            kv_b_proj=SimpleNamespace(weight=paddle.randn([kv_lora, heads * (nope + v_head_dim)])),
+            num_attention_heads_per_partition=heads,
+            qk_nope_head_dim=nope,
+            qk_rope_head_dim=rope,
+        )
+
+    def test_mla_layout_uses_only_the_nope_half_of_each_head(self):
+        attn = self._mla_attn()
+        factors = attn_update_module.resolve_qk_factors(attn)
+        self.assertEqual(factors["kind"], "mla")
+        self.assertEqual(factors["head_dim"], 4)  # qk_nope_head_dim, not q_head_dim
+        self.assertEqual(factors["num_heads"], 2)
+
+        # Head 1's content circuit composes through both latents.
+        q_latent = attn.q_a_proj.weight * attn.q_a_layernorm.weight.reshape([1, -1])
+        expected_q = q_latent @ attn.q_b_proj.weight[:, 6:10]  # head 1, first nope=4 of q_head_dim=6
+        kv_latent = attn.kv_a_proj_with_mqa.weight[:, :6] * attn.kv_a_layernorm.weight.reshape([1, -1])
+        expected_k = kv_latent @ attn.kv_b_proj.weight[:, 9:13]  # head 1, first nope=4 of width=9
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wq(factors, 1), expected_q, atol=1e-5).item())
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wk(factors, 1), expected_k, atol=1e-5).item())
+
+    def test_mla_without_q_lora_reads_q_proj_directly(self):
+        attn = self._mla_attn()
+        del attn.q_a_proj, attn.q_a_layernorm, attn.q_b_proj
+        attn.q_proj = SimpleNamespace(weight=paddle.randn([16, 12]))
+        factors = attn_update_module.resolve_qk_factors(attn)
+        self.assertEqual(factors["kind"], "mla")
+        self.assertIsNone(factors["q_a"])
+        expected = attn.q_proj.weight[:, 6:10]
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wq(factors, 1), expected, atol=1e-5).item())
+
+    @staticmethod
+    def _fused_qkv_attn(hidden=16, head_dim=4, heads=4, kv_heads=2):
+        """Standard attention: one qkv_proj grouped per KV head as Q|K|V."""
+        group_dim = (heads // kv_heads) * head_dim + 2 * head_dim
+        return SimpleNamespace(
+            qkv_proj=SimpleNamespace(weight=paddle.randn([hidden, kv_heads * group_dim])),
+            num_attention_heads_per_partition=heads,
+            num_query_groups_per_partition=kv_heads,
+            hidden_size_per_attention_head=head_dim,
+        )
+
+    def test_fused_qkv_layout_slices_the_interleaved_group(self):
+        attn = self._fused_qkv_attn()
+        factors = attn_update_module.resolve_qk_factors(attn)
+        self.assertEqual(factors["kind"], "fused_qkv")
+        self.assertEqual((factors["num_heads"], factors["num_kv_heads"]), (4, 2))
+        self.assertEqual(factors["group_dim"], 16)
+
+        # Head 3 is the second query head of group 1: q at 16+4, k at 16+8.
+        weight = attn.qkv_proj.weight
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wq(factors, 3), weight[:, 20:24]).item())
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wk(factors, 3), weight[:, 24:28]).item())
+        # Heads 2 and 3 share group 1's single key matrix.
+        self.assertTrue(
+            paddle.allclose(
+                attn_update_module.effective_wk(factors, 2), attn_update_module.effective_wk(factors, 3)
+            ).item()
+        )
+
+    def test_fused_qkv_layout_rejects_a_width_that_contradicts_the_grouping(self):
+        """The group arithmetic is checked against the real weight, not assumed."""
+        attn = self._fused_qkv_attn()
+        attn.qkv_proj = SimpleNamespace(weight=paddle.randn([16, 30]))
+        self.assertIsNone(attn_update_module.resolve_qk_factors(attn))
+
+    def test_split_qk_layout_maps_query_heads_onto_kv_groups(self):
+        attn = SimpleNamespace(
+            q_proj=SimpleNamespace(weight=paddle.randn([16, 16])),
+            k_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            hidden_size_per_attention_head=4,
+        )
+        factors = attn_update_module.resolve_qk_factors(attn)
+        self.assertEqual(factors["kind"], "split_qk")
+        self.assertEqual((factors["num_heads"], factors["num_kv_heads"]), (4, 2))
+        self.assertTrue(
+            paddle.allclose(attn_update_module.effective_wq(factors, 2), attn.q_proj.weight[:, 8:12]).item()
+        )
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wk(factors, 2), attn.k_proj.weight[:, 4:8]).item())
+
+    def test_split_qk_folds_a_per_head_qk_norm(self):
+        attn = SimpleNamespace(
+            q_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            k_proj=SimpleNamespace(weight=paddle.randn([16, 8])),
+            q_norm=SimpleNamespace(weight=paddle.rand([4]) + 0.5),
+            hidden_size_per_attention_head=4,
+        )
+        factors = attn_update_module.resolve_qk_factors(attn)
+        expected = attn.q_proj.weight[:, 4:8] * attn.q_norm.weight.reshape([1, -1])
+        self.assertTrue(paddle.allclose(attn_update_module.effective_wq(factors, 1), expected, atol=1e-5).item())
+
+    def test_mixed_layouts_in_one_model_are_bucketed_by_shape(self):
+        """Different circuit widths cannot share a batched eigensolve."""
+        dsv4 = self._attn(hidden=16, q_lora=8, head_dim=8, num_heads=2)
+        split = SimpleNamespace(
+            q_proj=SimpleNamespace(weight=paddle.randn([16, 16])),
+            k_proj=SimpleNamespace(weight=paddle.randn([16, 16])),
+            hidden_size_per_attention_head=4,
+        )
+        monitor = self._monitor_on([SimpleNamespace(self_attn=dsv4), SimpleNamespace(self_attn=split)])
+        self.assertEqual([f["kind"] for _i, _t, f in monitor._layers], ["dsv4_hybrid", "split_qk"])
+
+        monitor.step()
+        self._perturb(dsv4)
+        paddle.assign(split.q_proj.weight + 0.05 * paddle.randn([16, 16]), split.q_proj.weight)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="attn_update")
+        for name in attn_update_module.METRIC_NAMES:
+            self.assertIn(f"attn_update/layer_0/{name}", latest)
+            self.assertIn(f"attn_update/layer_1/{name}", latest)
+
+    def test_bucketed_pairs_match_per_pair_results_in_caller_order(self):
+        pairs = [
+            (paddle.randn([12, 4]), paddle.randn([12, 4])),
+            (paddle.randn([12, 6]), paddle.randn([12, 6])),
+            (paddle.randn([12, 4]), paddle.randn([12, 4])),
+        ]
+        bucketed = attn_update_module._spectrum_metrics_over_pairs(pairs)
+        for index, (a, b) in enumerate(pairs):
+            single = attn_update_module._spectrum_metrics(attn_update_module._squared_singular_values(a, b))
+            for key in attn_update_module._SPECTRUM_KEYS:
+                self.assertAlmostEqual(float(bucketed[key][index]), float(single[key]), places=4, msg=f"{key}[{index}]")
 
 
 if __name__ == "__main__":

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -634,6 +634,54 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         monitor._compute_gate_spectrum_metrics(0, SimpleNamespace())
         self.assertEqual(monitor._gpu_cnt["moe_health/layer_0/expert_gate_stable_rank_mean"], 0)
 
+    def test_routing_margin_is_finite_when_a_token_is_routed_nowhere(self):
+        """Unrouted rows (router -1 padding) must not turn any statistic into inf."""
+        scores = paddle.to_tensor(
+            [[0.6, 0.4, 0.1, 0.05], [0.1, 0.05, 0.6, 0.4], [0.9, 0.8, 0.7, 0.6]],
+            dtype="float32",
+        )
+        mask = paddle.to_tensor(
+            [[1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]],
+            dtype="float32",
+        )
+        margin, valid = moe_monitor_module._routing_margin(scores, mask)
+
+        self.assertTrue(bool(paddle.isfinite(margin).all()))
+        self.assertEqual([bool(v) for v in valid], [True, True, False])
+        # rows 0 and 1 both have boundary 0.4 - 0.1
+        self.assertAlmostEqual(float(margin[0]), 0.3, places=5)
+        self.assertAlmostEqual(float(margin[1]), 0.3, places=5)
+        # the unrouted row is refilled with the largest real margin, never inf
+        self.assertAlmostEqual(float(margin[2]), 0.3, places=5)
+
+    def test_routing_margin_mean_excludes_unrouted_tokens(self):
+        """The masked mean must equal the mean over routed tokens only."""
+        scores = paddle.to_tensor(
+            [[1.0, 0.9, 0.2, 0.1], [1.0, 0.5, 0.4, 0.3], [0.5, 0.5, 0.5, 0.5]],
+            dtype="float32",
+        )
+        mask = paddle.to_tensor(
+            [[1.0, 1.0, 0.0, 0.0], [1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+            dtype="float32",
+        )
+        margin, valid = moe_monitor_module._routing_margin(scores, mask)
+        weight = valid.astype("float32")
+        masked_mean = float((margin * weight).sum() / weight.sum().clip(min=1.0))
+
+        # row 0: 0.9 - 0.2 = 0.7   row 1: 0.5 - 0.4 = 0.1   row 2: excluded
+        self.assertAlmostEqual(masked_mean, 0.4, places=5)
+        # the unmasked mean would be pulled up by the refilled row
+        self.assertGreater(float(margin.mean()), masked_mean)
+
+    def test_routing_margin_all_tokens_unrouted_stays_finite(self):
+        """Degenerate all-zero mask must not emit inf either."""
+        scores = paddle.to_tensor([[0.4, 0.3, 0.2, 0.1]], dtype="float32")
+        mask = paddle.zeros([1, 4], dtype="float32")
+        margin, valid = moe_monitor_module._routing_margin(scores, mask)
+
+        self.assertTrue(bool(paddle.isfinite(margin).all()))
+        self.assertFalse(bool(valid.any()))
+
     def test_attn_type_tag_produces_typed_keys_and_split_global_aggregation(self):
         """When declare/record_layer_metric receives attn_type, keys are
         ``{prefix}/layer_N/{type}_{metric}`` and ``{prefix}/global_{type}_{metric}``.

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -2473,6 +2473,206 @@ class PaddleMLPUpdateMonitorTest(unittest.TestCase):
         self.assertEqual([measured for measured, _ in seen], [False] + [True] * 6)
         self.assertEqual([spectrum for _, spectrum in seen], [False, True, False, False, True, False, False])
 
+    # ── discovery and wiring ─────────────────────────────────────────────
+
+    def test_discovery_accepts_the_three_expert_block_layouts(self):
+        """The expert block hangs off ``layer.mlp`` on this model family, off
+        ``layer.moe`` elsewhere, and a bare ``MoELayer`` is its own module.
+        """
+        by_mlp = SimpleNamespace(mlp=self._moe_layer())
+        by_moe = SimpleNamespace(moe=self._moe_layer())
+        monitor = PaddleMLPUpdateMonitor(monitor_interval=1)
+
+        found = mlp_update_module._find_moe_layers(SimpleNamespace(layers=[by_mlp, by_moe]), 0, monitor.mark_mtp_layers)
+
+        self.assertEqual([idx for idx, _module in found], [0, 1])
+        self.assertIs(found[0][1], by_mlp.mlp)
+        self.assertIs(found[1][1], by_moe.moe)
+
+    def test_discovery_falls_back_to_named_sublayers_for_a_bare_moe_layer(self):
+        """A stack exposing no decoder-layer list is searched by class name."""
+        latent, experts = self.LATENT, self.EXPERTS
+
+        class MoELayer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.gate = nn.Linear(latent, experts)
+
+        class Block(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.block = MoELayer()
+
+        model = Block()
+        self.assertIsNone(layer_discovery.get_decoder_layers(model))
+
+        monitor = PaddleMLPUpdateMonitor(monitor_interval=1)
+        found = mlp_update_module._find_moe_layers(model, 0, monitor.mark_mtp_layers)
+
+        self.assertEqual([idx for idx, _module in found], [0])
+        self.assertIs(found[0][1], model.block)
+
+        class Dense(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.proj = nn.Linear(latent, experts)
+
+        self.assertEqual(mlp_update_module._find_moe_layers(Dense(), 0, monitor.mark_mtp_layers), [])
+
+    def test_down_weight_reads_every_expert_layout(self):
+        """Mirrors ``_expert_fc1_weight``: grouped-gemm ``weight2``, a fused
+        ``down_proj``, or a per-expert list that has to be stacked.
+        """
+        shape = [self.INTER, self.LATENT]
+        fused = SimpleNamespace(
+            grouped_gemm_experts=None,
+            experts=SimpleNamespace(down_proj=SimpleNamespace(weight=paddle.randn([self.EXPERTS, *shape]))),
+        )
+        listed = SimpleNamespace(
+            grouped_gemm_experts=None,
+            experts=[SimpleNamespace(down_proj=SimpleNamespace(weight=paddle.randn(shape))) for _ in range(3)],
+        )
+
+        self.assertEqual(list(mlp_update_module._expert_fc2_weight(fused).shape), [self.EXPERTS, *shape])
+        self.assertEqual(list(mlp_update_module._expert_fc2_weight(listed).shape), [3, *shape])
+        for empty in (None, []):
+            layer = SimpleNamespace(grouped_gemm_experts=None, experts=empty)
+            self.assertIsNone(mlp_update_module._expert_fc2_weight(layer))
+
+    def test_setup_entry_point_registers_a_working_monitor(self):
+        """``_MONITOR_MAP`` holds ``setup_mlp_update_monitor``, so that is what
+        production calls. It has to hand the monitor back through ``monitor_dict``
+        -- nothing else keeps a reference, so ``collect_expert_norms`` would never
+        be reached -- thread its keyword arguments through, and return the model
+        untouched.
+        """
+        moe_layer = self._moe_layer()
+        model = SimpleNamespace(layers=[SimpleNamespace(mlp=moe_layer)])
+        monitors = {}
+
+        returned = mlp_update_module.setup_mlp_update_monitor(
+            model, monitor_dict=monitors, monitor_interval=1, log_spectrum=True, spectrum_interval=4
+        )
+
+        self.assertIs(returned, model)
+        monitor = monitors["mlp_update"]
+        self.assertIsInstance(monitor, PaddleMLPUpdateMonitor)
+        self.assertTrue(monitor.log_spectrum)
+        self.assertEqual(monitor.spectrum_interval, 4)
+        self.assertEqual([idx for idx, _module in monitor._layers], [0])
+
+        monitor.collect_expert_norms()  # base point only
+        monitor.step()
+        experts = moe_layer.grouped_gemm_experts
+        experts.weight1 = self._bump(experts.weight1)
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        self.assertIn("mlp_update/layer_0/gate_rel_update_mean", training_logs.get_latest(prefix="mlp_update"))
+
+        # monitor_dict is optional; without one the model still comes back unchanged.
+        self.assertIs(mlp_update_module.setup_mlp_update_monitor(model), model)
+
+    def test_a_layer_without_a_shared_expert_declares_no_shared_keys(self):
+        """Declaring a key the layer can never record would publish a series that
+        stays permanently absent from the log.
+        """
+        moe_layer = self._moe_layer()
+        moe_layer.shared_experts = None
+        monitor = PaddleMLPUpdateMonitor(monitor_interval=1)
+        monitor.register_hooks(SimpleNamespace(layers=[SimpleNamespace(mlp=moe_layer)]))
+
+        declared = {key for key in monitor._gpu_cnt if "/layer_0/" in key}
+        self.assertIn("mlp_update/layer_0/gate_rel_update_mean", declared)
+        self.assertNotIn("mlp_update/layer_0/shared_gate_rel_update", declared)
+        self.assertEqual(len(declared), 33)  # 36 minus one shared key per projection
+
+    def test_a_model_without_moe_layers_allocates_nothing(self):
+        """A dense stack must leave the monitor inert, not half-initialised."""
+        monitor = PaddleMLPUpdateMonitor(monitor_interval=1)
+        monitor.register_hooks(SimpleNamespace(layers=[SimpleNamespace(self_attn=SimpleNamespace())]))
+
+        self.assertEqual(monitor._layers, [])
+        self.assertFalse(monitor._buffers_allocated)
+        monitor.collect_expert_norms()
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="mlp_update"), {})
+
+    def test_remove_hooks_releases_the_base_snapshots(self):
+        """The snapshots are the monitor's entire resident cost, so teardown has to
+        drop them rather than merely stop measuring.
+        """
+        monitor = self._monitor(self._moe_layer())
+        monitor.collect_expert_norms()
+        self.assertEqual(list(monitor._snapshots), [0])
+
+        monitor.remove_hooks()
+
+        self.assertEqual(monitor._snapshots, {})
+        self.assertEqual(monitor._layers, [])
+
+    def test_sample_interval_overrides_monitor_interval(self):
+        """The snapshot pair is the resident cost, so it may sample more sparsely
+        than the shared monitor clock.
+        """
+        self.assertEqual(PaddleMLPUpdateMonitor(monitor_interval=7).monitor_interval, 7)
+        self.assertEqual(PaddleMLPUpdateMonitor(monitor_interval=1, sample_interval=4).monitor_interval, 4)
+
+    def test_both_clocks_reject_non_positive_values(self):
+        """``spectrum_interval`` is a modulus; 0 would raise mid-training instead."""
+        with self.assertRaises(ValueError):
+            PaddleMLPUpdateMonitor(sample_interval=0)
+        with self.assertRaises(ValueError):
+            PaddleMLPUpdateMonitor(spectrum_interval=0)
+
+    def test_a_layer_that_raises_does_not_stop_the_later_layers(self):
+        """One unreadable expert block must cost its own layer's metrics, no more."""
+        good = self._moe_layer()
+        monitor = PaddleMLPUpdateMonitor(monitor_interval=1, verbose=True)
+        monitor._layers = [(0, BrokenPaddleMoELayer()), (1, good)]
+        for layer_idx in (0, 1):
+            for name in mlp_update_module.metric_names(False, with_shared=True):
+                monitor.declare_layer_metric(layer_idx, name)
+        monitor.allocate_buffers()
+
+        monitor.collect_expert_norms()
+        monitor.step()
+        experts = good.grouped_gemm_experts
+        experts.weight1 = self._bump(experts.weight1)
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mlp_update")
+        self.assertIn("mlp_update/layer_1/gate_rel_update_mean", latest)
+        self.assertNotIn("mlp_update/layer_0/gate_rel_update_mean", latest)
+
+    def test_a_weight_that_changes_shape_rebases_instead_of_differencing(self):
+        """After a resume or reshard the two readings describe different storage, so
+        the pair is skipped and the fresh snapshot becomes the new base point.
+        """
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer)
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        experts = moe_layer.grouped_gemm_experts
+        experts.weight1 = paddle.randn([self.EXPERTS + 2, self.LATENT, 2 * self.INTER])
+        experts.weight2 = paddle.randn([self.EXPERTS + 2, self.INTER, self.LATENT])
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mlp_update")
+        self.assertNotIn("mlp_update/layer_0/gate_rel_update_mean", latest)
+        self.assertNotIn("mlp_update/layer_0/update_zmax_max", latest)
+
+        experts.weight1 = self._bump(experts.weight1)
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+        self.assertIn("mlp_update/layer_0/gate_rel_update_mean", training_logs.get_latest(prefix="mlp_update"))
+
     def test_registered_in_the_paddlefleet_monitor_map(self):
         """The yaml switch resolves through _MONITOR_MAP."""
         self.assertIn("mlp_update", paddlefleet_backend._MONITOR_MAP)

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -24,6 +24,8 @@ PaddleMoEMonitor = importlib.import_module("internal_medicine.backends.paddlefle
 moe_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.moe_monitor")
 attn_update_module = importlib.import_module("internal_medicine.backends.paddlefleet.attn_update_monitor")
 PaddleAttnUpdateMonitor = attn_update_module.PaddleAttnUpdateMonitor
+mlp_update_module = importlib.import_module("internal_medicine.backends.paddlefleet.mlp_update_monitor")
+PaddleMLPUpdateMonitor = mlp_update_module.PaddleMLPUpdateMonitor
 qk_monitor_module = importlib.import_module("internal_medicine.backends.paddlefleet.qk_monitor")
 PaddleQKStatsMonitor = qk_monitor_module.PaddleQKStatsMonitor
 paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
@@ -2269,3 +2271,212 @@ class PaddleAttnUpdateMonitorTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PaddleMLPUpdateMonitorTest(unittest.TestCase):
+    """dW of the expert MLP, split per (layer, expert, gate/up/down)."""
+
+    EXPERTS = 6
+    LATENT = 32
+    INTER = 16
+
+    def setUp(self):
+        training_logs.reset()
+        paddle.seed(0)
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def _moe_layer(self):
+        return SimpleNamespace(
+            gate=SimpleNamespace(),
+            experts=None,
+            grouped_gemm_experts=SimpleNamespace(
+                weight1=paddle.randn([self.EXPERTS, self.LATENT, 2 * self.INTER]),
+                weight2=paddle.randn([self.EXPERTS, self.INTER, self.LATENT]),
+            ),
+            shared_experts=SimpleNamespace(
+                up_gate_proj=SimpleNamespace(weight=paddle.randn([self.LATENT, 2 * self.INTER])),
+                down_proj=SimpleNamespace(weight=paddle.randn([self.INTER, self.LATENT])),
+            ),
+        )
+
+    def _monitor(self, moe_layer, **kwargs):
+        monitor = PaddleMLPUpdateMonitor(monitor_interval=1, **kwargs)
+        monitor._layers = [(0, moe_layer)]
+        for name in mlp_update_module.metric_names(monitor.log_spectrum, with_shared=True):
+            monitor.declare_layer_metric(0, name)
+        monitor.allocate_buffers()
+        return monitor
+
+    @staticmethod
+    def _bump(weight, scale=0.01):
+        return weight + paddle.randn(weight.shape) * scale
+
+    def _latest(self):
+        return {key.split("/")[-1]: value for key, value in training_logs.get_latest(prefix="mlp_update").items()}
+
+    def test_gate_and_up_split_the_fused_fc1_along_the_intermediate_axis(self):
+        """gate | up must partition fc1's output width exactly, gate first."""
+        fc1 = paddle.arange(self.EXPERTS * self.LATENT * 2 * self.INTER, dtype="float32").reshape(
+            [self.EXPERTS, self.LATENT, 2 * self.INTER]
+        )
+        gate = moe_monitor_module._swiglu_gate_half(fc1)
+        up = mlp_update_module._swiglu_up_half(fc1)
+        self.assertEqual(list(gate.shape), [self.EXPERTS, self.LATENT, self.INTER])
+        self.assertTrue(bool(paddle.all(gate == fc1[..., : self.INTER])))
+        self.assertTrue(bool(paddle.all(up == fc1[..., self.INTER :])))
+        self.assertTrue(bool(paddle.all(paddle.concat([gate, up], axis=-1) == fc1)))
+
+    def test_first_collect_only_establishes_the_base_point(self):
+        """One reading cannot give an increment, so nothing may be logged."""
+        monitor = self._monitor(self._moe_layer())
+        monitor.collect_expert_norms()
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="mlp_update"), {})
+
+    def test_relative_update_matches_the_frobenius_ratio_per_expert(self):
+        """r = ||dW||_F / ||W||_F, measured on each expert's own gate matrix."""
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer)
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        base = moe_layer.grouped_gemm_experts.weight1
+        delta = paddle.randn(base.shape) * 0.02
+        moe_layer.grouped_gemm_experts.weight1 = base + delta
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        now_gate = (base + delta)[..., : self.INTER].astype("float64")
+        delta_gate = delta[..., : self.INTER].astype("float64")
+        reference = paddle.sqrt((delta_gate**2).sum(axis=[-2, -1])) / paddle.sqrt((now_gate**2).sum(axis=[-2, -1]))
+        latest = self._latest()
+        self.assertAlmostEqual(latest["gate_rel_update_mean"], float(reference.mean()), places=6)
+        self.assertAlmostEqual(latest["gate_rel_update_max"], float(reference.max()), places=6)
+        self.assertAlmostEqual(latest["gate_rel_update_min"], float(reference.min()), places=6)
+
+    def _stable_rank_against_dense(self, delta):
+        """``(monitor value, dense float64 SVD value)`` for the gate half of ``delta``."""
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer)
+        monitor.collect_expert_norms()
+        monitor.step()
+        moe_layer.grouped_gemm_experts.weight1 = moe_layer.grouped_gemm_experts.weight1 + delta
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        ranks = []
+        for expert in range(self.EXPERTS):
+            sigma = paddle.linalg.svd(delta[expert, :, : self.INTER].astype("float64"), full_matrices=False)[1]
+            ranks.append(float((sigma**2).sum() / sigma.max() ** 2))
+        return self._latest()["gate_stable_rank_mean"], sum(ranks) / len(ranks)
+
+    def test_stable_rank_is_exact_when_the_update_concentrates(self):
+        """A dominant direction makes the power iteration converge immediately.
+
+        This is the case the metric exists for, so it has to be tight here.
+        """
+        base = paddle.randn([self.EXPERTS, self.LATENT, 2 * self.INTER]) * 0.02
+        left = paddle.randn([self.EXPERTS, self.LATENT, 1])
+        right = paddle.randn([self.EXPERTS, 1, 2 * self.INTER])
+        delta = base + 20.0 * paddle.matmul(left, right)
+        got, reference = self._stable_rank_against_dense(delta)
+        self.assertAlmostEqual(got / reference, 1.0, places=5)
+
+    def test_stable_rank_bias_on_a_flat_update_is_small_and_one_sided(self):
+        """A near-flat spectrum converges slowly, and only ever understates sigma_1.
+
+        An understated sigma_1 inflates the stable rank, so the deviation must be
+        upward and within a few percent -- the regime where the exact value does
+        not change the reading anyway.
+        """
+        delta = paddle.randn([self.EXPERTS, self.LATENT, 2 * self.INTER]) * 0.02
+        got, reference = self._stable_rank_against_dense(delta)
+        self.assertGreaterEqual(got, reference - 1e-6)
+        self.assertLess(got / reference, 1.05)
+
+    def test_each_projection_is_measured_on_its_own_scale(self):
+        """A large down update must not leak into the gate / up readings."""
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer)
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        experts = moe_layer.grouped_gemm_experts
+        experts.weight1 = self._bump(experts.weight1, 0.01)
+        experts.weight2 = self._bump(experts.weight2, 0.20)
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        latest = self._latest()
+        self.assertGreater(latest["down_rel_update_mean"], 5 * latest["gate_rel_update_mean"])
+        self.assertAlmostEqual(latest["gate_rel_update_mean"], latest["up_rel_update_mean"], places=2)
+
+    def test_a_frozen_expert_reads_zero_update_and_unit_stable_rank(self):
+        """dW = 0 is 0/0 for the stable rank; it must land on the lower bound 1."""
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer)
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        delta = paddle.randn(moe_layer.grouped_gemm_experts.weight1.shape) * 0.02
+        delta[0] *= 0.0
+        moe_layer.grouped_gemm_experts.weight1 = moe_layer.grouped_gemm_experts.weight1 + delta
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        latest = self._latest()
+        self.assertAlmostEqual(latest["gate_rel_update_min"], 0.0, places=9)
+        self.assertAlmostEqual(latest["gate_stable_rank_min"], 1.0, places=6)
+        self.assertGreater(latest["gate_stable_rank_max"], 1.0)
+
+    def test_expert_score_keeps_a_single_anomalous_projection_visible(self):
+        """S[e] = max_m z(r_m[e]); an up-only outlier must not be averaged away."""
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer)
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        experts = moe_layer.grouped_gemm_experts
+        delta = paddle.randn(experts.weight1.shape) * 0.01
+        delta[2, :, self.INTER :] *= 25.0
+        experts.weight1 = experts.weight1 + delta
+        experts.weight2 = self._bump(experts.weight2, 0.01)
+        training_logs.reset()
+        monitor.collect_expert_norms()
+        monitor.step()
+
+        latest = self._latest()
+        # A z-score over n samples cannot exceed (n - 1) / sqrt(n), so the metric
+        # saturates: it is an outlier detector, not a magnitude.
+        ceiling = (self.EXPERTS - 1) / math.sqrt(self.EXPERTS)
+        self.assertGreater(latest["update_zmax_max"], 1.5)
+        self.assertLessEqual(latest["update_zmax_max"], ceiling + 1e-4)
+        self.assertGreater(latest["update_zmax_max"], latest["update_zmax_p90"])
+
+    def test_spectrum_rides_a_coarser_clock_than_the_relative_updates(self):
+        """log_spectrum with spectrum_interval=3: entropy on every third sample."""
+        moe_layer = self._moe_layer()
+        monitor = self._monitor(moe_layer, log_spectrum=True, spectrum_interval=3)
+        seen = []
+        for _ in range(7):
+            experts = moe_layer.grouped_gemm_experts
+            experts.weight1 = self._bump(experts.weight1)
+            training_logs.reset()
+            monitor.collect_expert_norms()
+            monitor.step()
+            keys = training_logs.get_latest(prefix="mlp_update")
+            seen.append((bool(keys), any("singular_entropy" in key for key in keys)))
+
+        self.assertEqual([measured for measured, _ in seen], [False] + [True] * 6)
+        self.assertEqual([spectrum for _, spectrum in seen], [False, True, False, False, True, False, False])
+
+    def test_registered_in_the_paddlefleet_monitor_map(self):
+        """The yaml switch resolves through _MONITOR_MAP."""
+        self.assertIn("mlp_update", paddlefleet_backend._MONITOR_MAP)
+        self.assertIs(paddlefleet_backend._MONITOR_MAP["mlp_update"], mlp_update_module.setup_mlp_update_monitor)


### PR DESCRIPTION
## Summary

- Add stable rank and singular-value entropy for the routed experts' SwiGLU gate projection: `expert_gate_stable_rank_{mean,min,max}` and `expert_gate_singular_entropy_{mean,min,max}`.
- Add the same two metrics for the shared expert as scalars: `shared_gate_stable_rank` and `shared_gate_singular_entropy`.
- Add the `attn_update` monitor, reporting spectral metrics of the QK-product increment for its first- and second-order terms: `delta2_*` and `delta3_*` over `norm`, `stable_rank`, and `singular_spectrum`.
- Add the `mlp_update` monitor, reporting the parameter increment `ΔW_m` of the MoE experts' MLP for `m ∈ {gate, up, down}`, measured per (layer, expert, projection) and aggregated per layer: 36 keys per layer.
- Give `attn_update` and `mlp_update` their own `sample_interval`, decoupled from the shared `monitor_interval`; `mlp_update` additionally puts its SVD work on a coarser `spectrum_interval` clock.
- Document all three in the README.

## Motivation

Gate stable rank tracks how many directions of an expert's gating projection still carry energy. A collapsing gate spectrum precedes expert under-use that hard assignment counts cannot show, because an expert can keep receiving tokens while its gating transform degenerates (arXiv:2608.09119, arXiv:2507.20534).

The QK product changes as `Δ₁ = Δ₂ + Δ₃`, where `Δ₂ = ΔW_q W_kᵀ + W_q ΔW_kᵀ` is first order and `Δ₃ = ΔW_q ΔW_kᵀ` is second order. The spectrum of `Δ₂` reports the rank of the update actually applied to attention logits, which weight norms alone do not distinguish (arXiv:2606.28116). `Δ₁` is left out: it is dominated by `Δ₂` through early and mid training, and measuring it again costs another `2·head_dim`-wide core.

`mlp_update` asks the same question of the expert FFN rather than of attention. For `ΔW_m^(l,e) = W_{m,t} − W_{m,t−δ}` it reports the relative update `r = ‖ΔW‖_F / (‖W‖_F + ε)`, the stable rank `‖ΔW‖_F² / ‖ΔW‖₂²`, and optionally the singular entropy. The three projections are measured separately rather than as one concatenated matrix: `gate` and `up` gate each other multiplicatively and `down` reads a different space, so their spectra are not comparable and stacking them would report the spectrum of an object the model never applies. Expert-level anomaly is scored as `S^(l,e) = max_m z(r_m^(l,e))`, standardising within each projection before taking the max, so a single misbehaving projection stays visible and the raw norms of the three -- which live on different scales -- are never averaged together.

Spectra are taken from the Gram matrix, `σ_i = sqrt(λ_i(WᵀW))` via `eigvalsh` on whichever of `WWᵀ` and `WᵀW` is smaller, rather than from `svdvals`. Routed and shared gates are solved in one batch by concatenating their Grams instead of their gate matrices: under `moe_split_feature_routing` the routed gate is `[512, 512]` while the shared one is `[1024, 512]`, so the sources cannot batch even though their Grams can. Alternating batch shapes between calls makes cuSOLVER rebuild its `syevj` workspace.

`attn_update` installs no forward hooks; it reads Q/K weights at step boundaries and treats the previous read as the base point. `Δ₂` and `Δ₃` factor exactly, so their non-zero spectra come from a thin-QR core `R_A R_Bᵀ` and the `d × d` product is never materialised. MoE gate spectra are collected in `on_step_begin`, before FP8 offline quantisation releases the bf16 expert weights.

`mlp_update` is weight-only for the same reason. Where the checkpoint fuses gate and up into one `gate_up_proj`, the increment is split along the intermediate axis into its two halves before any norm or spectrum is taken, rather than differenced from two separate snapshots. `σ₁` comes from power iteration on `ΔW` instead of a full solve, and the start vector is generated deterministically from `arange` rather than `paddle.randn`, so monitored steps do not advance the global RNG and desynchronise dropout or router noise. The base snapshot is cloned in the parameter's own dtype, which makes the measurement exact with respect to what is readable but quantised to the bf16 grid: relative updates below roughly `2⁻⁹` read as `r = 0`.

## Metric convention

Both entropies weight the spectrum by `σ²`, i.e. `p_i = σ_i² / Σ_j σ_j²`. One asymmetry is deliberate but worth flagging for anyone reading the two groups side by side: `moe_health` reports the entropy itself, `H = −Σ p log p`, while `attn_update` reports its exponential, `exp(H)`, an effective-rank count directly comparable to the `stable_rank` next to it.

## Validation

- `tests/test_paddlefleet_monitors.py`: 145 passed. With the `ape_health` suite that arrived from master, 150 passed.
- Gram spectra agree with `paddle.linalg.svd`, and recorded increment metrics agree with a float64 dense SVD of the materialised products, to within 1e-3 relative.
- Covered orthogonal and rank-one boundary values, batched versus per-matrix solves, Gram batching versus separate solves, shape-bucketing order, and the slicing and norm folding of four attention layouts.
- `mlp_update` is checked against the Frobenius ratio per expert, on a frozen expert (which reads exactly `r = 0` and unit stable rank), on the fused-fc1 split, and on the coarser spectrum clock. Its power-iteration stable rank is exact to 5 places when the update concentrates; on a flat random spectrum the bias is one-sided and under 5%, and that bound is asserted rather than hidden behind a looser tolerance.
- Coverage of the lines this PR adds: `attn_update_monitor.py` 85% branch, `mlp_update_monitor.py` 98% branch, `moe_monitor.py` 97% statement over its 63 added statements (the two uncovered are a `return None` fallback and a `logger.error` inside an exception handler).
- `mlp_update`'s discovery and wiring path is covered as well as its mathematics: the three expert-block layouts (`layer.mlp`, `layer.moe`, and a bare `MoELayer` found through `named_sublayers`), the dense stack that must yield no layers, `setup_mlp_update_monitor` as production calls it, a layer with no shared expert declaring 33 keys instead of 36, a dense model leaving the monitor inert rather than half-initialised, `remove_hooks` actually dropping the snapshots, one layer raising without stopping the later ones, and a weight that changes shape between readings being rebased rather than differenced against mismatched storage. What is left uncovered is the `except Exception: pass` around the `pp_rank` import and three arcs no reachable input takes.
- No forward hooks are added and no hook-time collectives are introduced; per-expert values are reduced to mean/min/max/quantiles on the existing log-time aggregation rather than emitted as 4608 series.

## Notes for reviewers

- This branch merges `master` through #54. The merge takes upstream's `_routing_margin` and `_masked_margin_metrics` wholesale, so the code added by 5a9d016 on this branch no longer exists in the tree: upstream's validity test also rejects all-selected rows, and it adds `router_margin_valid_ratio`. The commit stays in history; its implementation does not.
- The `+1/-3` in `tests/test_paddlefleet_ape_monitor.py` is `ruff format` collapsing one line to the repo's 120-column limit, nothing else. Happy to drop it from the diff if you would rather that file stayed untouched.
- Per-expert series are not exported. `update_zmax_{max,p90,min}` is the intended entry point for locating an anomalous expert; the per-expert values behind it stay on device.
