### PR TITLE
feat: add APE health monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
+- **APE Health** — CSA/HCA compressor APE 参数健康监控 (P0 级 7 指标；仅 paddlefleet)
 
 以及一个挂在**优化器**而不是模型上的模块，**始终装上**（无需点名，调用方零改动；上报频率同样受 `monitor_interval` 门控）：
 - **[Optimizer Update](./docs/optim_update.md)** — `optim/update_rms`、`optim/param_rms`、`optim/update_param_ratio`，与 grad norm 并排看
@@ -28,7 +29,7 @@ monitor_dict = {}
 # 启用全部监控 (默认)
 model = setup_internal_medicine(
     model,
-    monitors=['all'],              # 或指定 ['moe_health', 'qk_stats', 'massive_act', 'ple_health']
+    monitors=['all'],              # 或指定 ['ape_health', 'moe_health', 'qk_stats', 'massive_act']
     monitor_dict=monitor_dict,
     monitor_interval=1,
     verbose=False,
@@ -115,6 +116,7 @@ setup_internal_medicine()
     ├── setup_moe_monitor()   → MoESpecialistMonitor → forward hooks on MoE layers
     ├── setup_qk_monitor()    → QKStatsMonitor     → forward pre-hooks on core_attention
     ├── setup_massive_activation_monitor() → MassiveActivationMonitor → forward pre-hooks on transformer layers
+    ├── setup_ape_monitor() → APEHealthMonitor → forward pre-hooks on APE compressors
     └── setup_ple_monitor()   → PLEHealthMonitor   → forward hooks on PLE modules
                                         │
                                         ▼
@@ -136,7 +138,7 @@ setup_internal_medicine()
 {monitor_name}/global_{metric_name}                     # 全局聚合指标
 ```
 
-- `monitor_name`: `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health`
+- `monitor_name`: `ape_health` | `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health`
 - `global_idx`: 全局层索引。优先取模块自带的 `layer.layer_number`（0-based 全局编号）；取不到时回退到
   `pp_rank × local_layers + local_idx`。`num_empty_layers_add_in_head > 0` 时所有层号整体偏移该值，看板对号要减掉
 - `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -3,6 +3,7 @@
 import logging
 
 from .base import PaddleProbe
+from .ape_monitor import PaddleAPEHealthMonitor, setup_ape_monitor
 from .gather import install_gather_fn
 from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_massive_activation_monitor
 from .mhc_monitor import PaddleMHCHealthMonitor, setup_mhc_monitor
@@ -13,6 +14,7 @@ from .vha_monitor import PaddleVHAHealthMonitor, setup_vha_monitor
 logger = logging.getLogger(__name__)
 
 _MONITOR_MAP = {
+    "ape_health": setup_ape_monitor,
     "qk_stats": setup_qk_monitor,
     "moe_health": setup_moe_monitor,
     "massive_act": setup_massive_activation_monitor,
@@ -117,6 +119,8 @@ __all__ = [
     "PaddleProbe",
     "PaddleQKStatsMonitor",
     "setup_qk_monitor",
+    "PaddleAPEHealthMonitor",
+    "setup_ape_monitor",
     "PaddleMoEMonitor",
     "setup_moe_monitor",
     "PaddleMassiveActivationMonitor",

--- a/src/internal_medicine/backends/paddlefleet/ape_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/ape_metrics.py
@@ -1,0 +1,39 @@
+"""GPU-side metric computation for APE health monitoring."""
+
+import paddle
+
+
+def compute_ape_p0_metrics(ape: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Compute P0 metrics for one ``[position, channel]`` APE tensor."""
+    if len(ape.shape) != 2:
+        raise ValueError(f"APE must be rank-2 [position, channel], got {ape.shape}")
+    if ape.shape[0] <= 0 or ape.shape[1] <= 0:
+        raise ValueError(f"APE must have non-empty dimensions, got {ape.shape}")
+
+    values = paddle.cast(ape, "float32")
+    finite = paddle.isfinite(values)
+    non_finite_ratio = 1.0 - paddle.cast(finite, "float32").mean()
+    values = paddle.where(finite, values, paddle.zeros_like(values))
+
+    rms = paddle.sqrt(paddle.mean(paddle.square(values)))
+    centered = values - values.mean(axis=0, keepdim=True)
+    centered_rms = paddle.sqrt(paddle.mean(paddle.square(centered)))
+
+    position_range = values.max(axis=0) - values.min(axis=0)
+    position_range_p95 = paddle.quantile(position_range, 0.95)
+
+    probabilities = paddle.nn.functional.softmax(values, axis=0)
+    entropy = -(probabilities * paddle.log(paddle.clip(probabilities, min=1e-12))).sum(axis=0)
+    position_count = paddle.to_tensor(float(values.shape[0]), dtype="float32")
+    entropy_norm = entropy / paddle.log(position_count)
+    max_probability = probabilities.max(axis=0)
+
+    return {
+        "non_finite_ratio": non_finite_ratio,
+        "rms": rms,
+        "centered_rms": centered_rms,
+        "position_range_p95": position_range_p95,
+        "softmax_entropy_norm_mean": entropy_norm.mean(),
+        "softmax_max_prob_p95": paddle.quantile(max_probability, 0.95),
+        "effective_positions_mean": paddle.exp(entropy).mean(),
+    }

--- a/src/internal_medicine/backends/paddlefleet/ape_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/ape_monitor.py
@@ -1,0 +1,155 @@
+"""APE health monitor for PaddleFleet compressor parameters."""
+
+import logging
+
+import paddle
+from paddle import nn
+
+from .ape_metrics import compute_ape_p0_metrics
+from .base import PaddleProbe
+from .layer_discovery import get_attention_module, get_decoder_layers, iter_monitor_layers
+
+logger = logging.getLogger(__name__)
+
+_APE_BRANCHES = ("core", "indexer")
+_P0_METRICS = (
+    "non_finite_ratio",
+    "rms",
+    "centered_rms",
+    "position_range_p95",
+    "softmax_entropy_norm_mean",
+    "softmax_max_prob_p95",
+    "effective_positions_mean",
+)
+
+
+class PaddleAPEHealthMonitor(PaddleProbe):
+    """Monitor APE parameters without materializing them on CPU in hooks."""
+
+    METRIC_PREFIX = "ape_health"
+    MAX_AGGREGATED = {
+        f"{branch}_{metric}"
+        for branch in _APE_BRANCHES
+        for metric in ("non_finite_ratio", "position_range_p95", "softmax_max_prob_p95")
+    }
+    MIN_AGGREGATED = {
+        f"{branch}_{metric}"
+        for branch in _APE_BRANCHES
+        for metric in ("softmax_entropy_norm_mean", "effective_positions_mean")
+    }
+
+    def __init__(
+        self,
+        log_per_layer: bool = True,
+        log_global: bool = True,
+        monitor_interval: int = 1,
+        verbose: bool = False,
+        sample_layers: list[int] | None = None,
+    ):
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=monitor_interval,
+            verbose=verbose,
+        )
+        self.sample_layers = set(sample_layers) if sample_layers else None
+        self._failed_layers: set[tuple[int, str]] = set()
+
+    @staticmethod
+    def _compressors(attention) -> list[tuple[str, nn.Layer]]:
+        """Return distinct core/indexer compressors that own an APE tensor."""
+        core_attention = getattr(attention, "core_attention", None)
+        if core_attention is None:
+            return []
+        candidates = [
+            ("core", getattr(core_attention, "compressor", None)),
+            ("indexer", getattr(getattr(core_attention, "indexer", None), "compressor", None)),
+        ]
+        result = []
+        seen = set()
+        for branch, compressor in candidates:
+            ape = getattr(compressor, "ape", None)
+            if compressor is None or not isinstance(ape, paddle.Tensor) or id(compressor) in seen:
+                continue
+            seen.add(id(compressor))
+            result.append((branch, compressor))
+        return result
+
+    def _find_targets(self, model):
+        layers = get_decoder_layers(model)
+        if not layers:
+            return []
+
+        def matches(layer):
+            attention = get_attention_module(layer)
+            return attention is not None and bool(self._compressors(attention))
+
+        monitor_layers = iter_monitor_layers(layers, matches, pp_rank=self.pp_rank)
+        self.mark_mtp_layers(item.idx for item in monitor_layers if item.is_mtp)
+        targets = []
+        for item in monitor_layers:
+            if self.sample_layers and item.idx not in self.sample_layers:
+                continue
+            attention = get_attention_module(item.layer)
+            targets.extend((item.idx, branch, compressor) for branch, compressor in self._compressors(attention))
+        return targets
+
+    def register_hooks(self, model: nn.Layer):
+        targets = self._find_targets(model)
+        if not targets:
+            logger.info("[PaddleAPEHealthMonitor] No APE compressors found; skipping.")
+            return
+
+        for layer_idx, branch, _compressor in targets:
+            for metric_name in _P0_METRICS:
+                self.declare_layer_metric(layer_idx, f"{branch}_{metric_name}")
+        self.allocate_buffers()
+
+        for layer_idx, branch, compressor in targets:
+            hook = compressor.register_forward_pre_hook(self._make_ape_hook(layer_idx, branch))
+            self.hooks.append(hook)
+        logger.info("[PaddleAPEHealthMonitor] Registered %d APE hooks.", len(targets))
+
+    def _make_ape_hook(self, layer_idx: int, branch: str):
+        def hook_fn(module, _inputs):
+            if not module.training or not self._should_monitor():
+                return
+            try:
+                with paddle.no_grad():
+                    metrics = compute_ape_p0_metrics(module.ape)
+                    for name, value in metrics.items():
+                        self.record_layer_metric(layer_idx, f"{branch}_{name}", value)
+            except Exception as exc:
+                key = (layer_idx, branch)
+                if self.verbose and key not in self._failed_layers:
+                    logger.exception(
+                        "[PaddleAPEHealthMonitor] Failed at layer %s (%s): %s",
+                        layer_idx,
+                        branch,
+                        exc,
+                    )
+                    self._failed_layers.add(key)
+
+        return hook_fn
+
+
+def setup_ape_monitor(
+    model,
+    log_per_layer: bool = True,
+    log_global: bool = True,
+    monitor_interval: int = 1,
+    verbose: bool = False,
+    sample_layers: list[int] | None = None,
+    monitor_dict: dict | None = None,
+):
+    monitor = PaddleAPEHealthMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+        sample_layers=sample_layers,
+    )
+    monitor.register_hooks(model)
+    if monitor_dict is not None:
+        monitor_dict["ape_health"] = monitor
+    return model

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 AVAILABLE_MONITORS = {
     "megatron": ["qk_stats", "moe_health", "ple_health", "massive_act", "mhc_health"],
-    "paddlefleet": ["qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health"],
+    "paddlefleet": ["ape_health", "qk_stats", "moe_health", "massive_act", "mhc_health", "vha_health"],
 }
 
 

--- a/tests/test_paddlefleet_ape_monitor.py
+++ b/tests/test_paddlefleet_ape_monitor.py
@@ -1,0 +1,92 @@
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+try:
+    paddle = importlib.import_module("paddle")
+except Exception as exc:  # pragma: no cover - optional backend
+    raise unittest.SkipTest(f"paddle backend unavailable: {exc}") from exc
+
+ape_metrics = importlib.import_module("internal_medicine.backends.paddlefleet.ape_metrics")
+ape_monitor = importlib.import_module("internal_medicine.backends.paddlefleet.ape_monitor")
+training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
+
+
+class PaddleAPEMetricsTest(unittest.TestCase):
+    def test_uniform_ape_has_uniform_position_distribution(self):
+        metrics = ape_metrics.compute_ape_p0_metrics(paddle.zeros([4, 3], dtype="float32"))
+
+        self.assertAlmostEqual(float(metrics["non_finite_ratio"]), 0.0)
+        self.assertAlmostEqual(float(metrics["rms"]), 0.0)
+        self.assertAlmostEqual(float(metrics["centered_rms"]), 0.0)
+        self.assertAlmostEqual(float(metrics["position_range_p95"]), 0.0)
+        self.assertAlmostEqual(float(metrics["softmax_entropy_norm_mean"]), 1.0, places=6)
+        self.assertAlmostEqual(float(metrics["softmax_max_prob_p95"]), 0.25, places=6)
+        self.assertAlmostEqual(float(metrics["effective_positions_mean"]), 4.0, places=6)
+
+    def test_non_finite_values_are_counted_and_do_not_poison_metrics(self):
+        ape = paddle.to_tensor([[float("nan"), 1.0], [float("inf"), 1.0]], dtype="float32")
+        metrics = ape_metrics.compute_ape_p0_metrics(ape)
+
+        self.assertAlmostEqual(float(metrics["non_finite_ratio"]), 0.5)
+        self.assertTrue(all(bool(paddle.isfinite(value)) for value in metrics.values()))
+
+    def test_metric_function_requires_rank_two_ape(self):
+        with self.assertRaises(ValueError):
+            ape_metrics.compute_ape_p0_metrics(paddle.zeros([2, 2, 1], dtype="float32"))
+
+
+class PaddleAPEHealthMonitorTest(unittest.TestCase):
+    def tearDown(self):
+        training_logs.reset()
+
+    def test_p0_schema_and_aggregation_rules(self):
+        monitor = ape_monitor.PaddleAPEHealthMonitor()
+        for branch in ("core", "indexer"):
+            for metric in ape_monitor._P0_METRICS:
+                monitor.declare_layer_metric(0, f"{branch}_{metric}")
+
+        self.assertIn("core_non_finite_ratio", monitor.MAX_AGGREGATED)
+        self.assertIn("indexer_position_range_p95", monitor.MAX_AGGREGATED)
+        self.assertIn("core_softmax_entropy_norm_mean", monitor.MIN_AGGREGATED)
+        self.assertIn("indexer_effective_positions_mean", monitor.MIN_AGGREGATED)
+
+    def test_setup_discovers_core_and_indexer_ape(self):
+        class Compressor(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.ape = self.create_parameter(
+                    shape=[4, 3],
+                    default_initializer=paddle.nn.initializer.Constant(0.0),
+                )
+
+            def forward(self, value):
+                return value
+
+        core_compressor = Compressor()
+        indexer_compressor = Compressor()
+        core_attention = SimpleNamespace(
+            compressor=core_compressor,
+            indexer=SimpleNamespace(compressor=indexer_compressor),
+        )
+        model = SimpleNamespace(
+            layers=[SimpleNamespace(self_attn=SimpleNamespace(core_attention=core_attention))]
+        )
+        monitor_dict = {}
+
+        ape_monitor.setup_ape_monitor(model, monitor_dict=monitor_dict)
+        monitor = monitor_dict["ape_health"]
+        self.assertEqual(len(monitor.hooks), 2)
+
+        value = paddle.ones([1], dtype="float32")
+        core_compressor(value)
+        indexer_compressor(value)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="ape_health")
+        self.assertAlmostEqual(latest["ape_health/layer_0/core_rms"], 0.0)
+        self.assertAlmostEqual(latest["ape_health/layer_0/indexer_effective_positions_mean"], 4.0)


### PR DESCRIPTION
## Summary

Add APE P0 health monitoring for PaddleFleet CSA/HCA compressors.

The monitor reports APE parameter health and position-selection behavior at
layer/module granularity, covering both core compressors and indexer
compressors.

## What changed

- Add `ape_health` PaddleFleet monitor.
- Monitor both:
  - `core_attention.compressor.ape`
  - `core_attention.indexer.compressor.ape`
- Add seven P0 metrics:
  - `non_finite_ratio`
  - `rms`
  - `centered_rms`
  - `position_range_p95`
  - `softmax_entropy_norm_mean`
  - `softmax_max_prob_p95`
  - `effective_positions_mean`
- Keep metrics layer-wise and distinguish `core` / `indexer` branches.
- Use branch-specific position dimensions:
  - core: 128 positions
  - indexer: 4 positions
- Register `ape_health` in the PaddleFleet monitor registry.
- Add APE metric visualization and diagnosis support.
- Keep all metric reductions on GPU and only flush scalar metrics.

## Metric semantics

APE is monitored as a `[position, channel]` parameter.

- Position dimension is reduced into scalar summaries.
- Channel dimension is aggregated.
- Full per-position metrics are not emitted by default.
- `centered_rms` removes the per-channel position-common offset, which is
  invariant under the position softmax.
- Entropy and effective-position metrics are computed independently for core
  and indexer because their position counts are different.

## Validation

- APE monitor unit tests: 5 passed.
- Verified core/indexer hook registration and metric buffering.
- Verified NaN/Inf handling.
- Verified APE JSONL visualization parsing with real training logs.
- Verified generated logs contain layer-wise `core_*` metrics.
- Full repository test suite was not used as the merge gate.

## Expected metrics

For a uniform initialization:

- core:
  - `effective_positions_mean` approximately 128
  - `softmax_max_prob_p95` approximately `1 / 128`
- indexer:
  - `effective_positions_mean` approximately 4
  - `softmax_max_prob_p95` approximately `1 / 4`
- `non_finite_ratio` should remain 0