### PR TITLE
fix(moe): exclude invalid tokens from router margin metrics

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -81,19 +81,65 @@ def _assignment_mask(
     return (one_hot * valid.unsqueeze(-1).astype("float32")).sum(axis=1).clip(max=1.0)
 
 
-def _routing_margin(selection_scores: paddle.Tensor, assignment_mask: paddle.Tensor) -> paddle.Tensor:
-    """Return selected-boundary margins for an ungrouped top-k router."""
+def _routing_margin(
+    selection_scores: paddle.Tensor,
+    assignment_mask: paddle.Tensor,
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Return per-token margins and a mask for rows where margin is defined."""
+    selected_mask = assignment_mask > 0
+    valid = selected_mask.any(axis=-1) & (~selected_mask).any(axis=-1)
     selected = paddle.where(
-        assignment_mask > 0,
+        selected_mask,
         selection_scores,
         paddle.full_like(selection_scores, float("inf")),
     ).min(axis=-1)
     unselected = paddle.where(
-        assignment_mask > 0,
+        selected_mask,
         paddle.full_like(selection_scores, float("-inf")),
         selection_scores,
     ).max(axis=-1)
-    return selected - unselected
+    margin = selected - unselected
+    return paddle.where(valid, margin, paddle.zeros_like(margin)), valid
+
+
+def _masked_margin_metrics(
+    margin: paddle.Tensor,
+    valid: paddle.Tensor,
+) -> dict[str, paddle.Tensor]:
+    """Reduce routing margins over valid tokens only, without D2H sync."""
+    valid_f = valid.astype("float32")
+    valid_count = valid_f.sum()
+    safe_count = valid_count.clip(min=1.0)
+    zero = paddle.zeros([], dtype=margin.dtype)
+    has_valid = valid_count > 0
+
+    masked_margin = paddle.where(valid, margin, paddle.zeros_like(margin))
+    mean = masked_margin.sum() / safe_count
+
+    # Keep a fixed-size GPU tensor: invalid rows sort behind all valid rows and
+    # tensor-valued ranks select quantiles from only the valid prefix.
+    sorted_margin = paddle.sort(
+        paddle.where(valid, margin, paddle.full_like(margin, float("inf")))
+    )
+    count_i64 = valid.astype("int64").sum()
+    safe_count_i64 = count_i64.clip(min=1)
+
+    def quantile(q: float) -> paddle.Tensor:
+        rank = (safe_count_i64.astype("float32") - 1.0) * q
+        lower = paddle.floor(rank).astype("int64")
+        upper = paddle.ceil(rank).astype("int64")
+        lower_value = paddle.gather(sorted_margin, lower.reshape([1])).squeeze(0)
+        upper_value = paddle.gather(sorted_margin, upper.reshape([1])).squeeze(0)
+        value = lower_value + (upper_value - lower_value) * (rank - lower.astype("float32"))
+        return paddle.where(has_valid, value, zero)
+
+    return {
+        "router_margin_valid_ratio": valid_f.mean(),
+        "router_margin_mean": paddle.where(has_valid, mean, zero),
+        "router_margin_min": paddle.where(has_valid, sorted_margin[0], zero),
+        "router_margin_p10": quantile(0.10),
+        "router_margin_p01": quantile(0.01),
+    }
 
 
 def _compute_bias_affinity_jaccard(top_idx_with_bias, gates_no_bias, k, n_group=1, topk_group=1):
@@ -274,6 +320,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 "router_margin_min",
                 "router_margin_p10",
                 "router_margin_p01",
+                "router_margin_valid_ratio",
             ]
             for prefix in ("assignment_load", "gate_mass"):
                 gate_metrics += [
@@ -632,11 +679,9 @@ class PaddleMoEMonitor(PaddleProbe):
                     selection_scores = cached_gates.astype("float32")
                     if hasattr(gate, "e_score_correction_bias"):
                         selection_scores = selection_scores + gate.e_score_correction_bias.detach().astype("float32")
-                    margin = _routing_margin(selection_scores, assignment_mask)
-                    self.record_layer_metric(layer_idx, "router_margin_mean", margin.mean())
-                    self.record_layer_metric(layer_idx, "router_margin_min", margin.min())
-                    self.record_layer_metric(layer_idx, "router_margin_p10", paddle.quantile(margin, 0.10))
-                    self.record_layer_metric(layer_idx, "router_margin_p01", paddle.quantile(margin, 0.01))
+                    margin, valid_margin = _routing_margin(selection_scores, assignment_mask)
+                    for name, value in _masked_margin_metrics(margin, valid_margin).items():
+                        self.record_layer_metric(layer_idx, name, value)
 
         if hasattr(gate, "e_score_correction_bias"):
             top_idx_with_bias = None

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -387,6 +387,51 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
         self.assertEqual(float(assignment_mask.sum()), 0.0)
 
+    def test_routing_margin_is_finite_for_invalid_assignment_rows(self):
+        scores = paddle.to_tensor(
+            [[0.7, 0.2, 0.1], [0.6, 0.3, 0.1], [0.5, 0.4, 0.2]],
+            dtype="float32",
+        )
+        assignment_mask = paddle.to_tensor(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            dtype="float32",
+        )
+
+        margin, valid = moe_monitor_module._routing_margin(scores, assignment_mask)
+        metrics = moe_monitor_module._masked_margin_metrics(margin, valid)
+
+        self.assertTrue(bool(paddle.isfinite(margin).all()))
+        self.assertAlmostEqual(float(margin[0]), 0.0)
+        self.assertAlmostEqual(float(margin[1]), 0.3)
+        self.assertAlmostEqual(float(margin[2]), 0.0)
+        self.assertEqual(valid.tolist(), [False, True, False])
+        for value in metrics.values():
+            if value is not metrics["router_margin_valid_ratio"]:
+                self.assertAlmostEqual(float(value), 0.3)
+        self.assertAlmostEqual(float(metrics["router_margin_valid_ratio"]), 1.0 / 3.0)
+
+    def test_routing_margin_metrics_return_zero_for_all_invalid_rows(self):
+        margin = paddle.zeros([3], dtype="float32")
+        valid = paddle.zeros([3], dtype="bool")
+
+        metrics = moe_monitor_module._masked_margin_metrics(margin, valid)
+
+        self.assertTrue(all(bool(paddle.isfinite(value)) for value in metrics.values()))
+        self.assertTrue(all(float(value) == 0.0 for value in metrics.values()))
+        self.assertAlmostEqual(float(metrics["router_margin_valid_ratio"]), 0.0)
+
+    def test_routing_margin_metrics_exclude_invalid_rows_from_all_reductions(self):
+        margin = paddle.to_tensor([0.0, 0.1, 0.3, 0.0], dtype="float32")
+        valid = paddle.to_tensor([False, True, True, False], dtype="bool")
+
+        metrics = moe_monitor_module._masked_margin_metrics(margin, valid)
+
+        self.assertAlmostEqual(float(metrics["router_margin_mean"]), 0.2)
+        self.assertAlmostEqual(float(metrics["router_margin_min"]), 0.1)
+        self.assertAlmostEqual(float(metrics["router_margin_p10"]), 0.12)
+        self.assertAlmostEqual(float(metrics["router_margin_p01"]), 0.102)
+        self.assertAlmostEqual(float(metrics["router_margin_valid_ratio"]), 0.5)
+
     def test_mtp_layer_marker_is_encoded_in_metric_key(self):
         monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
         monitor.mark_mtp_layers([1])


### PR DESCRIPTION
### Summary

Fix `router_margin_*` metrics producing `inf` when router assignment rows do
not have a well-defined selected/unselected boundary.

### Problem

`router_margin` is defined as:

```text
min(selected scores) - max(unselected scores)
```

The previous implementation used `+inf` and `-inf` sentinels. This produced
non-finite margins in the following cases:

- No expert is selected for a token.
- All experts are selected for a token.
- Padding or invalid routing rows are included in the reduction.

The resulting `inf` values propagated into mean, min, and quantile metrics,
which caused the internal medicine viewer `/api/payload` endpoint to return
HTTP 500 because strict JSON does not support `inf` or `NaN`.

### Changes

- Return both per-token margin values and a margin-defined mask.
- Define a valid margin only when both selected and unselected experts exist.
- Apply masked reduction to:
  - `router_margin_mean`
  - `router_margin_min`
  - `router_margin_p10`
  - `router_margin_p01`
- Exclude invalid rows from all reductions.
- Return finite zero values when the whole batch has no valid margin rows.
- Add `router_margin_valid_ratio`.
- Keep the implementation GPU-side without D2H synchronization or new
  collectives.

### Metric Semantics

`router_margin_valid_ratio` means:

```text
number of tokens with a defined selected / unselected margin/total number of tokens
```

It is not an explicit padding-token ratio.

A margin value of zero with `valid_ratio > 0` means the margin may genuinely be
zero.

A margin value of zero with `valid_ratio == 0` means the batch had no valid
margin samples.
