### PR TITLE
feat(moe_health): 每层每专家的 token / combine 权重占比曲线

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 训练时模型健康的实时监控框架，通过 forward hook 零侵入式采集指标，不影响训练梯度。
 
 包含九大监控模块：
-- **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (13 指标)
+- **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (28 指标)
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
@@ -181,6 +181,8 @@ setup_internal_medicine()
 | 24 | `expert_gate_singular_entropy_max` | `moe_health/.../expert_gate_singular_entropy_max` | `max_e(...)` | 每层+全局 | 全谱最均匀的专家 |
 | 25 | `shared_gate_stable_rank` | `moe_health/.../shared_gate_stable_rank` | `‖W_g‖_F² / ‖W_g‖_2²` | 每层+全局 | 共享专家门控矩阵谱宽度 |
 | 26 | `shared_gate_singular_entropy` | `moe_health/.../shared_gate_singular_entropy` | `-Σ pᵢ log pᵢ, pᵢ = σᵢ²/Σσⱼ²` | 每层+全局 | 共享专家门控矩阵全谱利用率 |
+| 27 | `expert_token_share` | `moe_health/layer_N/expert_token_share_eK` | `count_K / Σ count × 100%` | 每层每专家 | 专家 K 分到的 token 占本层路由量的百分比 |
+| 28 | `expert_weight_share` | `moe_health/layer_N/expert_weight_share_eK` | `Σ probs_K / ΣΣ probs × 100%` | 每层每专家 | 专家 K 占本层总 combine 权重的百分比 (激活幅度贡献) |
 
 > 19-26 针对的是**专家 MLP 的 SwiGLU 门控投影** (`fc1` 前一半输出，即经过 SiLU 的那一半)，不是 router 的 `gate.weight`。
 > 奇异值经 Gram 矩阵特征分解得到 (`W Wᵀ` 或 `WᵀW` 取较小方阵)，比 `svdvals` 快约 40 倍；路由专家与共享专家的 Gram 拼成一个批次求解，避免 cuSOLVER 因批次形状变化重建 workspace。
@@ -211,6 +213,28 @@ PaddleFleet 后端还会直接从每次 router forward 的实际选择结果输�
 > 两种来源都在 global batch 级读取 (不在 forward hook 热路径上), 且计数已跨 rank
 > reduce, 因此无需 monitor 侧 collective, 统计值已是全局正确值。load 比值本身
 > scale-invariant, 直接用累加计数即可。
+
+> **注**: 指标 27-28 (`expert_*_share`) 是**每层每专家一条曲线**的向量指标 (256 专家的
+> 18 层模型 = 9216 个键), 只在 `log_per_layer=true` 时输出, 且不派生 `global_*`。
+> 它们与 `assignment_load_*` / `gate_mass_*` 互补: 后者回答一层「有多不均衡」,
+> 前者回答「是哪个专家造成的、是否长期是同一个」。
+>
+> `expert_token_share` 直接复用 `assignment_load_*` 已经算出的 hard-assignment
+> 计数向量, 因此除归一化外不增加任何 kernel, 且与之严格一致
+> (`max(expert_token_share) == assignment_load_max_frac × 100`)。
+> `expert_weight_share` 用的是 **combine 权重** (归一化并乘 `routed_scaling_factor`
+> 之后的 `probs`), 即该专家输出以多大权重进入残差 —— 这是「激活幅度」的可观测代理量。
+> 这里刻意不复用 `gate_mass` (它不含 scaling factor, 在
+> `routed_scaling_factor_param` 可学习时两者会分叉)。开 `moe_expert_fusion` 时融合
+> MoE 算子只返回已合并的输出, 真正的专家级输出 L2 取不到。
+>
+> 两者都不出 GPU: 热路径上整条向量一次 `add_`, 而不是每个专家一个累加器, 无 D2H
+> 同步、无 hook 内 collective。跨 rank 聚合就是各 DP rank 的普通均值, 与全局占比
+> 一致 (每个 rank 路由的 token 数相同)。
+>
+> 读法: 完全均衡时两者都等于 `100 / num_experts` (256 专家 ≈ 0.39%)。按层取这组
+> 曲线的 max / 中位 / min 最好用 —— max 抬升 = 热点专家, min 贴 0 = dead expert,
+> 中位数应稳定在均衡点附近; max 与中位数拉开距离即长尾不均衡。
 
 ### 健康阈值
 
@@ -752,6 +776,8 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | **MoE** | `expert_gate_singular_entropy_max` | `max_e(H(σ²))` | max | 上限 `log k`，平谱时取等 |
 | **MoE** | `shared_gate_stable_rank` | `srank(W_g)` | mean | 稳定 |
 | **MoE** | `shared_gate_singular_entropy` | `H(σ²)` | mean | 初始约 `0.96·log k`，不应持续下滑 |
+| **MoE** | `expert_token_share_eK` | `count_K/Σcount × 100%` | mean | 每层每专家；均衡时 = 100/E，长期高企 = 热点，贴 0 = dead expert |
+| **MoE** | `expert_weight_share_eK` | `Σprobs_K/ΣΣprobs × 100%` | mean | 每层每专家；与 token 占比偏离越大 = 该专家单 token 权重越重 |
 | **QK** | `max` | `max(QK^T/√d)` | max | 不应暴增 |
 | **QK** | `mean` | `mean(logits)` | mean | 稳定 |
 | **QK** | `entropy_avg` | `-Σ(p log p)` avg | mean | 适中 |

--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -36,6 +36,10 @@ class PaddleProbe(Probe):
         self._layer_metric_groups: dict[str, tuple[str, list[str]]] = {}
         self._layer_metric_keys: set[str] = set()  # 所有 per-layer key，用于 flush 时判断是否输出
         self._disabled_keys: set[str] = set()  # log_global=False 时被禁用的 global keys
+        self._vector_keys: dict[str, int] = {}  # per-layer 向量 key → 长度
+        self._gpu_vec: dict[str, paddle.Tensor] = {}  # per-layer 向量累加器 [size]
+        self._gpu_vec_cnt: dict[str, int] = {}
+        self._vector_elem_keys: dict[str, list[str]] = {}  # 向量 key → 展开后的逐元素 key
         self._mtp_layer_ids: set[int] = set()
         self._buffers_allocated = False
 
@@ -98,11 +102,16 @@ class PaddleProbe(Probe):
         for k in self._min_keys:
             self._gpu_acc[k] = paddle.full((), float("inf"), dtype=dtype)
             self._gpu_cnt[k] = 0
+        # vector: 每层一条 [size] 累加器，flush 时按元素展开成独立 key
+        for k, size in self._vector_keys.items():
+            self._gpu_vec[k] = paddle.zeros([size], dtype=dtype)
+            self._gpu_vec_cnt[k] = 0
         self._buffers_allocated = True
         if self.verbose:
             logger.info(
                 f"[{self.METRIC_PREFIX}] GPU buffer: "
-                f"mean={len(self._mean_keys)} max={len(self._max_keys)} min={len(self._min_keys)}"
+                f"mean={len(self._mean_keys)} max={len(self._max_keys)} min={len(self._min_keys)} "
+                f"vector={len(self._vector_keys)}"
             )
 
     def record_mean(self, key: str, val: paddle.Tensor) -> None:
@@ -212,6 +221,36 @@ class PaddleProbe(Probe):
         else:
             self.record_mean(layer_key, val)
 
+    # ------------------------------------------------------------------
+    # Per-layer vector metrics (one curve per element, e.g. per expert)
+    # ------------------------------------------------------------------
+
+    def declare_layer_vector(self, layer_idx: int, metric_name: str, size: int, elem_tag: str = "e") -> None:
+        """声明一个 per-layer 向量指标，mean 聚合，flush 时展开为 ``{key}_{elem_tag}{i}``。
+
+        用于「每层每个元素一条曲线」的指标（例如每个专家的占比）：热路径上整条
+        向量只有一次 ``add_``，而不是每个元素一个 kernel。向量指标不参与 global
+        派生 —— 跨层视图由 viewer 自己从各层曲线汇总。
+        """
+        assert not self._buffers_allocated, f"declare_layer_vector({metric_name!r}) after allocate_buffers"
+        if not self.log_per_layer:
+            return
+        key = self._layer_key(layer_idx, metric_name)
+        assert key not in self._vector_keys, f"declare_layer_vector({key!r}) declared twice"
+        size = int(size)
+        assert size > 0
+        self._vector_keys[key] = size
+        self._vector_elem_keys[key] = [f"{key}_{elem_tag}{i}" for i in range(size)]
+
+    def record_layer_vector(self, layer_idx: int, metric_name: str, vec: paddle.Tensor) -> None:
+        """热路径：整条 ``[size]`` 向量一次就地累加，不触发 D2H 同步。"""
+        key = self._layer_key(layer_idx, metric_name)
+        buf = self._gpu_vec.get(key)
+        if buf is None:  # log_per_layer=False 或该层未声明
+            return
+        buf.add_(vec.detach().astype(buf.dtype))
+        self._gpu_vec_cnt[key] += 1
+
     def _emits_layer_key(self, key: str) -> bool:
         """per-layer key 是否写进日志（global 派生不受此影响）。"""
         if key not in self._layer_metric_keys:
@@ -219,7 +258,7 @@ class PaddleProbe(Probe):
         return self.log_per_layer
 
     def _flush_gpu_buffer(self) -> dict[str, float]:
-        """单次批量 D2H：收集所有累加器 → 推导 global → stack→cpu→tolist → 重置。"""
+        """单次批量 D2H：收集所有累加器 → 推导 global → concat→cpu→tolist → 重置。"""
         keys: list[str] = []
         tensors: list[paddle.Tensor] = []
 
@@ -264,11 +303,25 @@ class PaddleProbe(Probe):
                     tensors.append(paddle.stack([self._gpu_acc[lk] for lk in active]).min())
                 keys.append(global_key)
 
-        # 5) 唯一 D2H 同步点：一次 stack → cpu → tolist
+        # 5) 唯一 D2H 同步点：一次 concat → cpu → tolist（标量与向量共用）
+        vec_key_groups: list[list[str]] = []
+        vec_tensors: list[paddle.Tensor] = []
+        for k, elem_keys in self._vector_elem_keys.items():
+            cnt = self._gpu_vec_cnt[k]
+            if cnt == 0:
+                continue
+            vec_key_groups.append(elem_keys)
+            vec_tensors.append(self._gpu_vec[k] / cnt)
+
         out: dict[str, float] = {}
-        if tensors:
-            vals = paddle.stack(tensors).cpu().tolist()
+        if tensors or vec_tensors:
+            flat = paddle.concat([t.reshape([-1]) for t in tensors] + vec_tensors)
+            vals = flat.cpu().tolist()
             out = dict(zip(keys, vals, strict=False))
+            offset = len(keys)
+            for elem_keys in vec_key_groups:
+                out.update(zip(elem_keys, vals[offset : offset + len(elem_keys)], strict=False))
+                offset += len(elem_keys)
 
         # 6) 重置所有累加器，为下一个 step 准备
         for k in self._mean_keys:
@@ -280,4 +333,7 @@ class PaddleProbe(Probe):
         for k in self._min_keys:
             paddle.assign(paddle.full((), float("inf"), dtype=self._gpu_acc[k].dtype), self._gpu_acc[k])
             self._gpu_cnt[k] = 0
+        for k in self._vector_keys:
+            self._gpu_vec[k].zero_()
+            self._gpu_vec_cnt[k] = 0
         return out

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -492,6 +492,13 @@ class PaddleMoEMonitor(PaddleProbe):
                 ]
             for m in gate_metrics + expert_metrics + act_metrics:
                 self.declare_layer_metric(layer_idx, m)
+            # Per-expert share curves: one metric element per routed expert.
+            # num_experts must come from static config here — a hook-time
+            # reduction would need a D2H sync to size the schema.
+            num_experts = int(getattr(getattr(moe_layer, "gate", None), "num_experts", 0) or 0)
+            if num_experts > 0:
+                for m in ("expert_token_share", "expert_weight_share"):
+                    self.declare_layer_vector(layer_idx, m, num_experts)
 
         self.allocate_buffers()
 
@@ -805,6 +812,7 @@ class PaddleMoEMonitor(PaddleProbe):
                 for prefix, mass in (("assignment_load", assignment), ("gate_mass", gate_mass)):
                     for name, value in _distribution_metrics(mass).items():
                         self.record_layer_metric(layer_idx, f"{prefix}_{name}", value)
+                self._record_expert_shares(layer_idx, assignment, outputs)
 
                 if (
                     k < num_experts
@@ -890,6 +898,39 @@ class PaddleMoEMonitor(PaddleProbe):
         if shared_sigma is not None:
             self.record_layer_metric(layer_idx, "shared_gate_stable_rank", _stable_rank(shared_sigma))
             self.record_layer_metric(layer_idx, "shared_gate_singular_entropy", _singular_value_entropy(shared_sigma))
+
+    def _record_expert_shares(self, layer_idx, assignment, outputs):
+        """Per-expert share of this layer's routed load, in percent.
+
+        The per-layer ``assignment_load_*`` / ``gate_mass_*`` metrics answer
+        *how* skewed a layer is; these answer *which* expert is responsible and
+        whether it stays the same one across steps. One curve per expert, so a
+        hot expert and a dead expert are both identifiable by index.
+
+        - ``expert_token_share`` reuses the caller's ``assignment`` vector (the
+          hard-assignment count already summed for ``assignment_load_*``), so it
+          adds no kernel beyond the normalisation and is exactly consistent with
+          it: ``max(curves) == assignment_load_max_frac * 100``.
+        - ``expert_weight_share`` uses ``probs`` — the post-normalisation,
+          post-``routed_scaling_factor`` combine weight each expert's output
+          carries into the residual. That is deliberately *not* ``gate_mass``,
+          which omits the scaling factor: with a learnable
+          ``routed_scaling_factor_param`` the two diverge, and only ``probs``
+          tracks the magnitude actually reaching the residual. It is a proxy for
+          activation magnitude, not the thing itself — the true per-expert output
+          norm is unobservable under ``moe_expert_fusion``, where the fused MoE
+          node returns already-combined output with no per-expert segmentation.
+
+        A perfectly balanced layer sits at ``100 / num_experts`` on both. Neither
+        leaves the GPU and neither needs a hook-time collective: the cross-rank
+        mean over DP ranks equals the global share, because every rank routes the
+        same number of tokens.
+        """
+        self.record_layer_vector(layer_idx, "expert_token_share", assignment / assignment.sum().clip(min=1e-12) * 100.0)
+        probs = outputs[3] if isinstance(outputs, tuple | list) and len(outputs) > 3 else None
+        if isinstance(probs, paddle.Tensor):
+            weights = probs.detach().astype("float32").reshape([-1, probs.shape[-1]]).sum(axis=0)
+            self.record_layer_vector(layer_idx, "expert_weight_share", weights / weights.sum().clip(min=1e-12) * 100.0)
 
     def _collect_expert_sumsq(self, moe_layer):
         """Per-expert / shared-expert sums of squares for one MoE layer.

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -452,6 +452,101 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["moe_health/layer_1_mtp/router_entropy"], 4.0, places=4)
         self.assertAlmostEqual(latest["moe_health/global_router_entropy"], 3.0, places=4)
 
+    def test_per_expert_vector_expands_to_one_key_per_expert(self):
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=True)
+        monitor.declare_layer_vector(0, "expert_token_share", 3)
+        monitor.allocate_buffers()
+
+        monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([10.0, 20.0, 70.0]))
+        monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([30.0, 20.0, 50.0]))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        # Mean over the two records, one key per expert, and no global rollup.
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e0"], 20.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e1"], 20.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e2"], 60.0, places=4)
+        self.assertNotIn("moe_health/global_expert_token_share", latest)
+
+    def test_per_expert_vector_shares_the_single_scalar_flush(self):
+        """Vector and scalar accumulators come back through one D2H together."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        monitor.declare_layer_metric(0, "router_entropy")
+        monitor.declare_layer_vector(0, "expert_weight_share", 2)
+        monitor.allocate_buffers()
+
+        monitor.record_layer_metric(0, "router_entropy", paddle.to_tensor(2.0))
+        monitor.record_layer_vector(0, "expert_weight_share", paddle.to_tensor([40.0, 60.0]))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/router_entropy"], 2.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_weight_share_e0"], 40.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_weight_share_e1"], 60.0, places=4)
+
+    def test_per_expert_vector_resets_between_steps(self):
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        monitor.declare_layer_vector(0, "expert_token_share", 2)
+        monitor.allocate_buffers()
+
+        monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([25.0, 75.0]))
+        monitor.step()
+        monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([60.0, 40.0]))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e0"], 60.0, places=4)
+
+    def test_per_expert_vector_skipped_when_log_per_layer_off(self):
+        monitor = PaddleMoEMonitor(log_per_layer=False, log_global=True)
+        monitor.declare_layer_vector(0, "expert_token_share", 2)
+        monitor.allocate_buffers()
+
+        monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([25.0, 75.0]))
+        monitor.step()
+
+        self.assertEqual(training_logs.get_latest(prefix="moe_health"), {})
+
+    def test_expert_shares_come_from_assignment_and_probs(self):
+        """assignment -> token share, probs -> combine-weight share, both in percent."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        monitor.declare_layer_vector(0, "expert_token_share", 3)
+        monitor.declare_layer_vector(0, "expert_weight_share", 3)
+        monitor.allocate_buffers()
+
+        # 2 tokens, 3 experts, top-1: token 0 -> e0, token 1 -> e2. `assignment`
+        # is the same per-expert count the caller already summed for
+        # assignment_load_*, so the two views stay exactly consistent.
+        assignment = paddle.to_tensor([1.0, 0.0, 1.0])
+        probs = paddle.to_tensor([[0.25, 0.0, 0.0], [0.0, 0.0, 0.75]])
+        outputs = (None, None, None, probs, None, None, None, None)
+        monitor._record_expert_shares(0, assignment, outputs)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        token = [latest[f"moe_health/layer_0/expert_token_share_e{i}"] for i in range(3)]
+        self.assertAlmostEqual(token[0], 50.0, places=4)
+        self.assertAlmostEqual(token[1], 0.0, places=4)
+        self.assertAlmostEqual(token[2], 50.0, places=4)
+        self.assertAlmostEqual(sum(token), 100.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_weight_share_e0"], 25.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_weight_share_e2"], 75.0, places=4)
+
+    def test_expert_token_share_survives_missing_probs(self):
+        """A gate that returns no combine weights still yields the token share."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        monitor.declare_layer_vector(0, "expert_token_share", 2)
+        monitor.declare_layer_vector(0, "expert_weight_share", 2)
+        monitor.allocate_buffers()
+
+        monitor._record_expert_shares(0, paddle.to_tensor([3.0, 1.0]), (None, None, None))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health")
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e0"], 75.0, places=4)
+        self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e1"], 25.0, places=4)
+        self.assertNotIn("moe_health/layer_0/expert_weight_share_e0", latest)
+
     def test_gpu_buffer_multi_layer_global_aggregation(self):
         """Global metrics are derived from layer accumulators at flush time."""
         monitor = PaddleMoEMonitor(log_per_layer=False, log_global=True)


### PR DESCRIPTION
## 动机

`assignment_load_*` / `gate_mass_*` (#50) 回答一层「有多不均衡」, 但看不到**是哪个专家**造成的、以及**是否长期是同一个**。排 dead expert / 热点专家、判断路由坍缩是不是在某几个固定专家上固化, 需要每个专家自己的一条曲线。

本 PR 加两个每层每专家的占比指标 (单位 %):

| 指标 | 日志键 | 公式 |
|---|---|---|
| `expert_token_share` | `moe_health/layer_N/expert_token_share_eK` | `count_K / Σ count × 100%` |
| `expert_weight_share` | `moe_health/layer_N/expert_weight_share_eK` | `Σ probs_K / ΣΣ probs × 100%` |

完全均衡时两者都等于 `100 / num_experts`。max 抬升 = 热点专家, 贴 0 = dead expert, 与中位数拉开距离 = 长尾不均衡。

## 与 #50 的关系: 互补, 且复用而非重算

- `expert_token_share` **直接复用 `assignment_load_*` 已经算出的 hard-assignment 计数向量**, 除一次归一化外不增加任何 kernel, 并且与之严格一致: `max(expert_token_share) == assignment_load_max_frac × 100`。
- `expert_weight_share` 用的是 `probs` —— 归一化并乘 `routed_scaling_factor` 之后的 **combine 权重**, 即该专家输出以多大权重进入残差。这里刻意**不**复用 `gate_mass`: 它不含 scaling factor, 在 `routed_scaling_factor_param` 可学习时两者会分叉, 只有 `probs` 跟踪真正到达残差的幅度。

它是「激活幅度」的可观测代理量, 不是本体 —— 开 `moe_expert_fusion` 时融合 MoE 算子只返回已合并的输出, 没有专家级切分, 真正的专家级输出 L2 取不到。

## 实现: PaddleProbe 新增向量指标 API

每层每专家一个 key 意味着 256 专家 × 18 层 = 9216 个键。逐个标量声明会在热路径上产生每层 256 个 `add_`, 违反 monitor 热路径纪律。因此在 `PaddleProbe` 上加了一组向量指标 API:

- `declare_layer_vector(layer_idx, metric_name, size, elem_tag="e")` —— 注册期声明, 长度取自静态配置 `gate.num_experts` (hook 期做 reduction 拿长度会引入 D2H)。
- `record_layer_vector(layer_idx, metric_name, vec)` —— 热路径上**整条 `[size]` 向量一次 `add_`**, 每层每 microbatch 1 个 kernel。
- flush 时与所有标量**共用同一次 `concat → cpu → tolist`** D2H, 再按元素展开成 `{key}_e{i}`。

不变量:
- 无 D2H 同步、无 hook 内 collective。跨 rank 聚合就是各 DP rank 的普通均值, 与全局占比一致 (每个 rank 路由的 token 数相同)。
- 只在 `log_per_layer=true` 时输出; 不派生 `global_*` (跨层视图交给消费侧汇总)。
- 完整 schema 在 `allocate_buffers()` 之前声明完毕; `declare_layer_vector` 有 assert 兜住。

## 测试

`tests/test_paddlefleet_monitors.py` 新增 6 个用例:

- 向量按专家展开成独立 key, 数量正确
- 向量与标量共用同一次 flush (不额外增加 D2H)
- step 之间累加器正确清零
- `log_per_layer=False` 时完全不产出
- `assignment` → token 占比、`probs` → 权重占比, 数值与百分比归一化正确
- gate 不返回 combine 权重时, token 占比仍然可用 (只跳过 weight 占比)

`pytest tests/ -q` (排除需要 torch/megatron 的 3 个文件) → **218 passed**。已 rebase 到 `master` (3e46f39)，与 #49 / #52 / gate-spectrum 指标的 README 编号冲突已解 (本 PR 的两个指标编号为 27-28)。`pre-commit run` (ruff + ruff format) 全绿。

megatron 侧未改动 —— `outputs`/`probs` 的取法是 paddlefleet `TopKRouter` 特有的, 需要另做映射。

## 线上观察

18 层 / 256 专家 / top-5 / EP=8 的预训练作业上实测: 按层取这组曲线的 max / 中位 / min, 中位数 0.267–0.329% (均衡点 0.391%, 长尾分布下略低于均衡点属预期), max 峰值出现在 L12 = 3.66% (≈ 中位数的 12 倍), min 最低在 L6 = 0.005% (≈ 中位数的 1/55)。后两个信号在只有标量统计时都看不到具体是哪个专家。
