### PR TITLE
feat(megatron): mhc_health 与 paddlefleet 对齐至 16 指标

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,8 +488,9 @@ Figure 10 那类映射热图使用：
 热路径上每个映射只有一次 `add_`，而不是每个元素一个 kernel；并且**不派生 `global_*` 键**——单个 cell 在
 43 层上的均值没有判读意义。`log_per_layer=False` 时这三组整体不产出。
 
-> megatron 与 paddlefleet 两个后端 schema、口径与归约方式一致，曲线可直接跨后端对比。两点后端差异：megatron 开启
-> `use_fused_mhc` 时 `compute_mappings` 会绕过 `_compute_h`，此时 11–14 四条 `h_res_logits*` 不落盘；AMP 反除只在
+> megatron 与 paddlefleet 两个后端 schema、口径与归约方式一致，曲线可直接跨后端对比。两点后端差异：新版 megatron
+> 开启 `use_fused_mhc` 时，11–14 四条 `h_res_logits*` 的 logits 由 `fused_proj_rms_compute_h` kernel 算出（其余实现
+> 由 native `_compute_h` 算出），这四条因此只做趋势对比，严格对齐需两侧都关 `use_fused_mhc`；AMP 反除只在
 > fp16 且调用方传入 `grad_scaler` 时发生（bf16 本就不缩放）。
 
 指标公式、采集路径、健康判读及论文 composite 定义统一维护在

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
-- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 29 标量指标 + `n²+2n` 条逐元素映射序列，megatron 后端 16 指标；仅在开启 mHC 层时生效)
+- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 29 标量指标 + `n²+2n` 条逐元素映射序列；megatron / paddlefleet 同 schema；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 - **APE Health** — CSA/HCA compressor APE 参数健康监控 (P0 级 7 指标；仅 paddlefleet)
 - **Attn Update** — QK 乘积增量 `Δ₂ = ΔW_q W_kᵗ + W_q ΔW_kᵗ` / `Δ₃ = ΔW_q ΔW_kᵗ` 的谱监控 (每项 3 指标；仅权重，不挂 forward hook)
@@ -437,7 +437,7 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 `h_{pre,post}_logits_min` 取极小值，其余按 token/batch 求均值。
 
 第 17-29 条对应论文 Eq. (7) 的静态与 pre-sigmoid 部分（`alpha` / `bias` / 门控 logits），
-**目前仅 paddlefleet 后端实现**，megatron 后端仍为前 16 条。
+megatron 与 paddlefleet 两个后端都已实现（17-20 在新版 megatron 开 `use_fused_mhc` 时不落盘，见本节末尾）。
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
 |---|------|--------|------|------|----------|
@@ -474,7 +474,7 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 `{c}` ∈ `{attn, mlp}`。第 21-29 条是 step 级参数量，在 `on_optimizer_begin`（optimizer step 之前）读一次参数，
 不在热路径，且仅在本 step 确实跑过被监控的 forward 时记录。
 
-除上述 29 个标量外，paddlefleet 后端还额外产出 **每元素展开的映射序列**（`n² + 2n` 条 / hc 模块，`n = 4` 时 24 条，
+除上述 29 个标量外，还额外产出 **每元素展开的映射序列**（`n² + 2n` 条 / hc 模块，`n = 4` 时 24 条，
 每层两个模块共 48 条）——即把 `h_res` 的 4×4 矩阵和 `h_pre` / `h_post` 两条 n 维向量逐元素记录，供还原论文
 Figure 10 那类映射热图使用：
 
@@ -488,10 +488,12 @@ Figure 10 那类映射热图使用：
 热路径上每个映射只有一次 `add_`，而不是每个元素一个 kernel；并且**不派生 `global_*` 键**——单个 cell 在
 43 层上的均值没有判读意义。`log_per_layer=False` 时这三组整体不产出。
 
-> megatron 与 paddlefleet 两个后端 schema、口径与归约方式一致，曲线可直接跨后端对比。两点后端差异：新版 megatron
-> 开启 `use_fused_mhc` 时，11–14 四条 `h_res_logits*` 的 logits 由 `fused_proj_rms_compute_h` kernel 算出（其余实现
-> 由 native `_compute_h` 算出），这四条因此只做趋势对比，严格对齐需两侧都关 `use_fused_mhc`；AMP 反除只在
-> fp16 且调用方传入 `grad_scaler` 时发生（bf16 本就不缩放）。
+> megatron 与 paddlefleet 两个后端 schema、口径与归约方式一致，曲线可直接跨后端对比。三点后端差异都只出现在
+> 新版 megatron 开启 `use_fused_mhc` 时：11–14 四条 `h_res_logits*` 的 logits 由 `fused_proj_rms_compute_h`
+> kernel 算出（其余实现由 native `_compute_h` 算出），因此只做趋势对比；17–20 四条 `h_{pre,post}_logits_*`
+> 需要 `_compute_h` 的 `(proj, r)` 入参，而 fused kernel 只返回 `(h_pre, h_post, h_res, r)` 不暴露 `proj`，
+> 这四条在该路径下不落盘（其余 25 条标量与全部逐元素序列不受影响）。严格对齐需两侧都关 `use_fused_mhc`。
+> 此外 AMP 反除只在 fp16 且调用方传入 `grad_scaler` 时发生（bf16 本就不缩放）。
 
 指标公式、采集路径、健康判读及论文 composite 定义统一维护在
 [`docs/mhc_health.md`](docs/mhc_health.md)，README 不再重复展开。

--- a/README.md
+++ b/README.md
@@ -488,6 +488,10 @@ Figure 10 那类映射热图使用：
 热路径上每个映射只有一次 `add_`，而不是每个元素一个 kernel；并且**不派生 `global_*` 键**——单个 cell 在
 43 层上的均值没有判读意义。`log_per_layer=False` 时这三组整体不产出。
 
+> megatron 与 paddlefleet 两个后端 schema、口径与归约方式一致，曲线可直接跨后端对比。两点后端差异：megatron 开启
+> `use_fused_mhc` 时 `compute_mappings` 会绕过 `_compute_h`，此时 11–14 四条 `h_res_logits*` 不落盘；AMP 反除只在
+> fp16 且调用方传入 `grad_scaler` 时发生（bf16 本就不缩放）。
+
 指标公式、采集路径、健康判读及论文 composite 定义统一维护在
 [`docs/mhc_health.md`](docs/mhc_health.md)，README 不再重复展开。
 

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -38,7 +38,8 @@ internal_medicine_monitors:
 
 `h_pre` 不在 `HyperConnectionModule.forward` 的返回中，普通 forward hook 看不到它。因此本 monitor **包裹
 （wrap）每个 mHC 模块的 `compute_mappings` 绑定方法**，直接捕获其真实返回的 `(h_pre, h_post, h_res)` —— 不重算。
-另外包 `_sinkhorn_op`（从其**入参**拿 Sinkhorn 之前的 `h_res` logits）和 `fused_h_res_h_post_bda`（拿子层输出，算分支/残差占比）。
+另外包 `_sinkhorn_op`（从其**入参**拿 Sinkhorn 之前的 `h_res` logits）、`_compute_h`（从其**入参** `(proj, r)`
+重建 `h_pre` / `h_post` 的 pre-sigmoid logits）和 `fused_h_res_h_post_bda`（拿子层输出，算分支/残差占比）。
 
 - `compute_mappings` 是普通 Python 方法（仅 `@nvtx_decorator`，非 `@torch.compile`），在 `_forward_normal` 中以
   `self.compute_mappings(...)` 调用，且**不被 checkpoint**，因此在 grad-enabled 的正向中恰好执行一次；实例属性
@@ -63,7 +64,7 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 
 ## 监控指标
 
-每个 hc 模块产出 29 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 16 个），指标名以
+每个 hc 模块产出 29 个指标（megatron 与 paddlefleet 两个后端同 schema），指标名以
 `attn_` / `mlp_` 前缀区分。`branch_residual_share_max`、`h_res_logits_max`、`h_res_logits_grad_max`、
 `composite_amax_gain_{fwd,bwd}_max`、`h_{pre,post}_logits_max`、`bias_{pre,post,res}_abs_max` 取极大值，
 `h_res_logits_min`、`h_res_logits_grad_min` 与 `h_{pre,post}_logits_min` 取极小值，其余按 token/batch 求均值
@@ -215,7 +216,8 @@ h_post_logits = r · proj[..., n:2n]  · α_post + b_post
 把所有饱和元素丢成 `±inf`，恰好丢掉这两条指标存在的意义。代价是与模型实现耦合：`_compute_h` 里
 `h` 的构成方式一旦改变，这四条会静默算错，改模型时必须同步。`H_post` 的因子 2 在 sigmoid 之外，不进 logit。
 
-调用方没有传 `proj` / `r` 时（stub、或未来绕过该签名的 fused 路径）这四个累加器保持为空，不写值。
+调用方没有传 `proj` / `r` 时（stub、或绕过该签名的 fused 路径）这四个累加器保持为空，不写值。新版 megatron 开
+`use_fused_mhc` 正是这种情况，见文末「后端差异」。
 
 ### Eq. (7) 静态参数（alpha / bias）
 
@@ -299,8 +301,8 @@ prefix `F_q = T_q @ ... @ T_0`；逆序遍历构造当前 branch 到尾部的 su
 一处后端差异：AMP 反除只在 fp16 且调用方传入 `grad_scaler` 时发生，bf16 下 megatron 本就不缩放，
 `finalize_scaled_grad_metrics()` 是 no-op。
 
-另有一处数值口径差异需要注意。两个后端的 `h_res_logits*` 都取自 `_sinkhorn_op` 的入参，所以**采集口径一致、
-16 条指标在两个后端都会落盘**（包括 megatron 开启 `use_fused_mhc` 时）。但 logits 由谁算出来在三种实现里不同：
+另有一处数值口径差异需要注意。两个后端的 `h_res_logits*`（11–14）都取自 `_sinkhorn_op` 的入参，所以**采集口径
+一致、这四条在两个后端都会落盘**（包括 megatron 开启 `use_fused_mhc` 时）。但 logits 由谁算出来在三种实现里不同：
 
 - paddlefleet 开 `use_fused_mhc`：只替换 `_proj_rms_op` / `_sinkhorn_op`，logits 仍由 native `_compute_h` 算出。
 - 旧版 megatron 开 `use_fused_mhc`：同上。
@@ -308,6 +310,12 @@ prefix `F_q = T_q @ ... @ T_0`；逆序遍历构造当前 branch 到尾部的 su
 
 因此新版 megatron + fused 的这四条与前两者**趋势可比、数值不可逐值比**。严格对齐验证应在两侧都关闭
 `use_fused_mhc`。
+
+还有一处只在新版 megatron + fused 下出现的缺口：`h_{pre,post}_logits_{min,max}` 这四条是从 `_compute_h` 的
+`(proj, r)` 入参重建出来的（`h = r · proj · α + b`，取 `[:n]` / `[n:2n]` 两段），而
+`fused_proj_rms_compute_h` 只返回 `(h_pre, h_post, h_res, r)`、不暴露 `proj`，在热路径上重做一遍投影 matmul
+又违反 hook 性能纪律。所以这四条在该路径下**累加器为空、不落盘**，而不是用别的量凑一个值上去。其余 25 条标量
+和全部逐元素序列不受影响。反推 sigmoid 也不可行：这四条正是饱和哨兵，一旦真的饱和，逆 sigmoid 就会溢出。
 
 作用域限制：复合只覆盖**本 rank 持有的层**。在 `sharding: stage1` 且无 PP 时，每张卡持有全部 Transformer 层，
 所以覆盖全网层范围。真开 PP 后它会退化成 stage 内语义（megatron 后端即如此，多 chunk 时按 `layer_offset` 排序，

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -38,7 +38,7 @@ internal_medicine_monitors:
 
 `h_pre` 不在 `HyperConnectionModule.forward` 的返回中，普通 forward hook 看不到它。因此本 monitor **包裹
 （wrap）每个 mHC 模块的 `compute_mappings` 绑定方法**，直接捕获其真实返回的 `(h_pre, h_post, h_res)` —— 不重算。
-另外包 `_compute_h`（拿 Sinkhorn 之前的 `h_res` logits）和 `fused_h_res_h_post_bda`（拿子层输出，算分支/残差占比）。
+另外包 `_sinkhorn_op`（从其**入参**拿 Sinkhorn 之前的 `h_res` logits）和 `fused_h_res_h_post_bda`（拿子层输出，算分支/残差占比）。
 
 - `compute_mappings` 是普通 Python 方法（仅 `@nvtx_decorator`，非 `@torch.compile`），在 `_forward_normal` 中以
   `self.compute_mappings(...)` 调用，且**不被 checkpoint**，因此在 grad-enabled 的正向中恰好执行一次；实例属性
@@ -166,7 +166,7 @@ amax_gain_bwd = mean_t( max_j | Σ_i  h_res_ji | )      # h_res 的行和（back
 
 ### 迭代前 logits 范围
 
-直接统计 `_compute_h` 产出、进入 Sinkhorn 前的 raw residual-mixing logits `z`。这两条保留符号，不执行
+直接统计传入 `_sinkhorn_op`、即进入 Sinkhorn 前的 raw residual-mixing logits `z`。这两条保留符号，不执行
 softmax，因此不会受概率饱和到 0/1 的截断影响：
 
 | 指标 | 公式 | 诊断意义 |
@@ -180,7 +180,7 @@ softmax，因此不会受概率饱和到 0/1 的截断影响：
 
 ### 迭代前 logits 梯度
 
-对 `_compute_h` 产出、传入 Sinkhorn 的 raw `h_res` logits `z` 注册 tensor gradient hook，监控的是
+对传入 `_sinkhorn_op` 的 raw `h_res` logits `z` 注册 tensor gradient hook，监控的是
 `dL/dz`，不是 Sinkhorn 最终矩阵或循环中间 `M` 的梯度：
 
 | 指标 | 公式 | 诊断意义 |
@@ -296,10 +296,18 @@ prefix `F_q = T_q @ ... @ T_0`；逆序遍历构造当前 branch 到尾部的 su
 4. **MTP 层被排除。** MTP 层不在主干传播路径上，乘进链条没有物理意义。megatron 后端不需要这道过滤：MTP block
    不在 `decoder.layers` 里，discovery 根本走不到。
 
-两处后端差异：megatron 的 `h_res_logits*` 四条指标依赖 `_compute_h`，而 `config.use_fused_mhc` 会让
-`compute_mappings` 直接走 `fused_proj_rms_compute_h` 而跳过它——此时这四条累加器为空、不落盘（其余 12 条不受影响）；
-AMP 反除只在 fp16 且调用方传入 `grad_scaler` 时发生，bf16 下 megatron 本就不缩放，`finalize_scaled_grad_metrics()`
-是 no-op。
+一处后端差异：AMP 反除只在 fp16 且调用方传入 `grad_scaler` 时发生，bf16 下 megatron 本就不缩放，
+`finalize_scaled_grad_metrics()` 是 no-op。
+
+另有一处数值口径差异需要注意。两个后端的 `h_res_logits*` 都取自 `_sinkhorn_op` 的入参，所以**采集口径一致、
+16 条指标在两个后端都会落盘**（包括 megatron 开启 `use_fused_mhc` 时）。但 logits 由谁算出来在三种实现里不同：
+
+- paddlefleet 开 `use_fused_mhc`：只替换 `_proj_rms_op` / `_sinkhorn_op`，logits 仍由 native `_compute_h` 算出。
+- 旧版 megatron 开 `use_fused_mhc`：同上。
+- 新版 megatron 开 `use_fused_mhc`：`fused_proj_rms_compute_h` 把 `compute_h` 也吸进 kernel，logits 由 kernel 算出。
+
+因此新版 megatron + fused 的这四条与前两者**趋势可比、数值不可逐值比**。严格对齐验证应在两侧都关闭
+`use_fused_mhc`。
 
 作用域限制：复合只覆盖**本 rank 持有的层**。在 `sharding: stage1` 且无 PP 时，每张卡持有全部 Transformer 层，
 所以覆盖全网层范围。真开 PP 后它会退化成 stage 内语义（megatron 后端即如此，多 chunk 时按 `layer_offset` 排序，

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -123,7 +123,7 @@ key 数量：`n = 4`、43 层、2 模块 = 2064 条逐层序列，是本 monitor
 两者都高，才说明每个 token 的总门量也在明显变化。反过来，`h_post_token_std -> 0` 仍允许不同 token 在 stream 间
 重新分配相同总门量，因此不能据此断言门控已完全失去输入区分能力。
 
-### 结构指标（paddlefleet 独有）
+### 结构指标
 
 `h_post_mean` / `h_post_std` 把 token 轴和 stream 轴一起池化，因此「n 个流一起变弱」与「n-1 个流死掉、
 剩一个扛全部」在均值上不可分；`branch_residual_share` 则回答 `h_post_mean` 回答不了的问题：门变小可能被
@@ -263,7 +263,7 @@ B_l = prod_{i=1}^{L-l} R_{L-i}
 应读 `||F_l||∞`，composite backward amplification 应读 `||B_l^T||∞ = ||B_l||1`。这里的 `l` 是每个顺序执行的
 residual branch；映射到 Transformer 时，attention 和 MLP 是交错的相邻 branch，不能拆成两条互不相干的链。
 
-#### 当前 PaddleFleet 实现
+#### 当前实现
 
 `apply_h_res` 的实际运算是 `mixed = h_resᵀ @ residual`，所以实现先对 token 求平均并转置，得到真正作用在
 流向量上的算子 `T_q = mean_token(h_res_q)ᵀ`。所有非 MTP branch 按物理执行顺序排列：
@@ -293,10 +293,17 @@ prefix `F_q = T_q @ ... @ T_0`；逆序遍历构造当前 branch 到尾部的 su
 3. **累乘发生在 microbatch 结算时**，快照按 `(layer_idx, attn-before-mlp)` 排序，不在 hook 里增量累乘。因此结果与
    hook 触发顺序无关；recompute 即使按反向层序重放，也会恢复成物理 branch 顺序。回归测试会故意逆序触发 hook，
    并用非交换矩阵分别核对正序 prefix 和逆序 suffix。
-4. **MTP 层被排除。** MTP 层不在主干传播路径上，乘进链条没有物理意义。
+4. **MTP 层被排除。** MTP 层不在主干传播路径上，乘进链条没有物理意义。megatron 后端不需要这道过滤：MTP block
+   不在 `decoder.layers` 里，discovery 根本走不到。
+
+两处后端差异：megatron 的 `h_res_logits*` 四条指标依赖 `_compute_h`，而 `config.use_fused_mhc` 会让
+`compute_mappings` 直接走 `fused_proj_rms_compute_h` 而跳过它——此时这四条累加器为空、不落盘（其余 12 条不受影响）；
+AMP 反除只在 fp16 且调用方传入 `grad_scaler` 时发生，bf16 下 megatron 本就不缩放，`finalize_scaled_grad_metrics()`
+是 no-op。
 
 作用域限制：复合只覆盖**本 rank 持有的层**。在 `sharding: stage1` 且无 PP 时，每张卡持有全部 Transformer 层，
-所以覆盖全网层范围。真开 PP 后它会退化成 stage 内语义，而我们既检测不到也修不了——`get_pipeline_model_parallel_rank`
+所以覆盖全网层范围。真开 PP 后它会退化成 stage 内语义（megatron 后端即如此，多 chunk 时按 `layer_offset` 排序，
+链条覆盖本 stage 持有的所有 chunk），而在 PaddleFleet 上我们既检测不到也修不了——`get_pipeline_model_parallel_rank`
 和 `get_pipeline_model_parallel_world_size` 在 PaddleFleet 里目前是 stub（无条件返回 0 / 1，
 `parallel_state.py:229`、`:246`）。要支持 PP 需要先等这两个函数实现，再补一次 flush 时的 all-gather；届时
 **collective 必须放在所有 per-layer `try/except` 之外**，否则单个 rank 吞异常会让整个 job 挂死而不是报错。

--- a/src/internal_medicine/backends/megatron/base.py
+++ b/src/internal_medicine/backends/megatron/base.py
@@ -53,6 +53,12 @@ class TorchProbe(Probe):
         self._layer_metric_groups: dict[str, tuple[str, list[str]]] = {}
         self._layer_metric_keys: set[str] = set()
         self._disabled_keys: set[str] = set()
+        # Per-layer vector metrics: key -> size, plus the expanded element keys
+        # the flush writes. Mean-aggregated only; they do not derive a global.
+        self._vector_keys: dict[str, int] = {}
+        self._vector_elem_keys: dict[str, list[str]] = {}
+        self._gpu_vec: dict[str, torch.Tensor] = {}
+        self._gpu_vec_cnt: dict[str, int] = {}
         self._buffers_allocated = False
         self.hook_timing_enabled = hook_timing_enabled
         self._hook_timing: dict[str, tuple[int, float]] = {}
@@ -147,12 +153,16 @@ class TorchProbe(Probe):
         for k in self._min_keys:
             self._gpu_acc[k] = torch.full((), float("inf"), device=device, dtype=dtype)
             self._gpu_cnt[k] = 0
+        # vector: one [size] accumulator per layer key, expanded per element at flush.
+        for k, size in self._vector_keys.items():
+            self._gpu_vec[k] = torch.zeros(size, device=device, dtype=dtype)
+            self._gpu_vec_cnt[k] = 0
         self._buffers_allocated = True
         if self.verbose:
             logger.info(
                 f"[{self.METRIC_PREFIX}] GPU buffer budget: "
                 f"mean={len(self._mean_keys)} max={len(self._max_keys)} "
-                f"min={len(self._min_keys)} keys"
+                f"min={len(self._min_keys)} vector={len(self._vector_keys)} keys"
             )
 
     def record_mean(self, key: str, val: torch.Tensor) -> None:
@@ -239,6 +249,37 @@ class TorchProbe(Probe):
         else:
             self.record_mean(layer_key, val)
 
+    # ------------------------------------------------------------------
+    # Per-layer vector metrics (one curve per element, e.g. per mapping cell)
+    # ------------------------------------------------------------------
+
+    def declare_layer_vector(self, layer_idx: int, metric_name: str, size: int, elem_tag: str = "e") -> None:
+        """Declare a per-layer vector metric, mean-aggregated, expanded at flush.
+
+        For "one curve per element per layer" series (a mapping cell, an expert
+        share): the hot path pays a single ``add_`` for the whole vector instead
+        of one kernel per element. Vector metrics derive **no** global key — a
+        mean of one cell over all layers has no diagnostic meaning.
+        """
+        assert not self._buffers_allocated, f"declare_layer_vector({metric_name!r}) after allocate_buffers"
+        if not self.log_per_layer:
+            return
+        key = self._layer_key(layer_idx, metric_name)
+        assert key not in self._vector_keys, f"declare_layer_vector({key!r}) declared twice"
+        size = int(size)
+        assert size > 0
+        self._vector_keys[key] = size
+        self._vector_elem_keys[key] = [f"{key}_{elem_tag}{i}" for i in range(size)]
+
+    def record_layer_vector(self, layer_idx: int, metric_name: str, vec: torch.Tensor) -> None:
+        """Hot path: one in-place accumulate for the whole ``[size]`` vector."""
+        key = self._layer_key(layer_idx, metric_name)
+        buf = self._gpu_vec.get(key)
+        if buf is None:  # log_per_layer=False, or this layer was never declared
+            return
+        buf.add_(vec.detach().to(buf.dtype))
+        self._gpu_vec_cnt[key] += 1
+
     def _flush_gpu_buffer(self) -> dict[str, float]:
         """Single batched D2H of all declared metrics, then reset.
 
@@ -289,9 +330,25 @@ class TorchProbe(Probe):
                 keys.append(global_key)
 
         out: dict[str, float] = {}
-        if tensors:
-            vals = torch.stack(tensors).cpu().tolist()
+        # Single D2H for scalars and vectors alike: flatten everything into one
+        # concat so the vector series cost no extra sync point.
+        vec_key_groups: list[list[str]] = []
+        vec_tensors: list[torch.Tensor] = []
+        for k, elem_keys in self._vector_elem_keys.items():
+            cnt = self._gpu_vec_cnt[k]
+            if cnt == 0:
+                continue
+            vec_key_groups.append(elem_keys)
+            vec_tensors.append(self._gpu_vec[k] / cnt)
+
+        if tensors or vec_tensors:
+            flat = torch.cat([t.reshape(-1) for t in tensors] + vec_tensors)
+            vals = flat.cpu().tolist()
             out = dict(zip(keys, vals, strict=False))
+            offset = len(keys)
+            for elem_keys in vec_key_groups:
+                out.update(zip(elem_keys, vals[offset : offset + len(elem_keys)], strict=False))
+                offset += len(elem_keys)
 
         for k in self._mean_keys:
             self._gpu_acc[k].zero_()
@@ -302,4 +359,7 @@ class TorchProbe(Probe):
         for k in self._min_keys:
             self._gpu_acc[k].fill_(float("inf"))
             self._gpu_cnt[k] = 0
+        for k in self._vector_keys:
+            self._gpu_vec[k].zero_()
+            self._gpu_vec_cnt[k] = 0
         return out

--- a/src/internal_medicine/backends/megatron/mhc_metrics.py
+++ b/src/internal_medicine/backends/megatron/mhc_metrics.py
@@ -14,6 +14,9 @@ axis the backward one. For a single doubly-stochastic ``h_res`` both sit at
 ~1.0; on the *composite* mapping (cumulative product of ``h_res`` across layers)
 they drift away from 1.0 with depth, flagging residual-stream amplification.
 
+``gate_logits_extrema`` and ``mapping_param_stats`` reach one step further back,
+to the ``alpha`` / ``bias`` / pre-sigmoid-logit terms of paper Eq. (7).
+
 All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
 ``.cpu()``), so they are safe to call from a forward hot path. See
 ``.claude/skills/monitor-hook-perf-rules``.
@@ -56,6 +59,74 @@ def h_res_logits_extrema(h_res_logits: torch.Tensor) -> dict[str, torch.Tensor]:
         "h_res_logits_min": logits.min(),
         "h_res_logits_max": logits.max(),
     }
+
+
+def gate_logits_extrema(
+    proj: torch.Tensor,
+    r: torch.Tensor,
+    alpha_pre: torch.Tensor,
+    alpha_post: torch.Tensor,
+    bias: torch.Tensor,
+    n: int,
+) -> dict[str, torch.Tensor]:
+    """Min/max of the *pre-sigmoid* ``H_pre`` / ``H_post`` logits (paper Eq. 7).
+
+    Keep in sync with ``HyperConnectionModule._compute_h``, which forms
+    ``h = r * proj * alpha + bias`` and slices ``[:n]`` / ``[n:2n]`` off it: if
+    the model changes how ``h`` is built, these four series go silently wrong.
+
+    Megatron's ``r`` is the reciprocal RMS produced by ``_projection_and_get_norm``
+    (the native path multiplies by it), unlike the fused kernel's reference which
+    divides by the RMS. This helper is only ever fed the native path's ``(proj, r)``
+    pair, so it follows the multiplication.
+    """
+    proj32 = proj.detach().float()
+    r32 = r.detach().float()
+    bias32 = bias.detach().float()
+    pre = r32 * proj32[..., :n] * alpha_pre.detach().float() + bias32[:n]
+    post = r32 * proj32[..., n : 2 * n] * alpha_post.detach().float() + bias32[n : 2 * n]
+    return {
+        "h_pre_logits_min": pre.min(),
+        "h_pre_logits_max": pre.max(),
+        "h_post_logits_min": post.min(),
+        "h_post_logits_max": post.max(),
+    }
+
+
+def mapping_param_stats(
+    alpha_pre: torch.Tensor,
+    alpha_post: torch.Tensor,
+    alpha_res: torch.Tensor,
+    bias: torch.Tensor,
+    n: int,
+) -> dict[str, torch.Tensor]:
+    """The static half of paper Eq. (7): the gating factors and the bias terms.
+
+    ``alpha_*`` are per-module scalars. ``bias`` is a single ``[n^2 + 2n]``
+    parameter whose slices are the paper's ``b^pre`` / ``b^post`` / ``b^res``, so
+    they are reported per slice rather than as one number. ``mean`` shows where
+    the slice sits (it starts at 0 and drifts), ``abs_max`` catches a single
+    runaway entry the mean would hide.
+
+    Step-level quantities: record once per optimizer step, not per microbatch.
+    """
+    alpha = {
+        "alpha_pre": alpha_pre,
+        "alpha_post": alpha_post,
+        "alpha_res": alpha_res,
+    }
+    stats = {name: value.detach().float().mean() for name, value in alpha.items()}
+
+    b = bias.detach().float()
+    slices = {
+        "pre": b[:n],
+        "post": b[n : 2 * n],
+        "res": b[2 * n :],
+    }
+    for name, part in slices.items():
+        stats[f"bias_{name}_mean"] = part.mean()
+        stats[f"bias_{name}_abs_max"] = part.abs().max()
+    return stats
 
 
 def h_post_structure_stats(h_post: torch.Tensor) -> dict[str, torch.Tensor]:

--- a/src/internal_medicine/backends/megatron/mhc_metrics.py
+++ b/src/internal_medicine/backends/megatron/mhc_metrics.py
@@ -1,20 +1,18 @@
 """mHC (Manifold-Constrained Hyper-Connections) metric compute functions.
 
 Pure, stateless tensor -> tensor helpers for the ``mhc_health`` monitor. They
-operate on the three mappings a ``HyperConnectionModule`` produces per token:
+operate on the three mappings a ``HyperConnectionModule`` produces per token
+(``n = num_residual_streams``, ``s`` = sequence, ``b`` = micro-batch):
 
 - ``h_pre``  [s, b, n]      — stream aggregation gate (sigmoid)
 - ``h_post`` [s, b, n]      — stream expansion gate (2*sigmoid)
 - ``h_res``  [s, b, n, n]   — Sinkhorn doubly-stochastic residual-mixing matrix
 
-``n = num_residual_streams``, ``s`` = sequence, ``b`` = micro-batch.
-
-The ``amax_gain`` diagnostic follows the mHC paper: the max-abs **row** sum of a
-mixing matrix bounds the worst-case forward-pass expansion, and the max-abs
-**column** sum bounds the backward-pass expansion. For a single doubly-stochastic
-``h_res`` both sit at ~1.0; on the *composite* mapping (cumulative product of
-``h_res`` across layers) they drift away from 1.0 with depth, flagging
-residual-stream amplification.
+The ``amax_gain`` diagnostic follows the mHC paper: the max-abs sum along the
+operator's contracted axis bounds the worst-case forward expansion, the other
+axis the backward one. For a single doubly-stochastic ``h_res`` both sit at
+~1.0; on the *composite* mapping (cumulative product of ``h_res`` across layers)
+they drift away from 1.0 with depth, flagging residual-stream amplification.
 
 All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
 ``.cpu()``), so they are safe to call from a forward hot path. See
@@ -23,24 +21,106 @@ All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
 
 import torch
 
+_EPS = 1e-12
+
 
 def amax_gain(mat: torch.Tensor, dim: int) -> torch.Tensor:
     """Per-token max-abs {row|col} sum of a batched ``[..., n, n]`` matrix, meaned over tokens.
 
-    ``dim=-1`` sums over columns -> per-row sums (forward gain); ``dim=-2`` sums
-    over rows -> per-column sums (backward gain). ``sum(dim)`` collapses one
-    ``n``-axis to ``[..., n]``; ``abs().amax(-1)`` takes the worst stream per token
-    (a 1-per-token scalar); ``mean()`` averages over all tokens.
+    The paper's worst-case gain bound. Which axis is "forward" depends on the
+    matrix passed in: streams mix as ``out = h_res^T @ x`` (see
+    ``HyperConnectionModule.apply_h_res``), so on ``h_res`` as stored ``dim=-2``
+    (column sums) is the forward gain and ``dim=-1`` the backward one; on an
+    already-transposed matrix the two swap.
 
-    Returns a 0-dim tensor on ``mat``'s device/dtype (fp32 from ``compute_mappings``).
+    ``sum(dim)`` collapses one ``n``-axis to ``[..., n]``; ``abs().amax(-1)``
+    takes the worst stream per token; ``mean()`` averages over all tokens.
+    Returns a 0-dim tensor on ``mat``'s device/dtype.
     """
     sums = mat.sum(dim=dim)  # [..., n]
     return sums.abs().amax(dim=-1).mean()  # 0-dim
 
 
 def gate_stats(h: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Mean and (unbiased) std of a gate tensor ``h`` [s, b, n] over all elements.
+    """Mean and (unbiased) std of a gate tensor ``h`` over all elements.
 
     Returns two 0-dim tensors ``(mean, std)``; no host sync.
     """
     return h.mean(), h.std()
+
+
+def h_res_logits_extrema(h_res_logits: torch.Tensor) -> dict[str, torch.Tensor]:
+    """Min/max of the raw residual-mixing logits before Sinkhorn."""
+    logits = h_res_logits.detach().float()
+    return {
+        "h_res_logits_min": logits.min(),
+        "h_res_logits_max": logits.max(),
+    }
+
+
+def h_post_structure_stats(h_post: torch.Tensor) -> dict[str, torch.Tensor]:
+    """Structure of the expansion gate across streams and across tokens."""
+    flat = h_post.detach().float()
+    flat = flat.reshape(-1, flat.shape[-1])  # [tokens, n]
+
+    per_token_mean = flat.mean(dim=-1)  # [tokens]
+    per_token_max = flat.amax(dim=-1)  # [tokens]
+    concentration = (per_token_max / per_token_mean.clamp(min=_EPS)).mean()
+    token_std = per_token_mean.std() if flat.shape[0] > 1 else torch.zeros((), device=flat.device, dtype=flat.dtype)
+
+    return {
+        "h_post_stream_concentration": concentration,
+        "h_post_token_std": token_std,
+    }
+
+
+def branch_residual_share(
+    h_res: torch.Tensor,
+    original_residual: torch.Tensor,
+    h_post: torch.Tensor,
+    layer_output: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> dict[str, torch.Tensor]:
+    """How much of the mHC update this layer wrote itself, per token?
+
+    Args:
+        h_res: ``[..., n, n]`` Sinkhorn doubly-stochastic mixing matrix.
+        original_residual: ``[..., n*C]`` incoming n-stream hidden states.
+        h_post: ``[..., n]`` expansion gate.
+        layer_output: ``[..., C]`` the sublayer output ``F(·)``.
+        bias: optional ``[C]`` bias added to the sublayer output.
+
+    Returns:
+        ``branch_residual_share`` (token mean) and
+        ``branch_residual_share_max`` (worst token), both in ``[0, 1]``.
+
+    Note:
+        The branch term is measured *before* dropout, so configs with
+        ``hidden_dropout > 0`` slightly over-estimate it; the pretraining
+        configs here use 0.
+    """
+    n = int(h_post.shape[-1])
+    xb = layer_output.detach().float()
+    if bias is not None:
+        xb = xb + bias.detach().float().reshape(*([1] * (xb.dim() - 1)), -1)
+    xb = xb.reshape(-1, xb.shape[-1])  # [tokens, C]
+
+    gate = h_post.detach().float().reshape(-1, n)  # [tokens, n]
+    branch_norm = gate.norm(dim=-1) * xb.norm(dim=-1)  # [tokens]
+
+    streams = original_residual.detach().float()
+    streams = streams.reshape(-1, n, streams.shape[-1] // n)  # [tokens, n, C]
+    res = h_res.detach().float().reshape(-1, n, n)  # [tokens, n, n]
+
+    gram = torch.einsum("tjc,tkc->tjk", streams, streams)  # [tokens, n, n]
+    mix = torch.einsum("tji,tki->tjk", res, res)  # [tokens, n, n]
+    residual_sq = (gram * mix).sum(dim=(-2, -1))  # [tokens]
+    residual_norm = residual_sq.clamp(min=0.0).sqrt()
+
+    # eps only guards the both-terms-zero token (share 0); it does not bound the
+    # value, which is why this form is safe where the raw ratio was not.
+    share = branch_norm / (branch_norm + residual_norm).clamp(min=_EPS)
+    return {
+        "branch_residual_share": share.mean(),
+        "branch_residual_share_max": share.max(),
+    }

--- a/src/internal_medicine/backends/megatron/mhc_monitor.py
+++ b/src/internal_medicine/backends/megatron/mhc_monitor.py
@@ -20,13 +20,24 @@ Forward hooks are not enough, so three bound methods are wrapped instead (see
 ``mhc_metrics`` for what each metric means):
 
 - ``compute_mappings`` — ``h_pre`` is not in ``forward``'s return value.
-- ``_compute_h``       — the mixing logits only exist before the Sinkhorn
-  projection. Note that, unlike PaddleFleet, Megatron's ``compute_mappings``
-  skips ``_compute_h`` entirely when ``config.use_fused_mhc`` selects
-  ``fused_proj_rms_compute_h``; the four ``h_res_logits*`` series are then
-  simply never recorded (their accumulators stay empty and are not emitted).
+- ``_sinkhorn_op``     — the mixing logits only exist before the Sinkhorn
+  projection, and this is the one call site that consumes them. ``_compute_h``
+  is *not* a usable hook point here: unlike PaddleFleet, Megatron's
+  ``compute_mappings`` skips ``_compute_h`` entirely when
+  ``config.use_fused_mhc`` selects ``fused_proj_rms_compute_h``, which produces
+  the logits inside the kernel instead. Both paths converge on the
+  ``_sinkhorn_op`` argument, so wrapping it records the logits the model
+  actually consumes on either path.
 - ``fused_h_res_h_post_bda`` — the only point where both update terms are
   visible.
+
+The fused kernel computes the logits itself, so on that path their values carry
+the kernel's numerics rather than the native reference's. The four
+``h_res_logits*`` series are therefore trend-comparable, but not value-for-value
+comparable, against a backend whose logits come from a native ``_compute_h``
+(PaddleFleet with fused mHC, or an older Megatron whose fused switch only swaps
+``_proj_rms_op`` / ``_sinkhorn_op``). Strict alignment runs should disable
+``use_fused_mhc`` on both sides.
 
 Hot-path discipline (no D2H sync, no hook-time collectives, schema fixed at
 registration): see ``.claude/skills/monitor-hook-perf-rules``.
@@ -212,10 +223,10 @@ class MHCHealthMonitor(TorchProbe):
             orig = mod.compute_mappings
             mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
             self._wrapped.append((mod, "compute_mappings", orig))
-            orig_h = getattr(mod, "_compute_h", None)
-            if orig_h is not None:
-                mod._compute_h = self._make_logits_capture(orig_h, layer_idx, comp)
-                self._wrapped.append((mod, "_compute_h", orig_h))
+            orig_sinkhorn = getattr(mod, "_sinkhorn_op", None)
+            if orig_sinkhorn is not None:
+                mod._sinkhorn_op = self._make_sinkhorn_input_capture(orig_sinkhorn, layer_idx, comp)
+                self._wrapped.append((mod, "_sinkhorn_op", orig_sinkhorn))
             orig_bda = getattr(mod, "fused_h_res_h_post_bda", None)
             if orig_bda is None:
                 continue
@@ -239,6 +250,12 @@ class MHCHealthMonitor(TorchProbe):
         # and falls back to the class method; if that fails, we re-bind the
         # captured original.
         for mod, attr, orig in self._wrapped:
+            if not hasattr(type(mod), attr):
+                # ``_sinkhorn_op`` is assigned in ``__init__`` and exists only on
+                # the instance, so ``delattr`` would remove it outright instead of
+                # exposing a class-level fallback. Restore by assignment.
+                setattr(mod, attr, orig)
+                continue
             try:
                 delattr(mod, attr)
             except AttributeError:
@@ -378,45 +395,51 @@ class MHCHealthMonitor(TorchProbe):
 
         return wrapped
 
-    def _make_logits_capture(self, orig, layer_idx: int, component: str):
-        """Wrap ``_compute_h`` to record the saturation sentinel."""
+    def _make_sinkhorn_input_capture(self, orig, layer_idx: int, component: str):
+        """Wrap ``_sinkhorn_op`` to record the saturation sentinel from its input.
 
-        def wrapped(proj, r):
-            out = orig(proj, r)  # the real mappings the model consumes — returned unchanged
-            if not self._should_monitor():
-                return out
-            try:
-                _h_pre, _h_post, h_res_logits = out
-                if h_res_logits.requires_grad:
+        The first argument is the pre-projection mixing logits, i.e. the same
+        tensor ``_compute_h`` returns on the unfused path (modulo the ``view`` to
+        [s, b, n, n], which leaves element-wise extrema and their gradients
+        unchanged) and the kernel output on the fused path.
+        """
 
-                    def record_grad_extrema(grad):
-                        try:
-                            grad_fp32 = grad.detach().float()
-                            self.record_layer_metric(
-                                layer_idx,
-                                f"{component}_h_res_logits_grad_min",
-                                grad_fp32.min(),
-                            )
-                            self.record_layer_metric(
-                                layer_idx,
-                                f"{component}_h_res_logits_grad_max",
-                                grad_fp32.max(),
-                            )
-                            self._grad_metrics_finalized = False
-                        except Exception as e:
-                            if self.verbose:
-                                logger.error(f"[MHCMonitor] Error logits gradient layer {layer_idx}/{component}: {e}")
-                        # Returning None leaves the autograd gradient untouched.
-                        return None
+        def wrapped(h_res_logits, *args, **kwargs):
+            if self._should_monitor():
+                try:
+                    if h_res_logits.requires_grad:
 
-                    h_res_logits.register_hook(record_grad_extrema)
-                with torch.no_grad():
-                    for name, value in h_res_logits_extrema(h_res_logits).items():
-                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
-            except Exception as e:
-                if self.verbose:
-                    logger.error(f"[MHCMonitor] Error logits layer {layer_idx}/{component}: {e}")
-            return out
+                        def record_grad_extrema(grad):
+                            try:
+                                grad_fp32 = grad.detach().float()
+                                self.record_layer_metric(
+                                    layer_idx,
+                                    f"{component}_h_res_logits_grad_min",
+                                    grad_fp32.min(),
+                                )
+                                self.record_layer_metric(
+                                    layer_idx,
+                                    f"{component}_h_res_logits_grad_max",
+                                    grad_fp32.max(),
+                                )
+                                self._grad_metrics_finalized = False
+                            except Exception as e:
+                                if self.verbose:
+                                    logger.error(
+                                        f"[MHCMonitor] Error logits gradient layer {layer_idx}/{component}: {e}"
+                                    )
+                            # Returning None leaves the autograd gradient untouched.
+                            return None
+
+                        h_res_logits.register_hook(record_grad_extrema)
+                    with torch.no_grad():
+                        for name, value in h_res_logits_extrema(h_res_logits).items():
+                            self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+                except Exception as e:
+                    if self.verbose:
+                        logger.error(f"[MHCMonitor] Error logits layer {layer_idx}/{component}: {e}")
+            # The real doubly-stochastic matrix the model consumes — unchanged.
+            return orig(h_res_logits, *args, **kwargs)
 
         return wrapped
 

--- a/src/internal_medicine/backends/megatron/mhc_monitor.py
+++ b/src/internal_medicine/backends/megatron/mhc_monitor.py
@@ -1,7 +1,7 @@
 """mHC Health Monitor for Megatron-Bridge.
 
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 16
-series, name-prefixed by component:
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 29
+scalar series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
     {attn,mlp}_h_post_mean  {attn,mlp}_h_post_std
@@ -11,12 +11,25 @@ series, name-prefixed by component:
     {attn,mlp}_h_res_logits_min  {attn,mlp}_h_res_logits_max
     {attn,mlp}_h_res_logits_grad_min  {attn,mlp}_h_res_logits_grad_max
     {attn,mlp}_composite_amax_gain_fwd_max  {attn,mlp}_composite_amax_gain_bwd_max
+    {attn,mlp}_h_pre_logits_min   {attn,mlp}_h_pre_logits_max
+    {attn,mlp}_h_post_logits_min  {attn,mlp}_h_post_logits_max
+    {attn,mlp}_alpha_pre  {attn,mlp}_alpha_post  {attn,mlp}_alpha_res
+    {attn,mlp}_bias_pre_mean   {attn,mlp}_bias_pre_abs_max
+    {attn,mlp}_bias_post_mean  {attn,mlp}_bias_post_abs_max
+    {attn,mlp}_bias_res_mean   {attn,mlp}_bias_res_abs_max
+
+plus a set of per-element mapping series (``n^2 + 2n`` per hc module) that expand
+``h_res`` / ``h_pre`` / ``h_post`` cell by cell.
+
+The last 13 scalars cover paper Eq. (7) — the ``alpha`` / ``bias`` /
+pre-sigmoid-logit terms that feed Eq. (8). The nine parameter series are
+step-level and are read once per flush, off the hot path.
 
 The schema, the metric semantics and the aggregation choices are kept identical
 to ``backends/paddlefleet/mhc_monitor.py`` on purpose: the two backends train
 the same mHC model, so the curves have to be comparable across them.
 
-Forward hooks are not enough, so three bound methods are wrapped instead (see
+Forward hooks are not enough, so four bound methods are wrapped instead (see
 ``mhc_metrics`` for what each metric means):
 
 - ``compute_mappings`` — ``h_pre`` is not in ``forward``'s return value.
@@ -28,16 +41,27 @@ Forward hooks are not enough, so three bound methods are wrapped instead (see
   the logits inside the kernel instead. Both paths converge on the
   ``_sinkhorn_op`` argument, so wrapping it records the logits the model
   actually consumes on either path.
+- ``_compute_h`` — the *only* route to the pre-sigmoid ``h_pre`` / ``h_post``
+  logits, which need its ``(proj, r)`` arguments. See the caveat below.
 - ``fused_h_res_h_post_bda`` — the only point where both update terms are
   visible.
 
-The fused kernel computes the logits itself, so on that path their values carry
-the kernel's numerics rather than the native reference's. The four
-``h_res_logits*`` series are therefore trend-comparable, but not value-for-value
-comparable, against a backend whose logits come from a native ``_compute_h``
-(PaddleFleet with fused mHC, or an older Megatron whose fused switch only swaps
-``_proj_rms_op`` / ``_sinkhorn_op``). Strict alignment runs should disable
-``use_fused_mhc`` on both sides.
+Two fused-path caveats, both specific to a Megatron whose ``use_fused_mhc``
+folds ``compute_h`` into the kernel:
+
+1. The kernel computes the residual-mixing logits itself, so on that path their
+   values carry the kernel's numerics rather than the native reference's. The
+   four ``h_res_logits*`` series are therefore trend-comparable, but not
+   value-for-value comparable, against a backend whose logits come from a native
+   ``_compute_h``.
+2. ``fused_proj_rms_compute_h`` returns ``(h_pre, h_post, h_res, r)`` and never
+   exposes ``proj``, so the four ``h_{pre,post}_logits_*`` series cannot be
+   rebuilt on that path without repeating the projection matmul on the hot path.
+   Their accumulators simply stay empty and are not emitted; the other 25
+   scalars and all the per-element series are unaffected.
+
+Strict cross-backend alignment runs should disable ``use_fused_mhc`` on both
+sides.
 
 Hot-path discipline (no D2H sync, no hook-time collectives, schema fixed at
 registration): see ``.claude/skills/monitor-hook-perf-rules``.
@@ -52,9 +76,11 @@ from .base import TorchProbe
 from .mhc_metrics import (
     amax_gain,
     branch_residual_share,
+    gate_logits_extrema,
     gate_stats,
     h_post_structure_stats,
     h_res_logits_extrema,
+    mapping_param_stats,
 )
 
 logger = logging.getLogger(__name__)
@@ -88,7 +114,39 @@ _METRIC_NAMES = (
     "h_res_logits_grad_max",
     "composite_amax_gain_fwd_max",
     "composite_amax_gain_bwd_max",
+    "h_pre_logits_min",
+    "h_pre_logits_max",
+    "h_post_logits_min",
+    "h_post_logits_max",
+    "alpha_pre",
+    "alpha_post",
+    "alpha_res",
+    "bias_pre_mean",
+    "bias_pre_abs_max",
+    "bias_post_mean",
+    "bias_post_abs_max",
+    "bias_res_mean",
+    "bias_res_abs_max",
 )
+
+# Read once per flush from the module parameters, not from the hot path.
+_PARAM_METRICS = (
+    "alpha_pre",
+    "alpha_post",
+    "alpha_res",
+    "bias_pre_mean",
+    "bias_pre_abs_max",
+    "bias_post_mean",
+    "bias_post_abs_max",
+    "bias_res_mean",
+    "bias_res_abs_max",
+)
+
+
+def _vector_metric_specs(n: int) -> tuple[tuple[str, str, int], ...]:
+    """``(metric_name, elem_tag, size)`` for the per-element mapping series."""
+    return (("h_res", "cell", n * n), ("h_pre", "idx", n), ("h_post", "idx", n))
+
 
 # Extrema, not means: a worst case that a mean over all layers would bury. The
 # `_max` / `_min` suffixes keep training_logs' classifier in agreement on the
@@ -100,9 +158,21 @@ _MAX_METRICS = frozenset(
         "h_res_logits_grad_max",
         "composite_amax_gain_fwd_max",
         "composite_amax_gain_bwd_max",
+        "h_pre_logits_max",
+        "h_post_logits_max",
+        "bias_pre_abs_max",
+        "bias_post_abs_max",
+        "bias_res_abs_max",
     }
 )
-_MIN_METRICS = frozenset({"h_res_logits_min", "h_res_logits_grad_min"})
+_MIN_METRICS = frozenset(
+    {
+        "h_res_logits_min",
+        "h_res_logits_grad_min",
+        "h_pre_logits_min",
+        "h_post_logits_min",
+    }
+)
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
@@ -144,6 +214,14 @@ class MHCHealthMonitor(TorchProbe):
         # for the composite product. Keyed rather than appended so the product is
         # built in layer order, not call order (see _record_composite).
         self._h_res_snapshot: dict[tuple[int, str], torch.Tensor] = {}
+        # (layer_idx, component, module) for the step-level parameter series.
+        self._param_targets: list[tuple[int, str, nn.Module]] = []
+        # Set by the capture wrapper: whether this step's forward was monitored.
+        # A plain bool assignment, so it costs nothing on the hot path, and it
+        # keeps the parameter series on exactly the steps the rest are on
+        # (`_should_monitor()` cannot answer that at flush time — `step()` has
+        # already incremented `step_count` by then).
+        self._captured_this_step = False
         # Gradient hooks see AMP-scaled activation gradients. The callback
         # finalizes these accumulators with this step's scale before flush.
         self._grad_metrics_finalized = False
@@ -213,9 +291,14 @@ class MHCHealthMonitor(TorchProbe):
         ``declare_layer_metric`` call remains legal.
         """
         entries = self._find_hc_modules(model, layer_offset=layer_offset)
-        for global_idx, comp, _ in entries:
+        for global_idx, comp, mod in entries:
             for name in _METRIC_NAMES:
                 self.declare_layer_metric(global_idx, f"{comp}_{name}")
+            # `n` is static module metadata, so reading it at declare time costs
+            # no hot-path sync and keeps the schema fixed (Rule 3).
+            for name, tag, size in _vector_metric_specs(int(getattr(mod, "n", 0) or 0)):
+                if size > 0:
+                    self.declare_layer_vector(global_idx, f"{comp}_{name}", size, elem_tag=tag)
         return entries
 
     def _attach_hooks(self, targets):
@@ -223,10 +306,15 @@ class MHCHealthMonitor(TorchProbe):
             orig = mod.compute_mappings
             mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
             self._wrapped.append((mod, "compute_mappings", orig))
+            self._param_targets.append((layer_idx, comp, mod))
             orig_sinkhorn = getattr(mod, "_sinkhorn_op", None)
             if orig_sinkhorn is not None:
                 mod._sinkhorn_op = self._make_sinkhorn_input_capture(orig_sinkhorn, layer_idx, comp)
                 self._wrapped.append((mod, "_sinkhorn_op", orig_sinkhorn))
+            orig_h = getattr(mod, "_compute_h", None)
+            if orig_h is not None:
+                mod._compute_h = self._make_gate_logits_capture(orig_h, layer_idx, comp, mod)
+                self._wrapped.append((mod, "_compute_h", orig_h))
             orig_bda = getattr(mod, "fused_h_res_h_post_bda", None)
             if orig_bda is None:
                 continue
@@ -261,6 +349,7 @@ class MHCHealthMonitor(TorchProbe):
             except AttributeError:
                 setattr(mod, attr, orig)
         self._wrapped = []
+        self._param_targets = []
         self._h_res_snapshot.clear()
         super().remove_hooks()
 
@@ -325,6 +414,11 @@ class MHCHealthMonitor(TorchProbe):
         ``grad_scaler``; both the Megatron (``scale``) and torch
         (``_scale``) attribute names are accepted.
         """
+        # This is the last hook before ``optimizer_step()``, so it is also where
+        # the Eq. (7) parameters still hold the values this step's forward
+        # actually used. Called outside the guard below and idempotent within a
+        # step, so the ``_flush_buffers`` fallback stays harmless.
+        self.finalize_param_metrics()
         if self._grad_metrics_finalized:
             return
         scale = None
@@ -338,6 +432,49 @@ class MHCHealthMonitor(TorchProbe):
                     acc = self._gpu_acc[key]
                     acc.div_(torch.as_tensor(scale, device=acc.device, dtype=acc.dtype))
         self._grad_metrics_finalized = True
+
+    def finalize_param_metrics(self) -> None:
+        """Record the step-level ``alpha`` / ``bias`` series from the parameters.
+
+        Cold path: once per step, so nine tiny reductions per module instead of
+        per microbatch. Skipped entirely when this step's forward was not
+        monitored, which keeps these series sampled on the same steps as the
+        activation ones under ``monitor_interval > 1`` — ``_should_monitor()``
+        cannot answer that here, because ``step()`` increments ``step_count``
+        before ``_flush_buffers`` runs.
+
+        Read point is ``finalize_scaled_grad_metrics``, i.e. *before*
+        ``optimizer.step()``, so the values line up with the forward that
+        produced this step's activation metrics. A caller that only drives
+        ``step()`` falls back to the flush path and therefore logs the
+        post-update value — one update later than the rest of the step's series.
+
+        The parameters are replicated across TP ranks (``HyperConnectionModule``
+        uses a plain ``nn.Linear``), so no collective is needed — every rank
+        holds the same values.
+        """
+        if not self._captured_this_step:
+            return
+        try:
+            for layer_idx, component, mod in self._param_targets:
+                try:
+                    with torch.no_grad():
+                        stats = mapping_param_stats(
+                            mod.alpha_pre,
+                            mod.alpha_post,
+                            mod.alpha_res,
+                            mod.bias,
+                            int(mod.n),
+                        )
+                    for name, value in stats.items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+                except Exception as e:
+                    # Per module, so one module without the Eq. (7) parameters
+                    # cannot silence the series for every other layer.
+                    if self.verbose:
+                        logger.error(f"[MHCMonitor] Error mapping params {layer_idx}/{component}: {e}")
+        finally:
+            self._captured_this_step = False
 
     def _flush_buffers(self) -> None:
         # Direct users and non-AMP trainers never call finalize_* themselves.
@@ -366,6 +503,7 @@ class MHCHealthMonitor(TorchProbe):
                 return out
             try:
                 h_pre, h_post, h_res = out
+                self._captured_this_step = True
                 with torch.no_grad():
                     h_pre = h_pre.detach()
                     h_post = h_post.detach()
@@ -383,11 +521,18 @@ class MHCHealthMonitor(TorchProbe):
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, dim=-2))
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, dim=-1))
 
-                    # Token-mean snapshot of the *operator* for the composite product.
+                    # Token-mean of every mapping element. One reduce feeds both
+                    # the per-cell series and the composite product's snapshot.
                     n = int(h_res.shape[-1])
-                    self._h_res_snapshot[(layer_idx, component)] = (
-                        h_res.float().reshape(-1, n, n).mean(dim=0).transpose(0, 1)
+                    res_mean = h_res.float().reshape(-1, n, n).mean(dim=0)
+                    self.record_layer_vector(layer_idx, f"{component}_h_res", res_mean.reshape(-1))
+                    self.record_layer_vector(layer_idx, f"{component}_h_pre", h_pre.float().reshape(-1, n).mean(dim=0))
+                    self.record_layer_vector(
+                        layer_idx, f"{component}_h_post", h_post.float().reshape(-1, n).mean(dim=0)
                     )
+
+                    # Token-mean snapshot of the *operator* for the composite product.
+                    self._h_res_snapshot[(layer_idx, component)] = res_mean.transpose(0, 1)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[MHCMonitor] Error layer {layer_idx}/{component}: {e}")
@@ -440,6 +585,44 @@ class MHCHealthMonitor(TorchProbe):
                         logger.error(f"[MHCMonitor] Error logits layer {layer_idx}/{component}: {e}")
             # The real doubly-stochastic matrix the model consumes — unchanged.
             return orig(h_res_logits, *args, **kwargs)
+
+        return wrapped
+
+    def _make_gate_logits_capture(self, orig, layer_idx: int, component: str, mod):
+        """Wrap ``_compute_h`` for the pre-sigmoid ``h_pre`` / ``h_post`` logits.
+
+        ``_compute_h`` does not return them, so they are rebuilt from its own
+        ``(proj, r)`` arguments plus ``mod``'s ``alpha`` / ``bias`` — see
+        ``gate_logits_extrema``. The residual-mixing logits are *not* read here;
+        ``_sinkhorn_op`` covers those on both the fused and the unfused path.
+
+        Under ``use_fused_mhc`` this wrapper never runs (``compute_mappings``
+        skips ``_compute_h``) and ``fused_proj_rms_compute_h`` does not expose
+        ``proj``, so these four accumulators stay empty and are not emitted
+        rather than being filled from a different quantity.
+        """
+
+        def wrapped(proj, r):
+            out = orig(proj, r)  # the real mappings the model consumes — returned unchanged
+            if not self._should_monitor():
+                return out
+            try:
+                if proj is not None and r is not None:
+                    with torch.no_grad():
+                        gate_logits = gate_logits_extrema(
+                            proj,
+                            r,
+                            mod.alpha_pre,
+                            mod.alpha_post,
+                            mod.bias,
+                            int(mod.n),
+                        )
+                    for name, value in gate_logits.items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MHCMonitor] Error gate logits layer {layer_idx}/{component}: {e}")
+            return out
 
         return wrapped
 

--- a/src/internal_medicine/backends/megatron/mhc_monitor.py
+++ b/src/internal_medicine/backends/megatron/mhc_monitor.py
@@ -1,31 +1,32 @@
 """mHC Health Monitor for Megatron-Bridge.
 
-Monitors the three per-token mappings of every ``HyperConnectionModule`` in an
-mHC (Manifold-Constrained Hyper-Connections) model:
-
-- ``h_pre`` / ``h_post`` — the aggregation / expansion gates: mean and std.
-- ``h_res``              — the doubly-stochastic residual-mixing matrix: the
-  paper's ``amax_gain`` forward (max-abs row sum) and backward (max-abs column
-  sum), computed both on this layer's ``h_res`` and on the running **composite
-  mapping** (cumulative product of ``h_res`` across the layers local to this
-  pipeline stage / VPP chunk).
-
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 8
-mean-aggregated series, name-prefixed by component:
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 16
+series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
     {attn,mlp}_h_post_mean  {attn,mlp}_h_post_std
-    {attn,mlp}_amax_gain_fwd            {attn,mlp}_amax_gain_bwd
-    {attn,mlp}_composite_amax_gain_fwd  {attn,mlp}_composite_amax_gain_bwd
+    {attn,mlp}_h_post_stream_concentration  {attn,mlp}_h_post_token_std
+    {attn,mlp}_branch_residual_share  {attn,mlp}_branch_residual_share_max
+    {attn,mlp}_amax_gain_fwd  {attn,mlp}_amax_gain_bwd
+    {attn,mlp}_h_res_logits_min  {attn,mlp}_h_res_logits_max
+    {attn,mlp}_h_res_logits_grad_min  {attn,mlp}_h_res_logits_grad_max
+    {attn,mlp}_composite_amax_gain_fwd_max  {attn,mlp}_composite_amax_gain_bwd_max
 
-``h_pre`` is not part of ``HyperConnectionModule.forward``'s return, so we cannot
-use a forward hook. Instead we wrap the module's ``compute_mappings`` bound method
-to capture its real ``(h_pre, h_post, h_res)`` — no recompute. Everything is
-detached and computed under ``no_grad`` (see the VRAM-safety notes on the hook).
+The schema, the metric semantics and the aggregation choices are kept identical
+to ``backends/paddlefleet/mhc_monitor.py`` on purpose: the two backends train
+the same mHC model, so the curves have to be comparable across them.
 
-The monitor is a hard no-op unless the model actually uses the mHC layer: if the
-mHC classes cannot be imported, or no ``HyperConnectionTransformerLayer`` is
-found, ``setup_mhc_monitor`` attaches nothing and registers no metrics.
+Forward hooks are not enough, so three bound methods are wrapped instead (see
+``mhc_metrics`` for what each metric means):
+
+- ``compute_mappings`` — ``h_pre`` is not in ``forward``'s return value.
+- ``_compute_h``       — the mixing logits only exist before the Sinkhorn
+  projection. Note that, unlike PaddleFleet, Megatron's ``compute_mappings``
+  skips ``_compute_h`` entirely when ``config.use_fused_mhc`` selects
+  ``fused_proj_rms_compute_h``; the four ``h_res_logits*`` series are then
+  simply never recorded (their accumulators stay empty and are not emitted).
+- ``fused_h_res_h_post_bda`` — the only point where both update terms are
+  visible.
 
 Hot-path discipline (no D2H sync, no hook-time collectives, schema fixed at
 registration): see ``.claude/skills/monitor-hook-perf-rules``.
@@ -37,7 +38,13 @@ import torch
 import torch.nn as nn
 
 from .base import TorchProbe
-from .mhc_metrics import amax_gain, gate_stats
+from .mhc_metrics import (
+    amax_gain,
+    branch_residual_share,
+    gate_stats,
+    h_post_structure_stats,
+    h_res_logits_extrema,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,27 +65,48 @@ _METRIC_NAMES = (
     "h_pre_std",
     "h_post_mean",
     "h_post_std",
+    "h_post_stream_concentration",
+    "h_post_token_std",
+    "branch_residual_share",
+    "branch_residual_share_max",
     "amax_gain_fwd",
     "amax_gain_bwd",
-    "composite_amax_gain_fwd",
-    "composite_amax_gain_bwd",
+    "h_res_logits_min",
+    "h_res_logits_max",
+    "h_res_logits_grad_min",
+    "h_res_logits_grad_max",
+    "composite_amax_gain_fwd_max",
+    "composite_amax_gain_bwd_max",
 )
+
+# Extrema, not means: a worst case that a mean over all layers would bury. The
+# `_max` / `_min` suffixes keep training_logs' classifier in agreement on the
+# full key too.
+_MAX_METRICS = frozenset(
+    {
+        "branch_residual_share_max",
+        "h_res_logits_max",
+        "h_res_logits_grad_max",
+        "composite_amax_gain_fwd_max",
+        "composite_amax_gain_bwd_max",
+    }
+)
+_MIN_METRICS = frozenset({"h_res_logits_min", "h_res_logits_grad_min"})
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
     ("attn", "self_attention_hyper_connection"),
     ("mlp", "mlp_hyper_connection"),
 )
+_COMPONENT_ORDER = {component: order for order, (component, _) in enumerate(_COMPONENTS)}
 
 
 class MHCHealthMonitor(TorchProbe):
     """Monitor the h_pre / h_post / h_res mappings of mHC hyper-connection layers."""
 
     METRIC_PREFIX = "mhc_health"
-    # Every metric is a mean over tokens/batch (and over microbatches/ranks at
-    # flush). No max/min series, so both classification sets stay empty. The
-    # metric names end in _mean/_std/_fwd/_bwd — never a `_max`/`_min` boundary —
-    # so training_logs' suffix classifier also keeps them as "mean".
+    # Populated in __init__ with component-prefixed names, because
+    # record_layer_metric classifies on the name it is handed.
     MAX_AGGREGATED: set[str] = set()
     MIN_AGGREGATED: set[str] = set()
 
@@ -90,6 +118,8 @@ class MHCHealthMonitor(TorchProbe):
         verbose: bool = False,
         hook_timing_enabled: bool = False,
     ):
+        self.MAX_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MAX_METRICS}
+        self.MIN_AGGREGATED = {f"{comp}_{m}" for comp, _ in _COMPONENTS for m in _MIN_METRICS}
         super().__init__(
             log_per_layer=log_per_layer,
             log_global=log_global,
@@ -97,10 +127,15 @@ class MHCHealthMonitor(TorchProbe):
             verbose=verbose,
             hook_timing_enabled=hook_timing_enabled,
         )
-        # chunk_id -> running composite mapping [s*b, n, n], detached (no graph).
-        self._composite: dict[int, torch.Tensor] = {}
-        # (module, original_compute_mappings) pairs, for remove_hooks() restoration.
-        self._wrapped: list[tuple[nn.Module, object]] = []
+        # (module, attribute name, original bound method) triples, for remove_hooks().
+        self._wrapped: list[tuple[nn.Module, str, object]] = []
+        # (layer_idx, component) -> token-mean of the *operator* h_res^T [n, n],
+        # for the composite product. Keyed rather than appended so the product is
+        # built in layer order, not call order (see _record_composite).
+        self._h_res_snapshot: dict[tuple[int, str], torch.Tensor] = {}
+        # Gradient hooks see AMP-scaled activation gradients. The callback
+        # finalizes these accumulators with this step's scale before flush.
+        self._grad_metrics_finalized = False
 
     # ------------------------------------------------------------------
     # Discovery
@@ -151,34 +186,6 @@ class MHCHealthMonitor(TorchProbe):
     # Three-phase setup: prepare (declare) -> allocate -> attach
     # ------------------------------------------------------------------
 
-    def _prepare_layers(self, model: nn.Module, chunk_id: int, layer_offset: int = 0):
-        entries = self._find_hc_modules(model, layer_offset=layer_offset)
-        if not entries:
-            return []
-        for global_idx, comp, _ in entries:
-            for name in _METRIC_NAMES:
-                self.declare_layer_metric(global_idx, f"{comp}_{name}")
-        # The chunk root = the attn hc of the lowest-index layer; it is the first
-        # hc module executed on this stage, so it resets the composite each forward.
-        root_idx = min(gi for gi, comp, _ in entries if comp == "attn")
-        return [(gi, comp, mod, chunk_id, comp == "attn" and gi == root_idx) for gi, comp, mod in entries]
-
-    def _attach_hooks(self, targets):
-        for layer_idx, comp, mod, chunk_id, is_root in targets:
-            orig = mod.compute_mappings
-            mod.compute_mappings = self._make_capture(orig, layer_idx, comp, chunk_id, is_root)
-            self._wrapped.append((mod, orig))
-        logger.info(f"[MHCMonitor] Wrapped {len(self._wrapped)} hyper-connection modules.")
-
-    def register_hooks(self, model: nn.Module):
-        """Single-chunk convenience path. Prefer ``setup_mhc_monitor`` for VPP."""
-        self._init_parallel_state()
-        targets = self._prepare_layers(model, chunk_id=0)
-        if not targets:
-            return
-        self.allocate_buffers(next(model.parameters()).device)
-        self._attach_hooks(targets)
-
     def _init_parallel_state(self):
         try:
             from megatron.core import parallel_state
@@ -188,46 +195,156 @@ class MHCHealthMonitor(TorchProbe):
         except ImportError:
             pass
 
+    def _prepare_layers(self, model: nn.Module, layer_offset: int = 0):
+        """Discover one chunk's hc modules and declare their metric schema.
+
+        Buffers are still unallocated at this point, so every
+        ``declare_layer_metric`` call remains legal.
+        """
+        entries = self._find_hc_modules(model, layer_offset=layer_offset)
+        for global_idx, comp, _ in entries:
+            for name in _METRIC_NAMES:
+                self.declare_layer_metric(global_idx, f"{comp}_{name}")
+        return entries
+
+    def _attach_hooks(self, targets):
+        for layer_idx, comp, mod in targets:
+            orig = mod.compute_mappings
+            mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
+            self._wrapped.append((mod, "compute_mappings", orig))
+            orig_h = getattr(mod, "_compute_h", None)
+            if orig_h is not None:
+                mod._compute_h = self._make_logits_capture(orig_h, layer_idx, comp)
+                self._wrapped.append((mod, "_compute_h", orig_h))
+            orig_bda = getattr(mod, "fused_h_res_h_post_bda", None)
+            if orig_bda is None:
+                continue
+            mod.fused_h_res_h_post_bda = self._make_bda_capture(orig_bda, layer_idx, comp)
+            self._wrapped.append((mod, "fused_h_res_h_post_bda", orig_bda))
+        logger.info(f"[MHCMonitor] Wrapped {len(self._wrapped)} hyper-connection methods.")
+
+    def register_hooks(self, model: nn.Module):
+        """Single-chunk convenience path. Prefer ``setup_mhc_monitor`` for VPP."""
+        self._init_parallel_state()
+        targets = self._prepare_layers(model)
+        if not targets:
+            logger.info("[MHCMonitor] No hyper-connection layers found; skipping.")
+            return
+        self.allocate_buffers(next(model.parameters()).device)
+        self._attach_hooks(targets)
+
     def remove_hooks(self):
-        # Restore the original bound methods and drop all cross-call state so the
-        # monitor holds no module references or composite tensors after teardown.
-        for mod, orig in self._wrapped:
+        # Restore the original bound methods so the monitor holds no module
+        # references after teardown. ``delattr`` removes the instance attribute
+        # and falls back to the class method; if that fails, we re-bind the
+        # captured original.
+        for mod, attr, orig in self._wrapped:
             try:
-                del mod.compute_mappings  # fall back to the class method
+                delattr(mod, attr)
             except AttributeError:
-                mod.compute_mappings = orig
+                setattr(mod, attr, orig)
         self._wrapped = []
-        self._composite.clear()
+        self._h_res_snapshot.clear()
         super().remove_hooks()
 
-    def step(self):
-        super().step()
-        # Release the running composite between train steps so a [s*b, n, n]
-        # buffer never sits idle in VRAM; the root reseeds it next forward, so
-        # clearing is correctness-neutral.
-        self._composite.clear()
-
     # ------------------------------------------------------------------
-    # Capture wrapper (the hot path)
+    # Composite product (flush time, not hot path)
     # ------------------------------------------------------------------
 
-    def _make_capture(self, orig, layer_idx: int, component: str, chunk_id: int, is_root: bool):
+    def _record_composite(self) -> None:
+        """Record the gains of the layer-ordered cumulative product of h_res^T.
+
+        The snapshots hold ``h_res^T``, i.e. the matrix ``apply_h_res`` actually
+        applies to the stream vector (``mixed = h_res^T @ residual``), so the
+        product ``A_k = h_res_k^T ... h_res_0^T`` is the real composite operator
+        from the first layer up to layer ``k``. ``_fwd`` is its max-abs row sum
+        (worst forward signal gain), ``_bwd`` its max-abs column sum.
+
+        Scope is the layers this rank owns, i.e. one pipeline stage / VPP chunk
+        set under PP. Unlike PaddleFleet there is no MTP filter: Megatron keeps
+        MTP blocks outside ``decoder.layers``, so discovery never reaches them.
+        """
+        branches = sorted(
+            ((idx, component, mat) for (idx, component), mat in self._h_res_snapshot.items()),
+            key=lambda item: (item[0], _COMPONENT_ORDER[item[1]]),
+        )
+
+        prefix = None
+        for layer_idx, component, mat in branches:
+            prefix = mat if prefix is None else torch.matmul(mat, prefix)
+            self.record_layer_metric(
+                layer_idx,
+                f"{component}_composite_amax_gain_fwd_max",
+                amax_gain(prefix, dim=-1),
+            )
+
+        suffix = None
+        for layer_idx, component, mat in reversed(branches):
+            suffix = mat if suffix is None else torch.matmul(suffix, mat)
+            self.record_layer_metric(
+                layer_idx,
+                f"{component}_composite_amax_gain_bwd_max",
+                amax_gain(suffix, dim=-2),
+            )
+
+    def finalize_composite_microbatch(self) -> None:
+        """Record and release one microbatch's detached composite snapshots."""
+        if not self._h_res_snapshot:
+            return
+        try:
+            with torch.no_grad():
+                self._record_composite()
+        except Exception as e:
+            if self.verbose:
+                logger.error(f"[MHCMonitor] Error composite: {e}")
+        finally:
+            self._h_res_snapshot.clear()
+
+    def finalize_scaled_grad_metrics(self, scaler=None) -> None:
+        """Remove AMP loss scaling from this step's logits-gradient extrema.
+
+        A no-op under bf16 (Megatron runs it unscaled) and whenever the caller
+        does not hand us the scaler. Under fp16 pass the optimizer's
+        ``grad_scaler``; both the Megatron (``scale``) and torch
+        (``_scale``) attribute names are accepted.
+        """
+        if self._grad_metrics_finalized:
+            return
+        scale = None
+        if scaler is not None:
+            scale = getattr(scaler, "scale", None)
+            if scale is None:
+                scale = getattr(scaler, "_scale", None)
+        if scale is not None:
+            for key in self._max_keys | self._min_keys:
+                if "_h_res_logits_grad_" in key and self._gpu_cnt[key] > 0:
+                    acc = self._gpu_acc[key]
+                    acc.div_(torch.as_tensor(scale, device=acc.device, dtype=acc.dtype))
+        self._grad_metrics_finalized = True
+
+    def _flush_buffers(self) -> None:
+        # Direct users and non-AMP trainers never call finalize_* themselves.
+        self.finalize_scaled_grad_metrics()
+        self.finalize_composite_microbatch()
+        super()._flush_buffers()
+        self._grad_metrics_finalized = False
+
+    # ------------------------------------------------------------------
+    # Capture wrappers (the hot path)
+    # ------------------------------------------------------------------
+
+    def _make_capture(self, orig, layer_idx: int, component: str):
         """Wrap ``compute_mappings`` to record metrics from its real return value.
 
         VRAM safety: the mappings arrive attached to the training autograd graph;
-        we ``.detach()`` them and do all metric/composite math under ``no_grad`` so
-        no stored tensor pins the graph through backward. The composite slot holds
-        one detached ``[s*b, n, n]`` tensor per chunk (cloned on seed so it never
-        aliases the model's ``h_res`` storage); ``step()`` clears it.
+        we ``.detach()`` them and do all metric math under ``no_grad`` so no
+        stored tensor pins the graph through backward. The only cross-call state
+        is one token-meaned ``[n, n]`` snapshot per (layer, component), released
+        by ``finalize_composite_microbatch``.
         """
 
         def wrapped(x):
             out = orig(x)  # the real mappings the model consumes — returned unchanged
-            # Gate the whole capture: metrics are only recorded on monitored steps,
-            # and the composite is reset at the chunk root on each such step, so
-            # gating here keeps the composite self-consistent (root reset -> ordered
-            # bmm builds within one monitored forward). _should_monitor() also
-            # requires grad enabled, selecting the training (not a no-grad) forward.
             if not self._should_monitor():
                 return out
             try:
@@ -243,29 +360,109 @@ class MHCHealthMonitor(TorchProbe):
                     self.record_layer_metric(layer_idx, f"{component}_h_pre_std", pre_std)
                     self.record_layer_metric(layer_idx, f"{component}_h_post_mean", post_mean)
                     self.record_layer_metric(layer_idx, f"{component}_h_post_std", post_std)
+                    for name, value in h_post_structure_stats(h_post).items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
 
-                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, dim=-1))
-                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, dim=-2))
+                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, dim=-2))
+                    self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, dim=-1))
 
-                    # Composite mapping M_k = h_res_k @ M_{k-1} (per token).
-                    s, b, n, _ = h_res.shape
-                    hb = h_res.reshape(s * b, n, n)
-                    prev = self._composite.get(chunk_id)
-                    # Reset at the chunk root each forward; also self-heals on first
-                    # fire / shape drift (variable s*b across microbatches). identity @
-                    # h_res == h_res, so seed with h_res; clone() so the slot owns a
-                    # fresh buffer and never pins the model's h_res storage.
-                    if is_root or prev is None or prev.shape != hb.shape:  # noqa: SIM108
-                        M = hb.clone()
-                    else:
-                        M = torch.bmm(hb, prev)  # fresh tensor, no graph
-                    self._composite[chunk_id] = M
-
-                    self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_fwd", amax_gain(M, dim=-1))
-                    self.record_layer_metric(layer_idx, f"{component}_composite_amax_gain_bwd", amax_gain(M, dim=-2))
+                    # Token-mean snapshot of the *operator* for the composite product.
+                    n = int(h_res.shape[-1])
+                    self._h_res_snapshot[(layer_idx, component)] = (
+                        h_res.float().reshape(-1, n, n).mean(dim=0).transpose(0, 1)
+                    )
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[MHCMonitor] Error layer {layer_idx}/{component}: {e}")
+            return out
+
+        return wrapped
+
+    def _make_logits_capture(self, orig, layer_idx: int, component: str):
+        """Wrap ``_compute_h`` to record the saturation sentinel."""
+
+        def wrapped(proj, r):
+            out = orig(proj, r)  # the real mappings the model consumes — returned unchanged
+            if not self._should_monitor():
+                return out
+            try:
+                _h_pre, _h_post, h_res_logits = out
+                if h_res_logits.requires_grad:
+
+                    def record_grad_extrema(grad):
+                        try:
+                            grad_fp32 = grad.detach().float()
+                            self.record_layer_metric(
+                                layer_idx,
+                                f"{component}_h_res_logits_grad_min",
+                                grad_fp32.min(),
+                            )
+                            self.record_layer_metric(
+                                layer_idx,
+                                f"{component}_h_res_logits_grad_max",
+                                grad_fp32.max(),
+                            )
+                            self._grad_metrics_finalized = False
+                        except Exception as e:
+                            if self.verbose:
+                                logger.error(f"[MHCMonitor] Error logits gradient layer {layer_idx}/{component}: {e}")
+                        # Returning None leaves the autograd gradient untouched.
+                        return None
+
+                    h_res_logits.register_hook(record_grad_extrema)
+                with torch.no_grad():
+                    for name, value in h_res_logits_extrema(h_res_logits).items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MHCMonitor] Error logits layer {layer_idx}/{component}: {e}")
+            return out
+
+        return wrapped
+
+    def _make_bda_capture(self, orig, layer_idx: int, component: str):
+        """Wrap ``fused_h_res_h_post_bda`` to record the branch/residual ratio.
+
+        The only place both mHC update terms are available: the call receives
+        ``h_res`` + ``original_residual`` and ``layer_output_with_bias``. Metrics
+        come from the **arguments**, so the fused fast path, the checkpointed
+        path and the sequential dropout path are covered identically. Arguments
+        are read by keyword with a positional fallback — Megatron's
+        ``TransformerLayer`` passes them positionally today, but relying on that
+        alone would silently stop recording if it switched.
+        """
+
+        def wrapped(*args, **kwargs):
+            out = orig(*args, **kwargs)
+            if not self._should_monitor():
+                return out
+            try:
+
+                def pick(name, pos):
+                    if name in kwargs:
+                        return kwargs[name]
+                    return args[pos] if len(args) > pos else None
+
+                h_res = pick("h_res", 0)
+                original_residual = pick("original_residual", 1)
+                h_post = pick("h_post", 2)
+                layer_output_with_bias = pick("layer_output_with_bias", 3)
+                if h_res is None or original_residual is None or h_post is None:
+                    return out
+                if isinstance(layer_output_with_bias, tuple):
+                    layer_output, bias = layer_output_with_bias
+                else:
+                    layer_output, bias = layer_output_with_bias, None
+                if layer_output is None:
+                    return out
+
+                with torch.no_grad():
+                    stats = branch_residual_share(h_res, original_residual, h_post, layer_output, bias)
+                    for name, value in stats.items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+            except Exception as e:
+                if self.verbose:
+                    logger.error(f"[MHCMonitor] Error bda layer {layer_idx}/{component}: {e}")
             return out
 
         return wrapped
@@ -283,9 +480,9 @@ def setup_mhc_monitor(
     """Enable the mHC health monitor. No-op on any non-mHC model.
 
     Multi-chunk (VPP / interleaved 1F1B) safe: declares the schema across all
-    chunks before ``allocate_buffers`` locks it, then attaches. Each model chunk
-    gets its own composite slot (keyed by its enumerate index) so a later chunk's
-    layers never contaminate an earlier chunk's running product.
+    chunks before ``allocate_buffers`` locks it, then attaches. Layer ids are
+    offset per chunk, so the composite product keyed on them stays ordered and
+    a later chunk's layers never contaminate an earlier chunk's product.
     """
     # No-op guarantee #1: mHC classes unavailable -> touch nothing.
     if HyperConnectionTransformerLayer is None or HyperConnectionModule is None:
@@ -304,9 +501,8 @@ def setup_mhc_monitor(
 
     chunk_targets = []
     layer_offset = 0
-    for chunk_id, m in enumerate(models):
-        targets = monitor._prepare_layers(m, chunk_id=chunk_id, layer_offset=layer_offset)
-        chunk_targets.append(targets)
+    for m in models:
+        chunk_targets.append(monitor._prepare_layers(m, layer_offset=layer_offset))
         stack = monitor._find_layer_stack(m)
         layer_offset += len(stack) if stack is not None else 0
 
@@ -322,5 +518,5 @@ def setup_mhc_monitor(
         # No-op guarantee #2: no HyperConnectionTransformerLayer found.
         logger.info("[MHCMonitor] No hyper-connection layers found; skipping.")
 
-    logger.info(f"[MHCMonitor] Setup complete. Monitoring {len(monitor._wrapped)} hc modules.")
+    logger.info(f"[MHCMonitor] Setup complete. Monitoring {len(monitor._wrapped)} hc methods.")
     return model

--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -293,4 +293,3 @@ def iter_monitor_layers(
         monitor_layers.append(_make(idx, layer, True))
 
     return monitor_layers
-

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -108,6 +108,7 @@ _PARAM_METRICS = (
     "bias_res_abs_max",
 )
 
+
 def _vector_metric_specs(n: int) -> tuple[tuple[str, str, int], ...]:
     """``(metric_name, elem_tag, size)`` for the per-element mapping series."""
     return (("h_res", "cell", n * n), ("h_pre", "idx", n), ("h_post", "idx", n))

--- a/tests/test_mhc_monitor.py
+++ b/tests/test_mhc_monitor.py
@@ -22,6 +22,14 @@ training_logs = importlib.import_module("internal_medicine.core.training_logs").
 MHCHealthMonitor = mhc_monitor.MHCHealthMonitor
 
 
+def _fake_sinkhorn(input_logits, num_iterations=1, eps=1e-6):
+    """Stand-in for ``native_sinkhorn`` / ``fused_sinkhorn``: identity is enough.
+
+    Only the *input* matters here — that is the monitor's hook point.
+    """
+    return input_logits
+
+
 class FakeHC(nn.Module):
     """Stand-in for HyperConnectionModule exposing the three wrapped methods."""
 
@@ -36,15 +44,17 @@ class FakeHC(nn.Module):
         if h_res_logits is None:
             h_res_logits = torch.zeros(*h_pre.shape[:-1], n * n)
         self._h_res_logits = h_res_logits
+        # Instance attribute, exactly as the real module assigns it in __init__.
+        self._sinkhorn_op = _fake_sinkhorn
 
     def _compute_h(self, proj, r):
         return self._h_pre, self._h_post, self._h_res_logits
 
     def compute_mappings(self, x):
-        # Mirrors the real module: _compute_h yields the raw logits, the Sinkhorn
-        # projection then turns them into h_res. Going through self._compute_h is
-        # what lets the monitor's instance-attribute shadowing see the logits.
-        self._compute_h(None, None)
+        # Mirrors the real module: the raw logits reach _sinkhorn_op on both the
+        # fused and the unfused path, which is why the monitor wraps that call
+        # instead of _compute_h (the fused kernel skips _compute_h entirely).
+        self._sinkhorn_op(self._h_res_logits, 1, 1e-6)
         return self._h_pre, self._h_post, self._h_res
 
     def fused_h_res_h_post_bda(
@@ -303,7 +313,7 @@ class MHCLogitsTest(_MHCFixture, unittest.TestCase):
         monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
         self._prepare_and_attach(monitor, model)
 
-        _, _, captured = hc._compute_h(None, None)
+        captured = hc._sinkhorn_op(hc._h_res_logits, 1, 1e-6)
         weight = torch.tensor([[[2.0, -7.0, 4.0, 1.5]]])
         loss_scale = 16.0
         (captured * weight * loss_scale).sum().backward()
@@ -340,13 +350,13 @@ class MHCLogitsTest(_MHCFixture, unittest.TestCase):
         self._prepare_and_attach(monitor, model)
 
         with torch.no_grad():
-            hc._compute_h(None, None)
+            hc._sinkhorn_op(hc._h_res_logits, 1, 1e-6)
         min_key = "mhc_health/layer_0/attn_h_res_logits_grad_min"
         max_key = "mhc_health/layer_0/attn_h_res_logits_grad_max"
         self.assertEqual(monitor._gpu_cnt[min_key], 0)
         self.assertEqual(monitor._gpu_cnt[max_key], 0)
 
-        _, _, replay_logits = hc._compute_h(None, None)
+        replay_logits = hc._sinkhorn_op(hc._h_res_logits, 1, 1e-6)
         replay_logits.sum().backward()
         self.assertEqual(monitor._gpu_cnt[min_key], 1)
         self.assertEqual(monitor._gpu_cnt[max_key], 1)
@@ -354,6 +364,35 @@ class MHCLogitsTest(_MHCFixture, unittest.TestCase):
         latest = training_logs.get_latest(prefix="mhc_health")
         self.assertAlmostEqual(latest[min_key], 1.0, places=5)
         self.assertAlmostEqual(latest[max_key], 1.0, places=5)
+
+    def test_logits_recorded_on_fused_path_that_never_calls_compute_h(self):
+        # With use_fused_mhc, fused_proj_rms_compute_h produces the logits inside
+        # the kernel and compute_mappings never reaches _compute_h. The hook point
+        # is _sinkhorn_op's argument, so the four series must still land.
+        n, s, b = 2, 1, 1
+
+        class FusedFakeHC(FakeHC):
+            def _compute_h(self, proj, r):  # pragma: no cover - must never run
+                raise AssertionError("fused path must not call _compute_h")
+
+        hc = FusedFakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.5),
+            h_post=torch.ones(s, b, n),
+            h_res=torch.eye(n).reshape(s, b, n, n),
+            h_res_logits=torch.tensor([[[-3.0, 5.0, 0.0, 1.0]]]),
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for key in ("mhc_health/layer_0/attn_h_res_logits_min", "mhc_health/global_attn_h_res_logits_min"):
+            self.assertAlmostEqual(latest[key], -3.0, places=5)
+        for key in ("mhc_health/layer_0/attn_h_res_logits_max", "mhc_health/global_attn_h_res_logits_max"):
+            self.assertAlmostEqual(latest[key], 5.0, places=5)
 
     def test_logits_extrema_are_recorded_and_reduce_by_extremum_across_layers(self):
         # layer_0 has zero logits; layer_1 spans [-104, 7.5]. The global series
@@ -595,11 +634,14 @@ class MHCTeardownTest(_MHCFixture, unittest.TestCase):
         self._prepare_and_attach(monitor, model)
         self.assertIsNot(hc.compute_mappings, original)
         self.assertIn("fused_h_res_h_post_bda", vars(hc))
+        self.assertIsNot(hc._sinkhorn_op, _fake_sinkhorn)
         monitor.remove_hooks()
         self.assertNotIn("fused_h_res_h_post_bda", vars(hc))
         # falls back to the (bound) class methods after deleting the instance attrs
         self.assertEqual(hc.compute_mappings.__func__, FakeHC.compute_mappings)
-        self.assertEqual(hc._compute_h.__func__, FakeHC._compute_h)
+        # _sinkhorn_op only ever lives on the instance, so it is restored by
+        # assignment rather than by falling back to a class attribute.
+        self.assertIs(hc._sinkhorn_op, _fake_sinkhorn)
         self.assertEqual(hc.fused_h_res_h_post_bda.__func__, FakeHC.fused_h_res_h_post_bda)
         self.assertEqual(monitor._wrapped, [])
         self.assertEqual(monitor._h_res_snapshot, {})

--- a/tests/test_mhc_monitor.py
+++ b/tests/test_mhc_monitor.py
@@ -31,9 +31,9 @@ def _fake_sinkhorn(input_logits, num_iterations=1, eps=1e-6):
 
 
 class FakeHC(nn.Module):
-    """Stand-in for HyperConnectionModule exposing the three wrapped methods."""
+    """Stand-in for HyperConnectionModule exposing the four wrapped methods."""
 
-    def __init__(self, n, h_pre, h_post, h_res, h_res_logits=None):
+    def __init__(self, n, h_pre, h_post, h_res, h_res_logits=None, fused=False, proj=None, r=None):
         super().__init__()
         self.n = n
         self._h_pre = h_pre
@@ -46,14 +46,29 @@ class FakeHC(nn.Module):
         self._h_res_logits = h_res_logits
         # Instance attribute, exactly as the real module assigns it in __init__.
         self._sinkhorn_op = _fake_sinkhorn
+        # use_fused_mhc: compute_mappings then skips _compute_h entirely.
+        self._fused = fused
+        # The (proj, r) pair the native path hands _compute_h. Defaults make the
+        # pre/post logits read as bias-only, which keeps them easy to assert on.
+        leading = tuple(h_pre.shape[:-1])
+        self._proj = torch.zeros(*leading, n * n + 2 * n) if proj is None else proj
+        self._r = torch.ones(*leading, 1) if r is None else r
+        # Paper Eq. (7) parameters, same shapes as the real module.
+        self.alpha_pre = nn.Parameter(torch.full((1,), 0.1))
+        self.alpha_post = nn.Parameter(torch.full((1,), 0.2))
+        self.alpha_res = nn.Parameter(torch.full((1,), 0.3))
+        self.bias = nn.Parameter(torch.zeros(n * n + 2 * n))
 
     def _compute_h(self, proj, r):
         return self._h_pre, self._h_post, self._h_res_logits
 
     def compute_mappings(self, x):
-        # Mirrors the real module: the raw logits reach _sinkhorn_op on both the
-        # fused and the unfused path, which is why the monitor wraps that call
-        # instead of _compute_h (the fused kernel skips _compute_h entirely).
+        # Mirrors the real module: the native path goes through _compute_h, the
+        # fused kernel skips it, and the raw logits reach _sinkhorn_op on both —
+        # which is why the monitor reads h_res logits from that call and the
+        # pre-sigmoid pre/post logits from _compute_h's arguments.
+        if not self._fused:
+            self._compute_h(self._proj, self._r)
         self._sinkhorn_op(self._h_res_logits, 1, 1e-6)
         return self._h_pre, self._h_post, self._h_res
 
@@ -192,6 +207,36 @@ class MHCMetricsTest(unittest.TestCase):
             self.assertEqual(tuple(value.shape), ())
             self.assertEqual(value.dtype, torch.float32)
             self.assertFalse(value.requires_grad)
+
+    def test_gate_logits_extrema_match_compute_h_formula(self):
+        # Pins the helper against the model's own `h = r * proj * alpha + bias`
+        # slicing. n=2, so proj[..., :2] feeds pre and proj[..., 2:4] feeds post.
+        n = 2
+        proj = torch.tensor([[[1.0, -2.0, 3.0, -4.0, 0.0, 0.0, 0.0, 0.0]]])
+        r = torch.tensor([[[2.0]]])
+        bias = torch.tensor([0.5, 0.5, -1.0, -1.0, 0.0, 0.0, 0.0, 0.0])
+        stats = mhc_metrics.gate_logits_extrema(proj, r, torch.tensor([3.0]), torch.tensor([0.5]), bias, n)
+        # pre  = 2 * [1, -2] * 3   + [0.5, 0.5]  = [6.5, -11.5]
+        # post = 2 * [3, -4] * 0.5 + [-1, -1]    = [2.0, -5.0]
+        self.assertAlmostEqual(stats["h_pre_logits_min"].item(), -11.5, places=5)
+        self.assertAlmostEqual(stats["h_pre_logits_max"].item(), 6.5, places=5)
+        self.assertAlmostEqual(stats["h_post_logits_min"].item(), -5.0, places=5)
+        self.assertAlmostEqual(stats["h_post_logits_max"].item(), 2.0, places=5)
+
+    def test_mapping_param_stats_slices_bias_by_paper_layout(self):
+        # bias is one [n^2 + 2n] parameter: [:n] pre, [n:2n] post, [2n:] res.
+        n = 2
+        bias = torch.tensor([1.0, -3.0, 2.0, 2.0, 0.0, -8.0, 4.0, 0.0])
+        stats = mhc_metrics.mapping_param_stats(torch.tensor([0.1]), torch.tensor([0.2]), torch.tensor([0.3]), bias, n)
+        self.assertAlmostEqual(stats["alpha_pre"].item(), 0.1, places=6)
+        self.assertAlmostEqual(stats["alpha_post"].item(), 0.2, places=6)
+        self.assertAlmostEqual(stats["alpha_res"].item(), 0.3, places=6)
+        self.assertAlmostEqual(stats["bias_pre_mean"].item(), -1.0, places=6)
+        self.assertAlmostEqual(stats["bias_pre_abs_max"].item(), 3.0, places=6)
+        self.assertAlmostEqual(stats["bias_post_mean"].item(), 2.0, places=6)
+        self.assertAlmostEqual(stats["bias_post_abs_max"].item(), 2.0, places=6)
+        self.assertAlmostEqual(stats["bias_res_mean"].item(), -1.0, places=6)
+        self.assertAlmostEqual(stats["bias_res_abs_max"].item(), 8.0, places=6)
 
 
 class _MHCFixture:
@@ -381,6 +426,7 @@ class MHCLogitsTest(_MHCFixture, unittest.TestCase):
             h_post=torch.ones(s, b, n),
             h_res=torch.eye(n).reshape(s, b, n, n),
             h_res_logits=torch.tensor([[[-3.0, 5.0, 0.0, 1.0]]]),
+            fused=True,
         )
         model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
         monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
@@ -393,6 +439,11 @@ class MHCLogitsTest(_MHCFixture, unittest.TestCase):
             self.assertAlmostEqual(latest[key], -3.0, places=5)
         for key in ("mhc_health/layer_0/attn_h_res_logits_max", "mhc_health/global_attn_h_res_logits_max"):
             self.assertAlmostEqual(latest[key], 5.0, places=5)
+        # The pre/post gate logits need _compute_h's (proj, r), which the fused
+        # kernel does not expose: those four must stay absent rather than be
+        # filled from some other quantity.
+        for name in ("h_pre_logits_min", "h_pre_logits_max", "h_post_logits_min", "h_post_logits_max"):
+            self.assertNotIn(f"mhc_health/layer_0/attn_{name}", latest)
 
     def test_logits_extrema_are_recorded_and_reduce_by_extremum_across_layers(self):
         # layer_0 has zero logits; layer_1 spans [-104, 7.5]. The global series
@@ -643,7 +694,9 @@ class MHCTeardownTest(_MHCFixture, unittest.TestCase):
         # assignment rather than by falling back to a class attribute.
         self.assertIs(hc._sinkhorn_op, _fake_sinkhorn)
         self.assertEqual(hc.fused_h_res_h_post_bda.__func__, FakeHC.fused_h_res_h_post_bda)
+        self.assertEqual(hc._compute_h.__func__, FakeHC._compute_h)
         self.assertEqual(monitor._wrapped, [])
+        self.assertEqual(monitor._param_targets, [])
         self.assertEqual(monitor._h_res_snapshot, {})
 
     def test_no_graph_retention(self):
@@ -671,6 +724,173 @@ class MHCTeardownTest(_MHCFixture, unittest.TestCase):
             self.assertFalse(mat.requires_grad, msg=str(key))
             self.assertIsNone(mat.grad_fn, msg=str(key))
         monitor.step()
+
+
+class MHCEq7Test(_MHCFixture, unittest.TestCase):
+    """Paper Eq. (7): the pre-sigmoid gate logits and the alpha / bias params."""
+
+    def _hc(self, n, s, b, proj=None):
+        return FakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.5),
+            h_post=torch.ones(s, b, n),
+            h_res=torch.eye(n).reshape(1, 1, n, n).expand(s, b, n, n).contiguous(),
+            proj=proj,
+        )
+
+    def test_gate_logits_recorded_from_compute_h_arguments(self):
+        n, s, b = 2, 1, 1
+        # r defaults to 1 and bias to 0, so the logits are proj * alpha:
+        # pre  = [1, -2] * 0.1 = [0.1, -0.2]
+        # post = [3, -4] * 0.2 = [0.6, -0.8]
+        proj = torch.tensor([[[1.0, -2.0, 3.0, -4.0, 0.0, 0.0, 0.0, 0.0]]])
+        hc = self._hc(n, s, b, proj=proj)
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for scope in ("layer_0/attn", "global_attn"):
+            self.assertAlmostEqual(latest[f"mhc_health/{scope}_h_pre_logits_min"], -0.2, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/{scope}_h_pre_logits_max"], 0.1, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/{scope}_h_post_logits_min"], -0.8, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/{scope}_h_post_logits_max"], 0.6, places=5)
+
+    def test_gate_logits_reduce_by_extremum_across_layers(self):
+        # A single saturating layer must not be averaged away by the global key.
+        n, s, b = 2, 1, 1
+        calm = torch.zeros(s, b, n * n + 2 * n)
+        wild = torch.tensor([[[0.0, -300.0, 90.0, 0.0, 0.0, 0.0, 0.0, 0.0]]])
+        model = _mhc_model(
+            [
+                FakeLayer(attn=self._hc(n, s, b, proj=calm), mlp=self._hc(n, s, b, proj=calm), layer_number=1),
+                FakeLayer(attn=self._hc(n, s, b, proj=wild), mlp=self._hc(n, s, b, proj=wild), layer_number=2),
+            ]
+        )
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        # alpha_pre = 0.1 -> -300 * 0.1 = -30; alpha_post = 0.2 -> 90 * 0.2 = 18.
+        self.assertAlmostEqual(latest["mhc_health/global_attn_h_pre_logits_min"], -30.0, places=4)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_h_post_logits_max"], 18.0, places=4)
+
+    def test_param_series_read_once_per_step_from_parameters(self):
+        n, s, b = 2, 1, 1
+        hc = self._hc(n, s, b)
+        with torch.no_grad():
+            hc.bias.copy_(torch.tensor([1.0, -3.0, 2.0, 2.0, 0.0, -8.0, 4.0, 0.0]))
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        # Cold path: nothing recorded until the flush reads the parameters.
+        self.assertEqual(monitor._gpu_cnt["mhc_health/layer_0/attn_alpha_pre"], 0)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_alpha_pre"], 0.1, places=6)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_alpha_post"], 0.2, places=6)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_alpha_res"], 0.3, places=6)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_bias_pre_mean"], -1.0, places=6)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_bias_res_abs_max"], 8.0, places=6)
+
+    def test_param_series_skipped_when_forward_was_not_monitored(self):
+        # The parameter series are read at flush time, off the hot path, so they
+        # need their own guard: without it they would log on every step even when
+        # no monitored forward ran, at a different cadence from every other
+        # series. Flushing without driving a forward must emit nothing.
+        n, s, b = 2, 1, 1
+        hc = self._hc(n, s, b)
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        self._prepare_and_attach(monitor, model)
+        self.assertFalse(monitor._captured_this_step)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertNotIn("mhc_health/layer_0/attn_alpha_pre", latest)
+        self.assertEqual(monitor._gpu_cnt["mhc_health/layer_0/attn_alpha_pre"], 0)
+
+
+class MHCVectorMetricsTest(_MHCFixture, unittest.TestCase):
+    """The per-element mapping series (n^2 + 2n per hc module)."""
+
+    def test_mapping_cells_expand_per_element(self):
+        n, s, b = 2, 2, 3
+        # h_res = identity -> token-mean cells are [1, 0, 0, 1] in row-major order.
+        hc = FakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.25),
+            h_post=torch.full((s, b, n), 1.5),
+            h_res=torch.eye(n).reshape(1, 1, n, n).expand(s, b, n, n).contiguous(),
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for cell, expected in enumerate((1.0, 0.0, 0.0, 1.0)):
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/attn_h_res_cell{cell}"], expected, places=5)
+        for idx in range(n):
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/attn_h_pre_idx{idx}"], 0.25, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/attn_h_post_idx{idx}"], 1.5, places=5)
+
+    def test_vector_series_derive_no_global_key(self):
+        # A mean of one cell over all layers has no diagnostic meaning, so the
+        # per-element series must not produce a global_* twin.
+        n, s, b = 2, 1, 1
+        hc = FakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.5),
+            h_post=torch.ones(s, b, n),
+            h_res=torch.eye(n).reshape(s, b, n, n),
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertIn("mhc_health/layer_0/attn_h_res_cell0", latest)
+        for key in latest:
+            self.assertNotIn("global_attn_h_res_cell", key)
+            self.assertNotIn("global_attn_h_pre_idx", key)
+
+    def test_vector_series_absent_when_per_layer_logging_is_off(self):
+        n, s, b = 2, 1, 1
+        hc = FakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.5),
+            h_post=torch.ones(s, b, n),
+            h_res=torch.eye(n).reshape(s, b, n, n),
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor(log_per_layer=False, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        self.assertEqual(monitor._vector_keys, {})
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for key in latest:
+            self.assertNotIn("_h_res_cell", key)
+        # The scalar globals still come through.
+        self.assertIn("mhc_health/global_attn_amax_gain_fwd", latest)
 
 
 class MHCMonitorNoOpTest(unittest.TestCase):

--- a/tests/test_mhc_monitor.py
+++ b/tests/test_mhc_monitor.py
@@ -23,25 +23,59 @@ MHCHealthMonitor = mhc_monitor.MHCHealthMonitor
 
 
 class FakeHC(nn.Module):
-    """Stand-in for HyperConnectionModule exposing compute_mappings + layer_number."""
+    """Stand-in for HyperConnectionModule exposing the three wrapped methods."""
 
-    def __init__(self, n, layer_number, h_pre, h_post, h_res):
+    def __init__(self, n, h_pre, h_post, h_res, h_res_logits=None):
         super().__init__()
         self.n = n
-        self.layer_number = layer_number
         self._h_pre = h_pre
         self._h_post = h_post
         self._h_res = h_res
+        # Raw pre-Sinkhorn mixing logits. Zeros -> uniform rows -> every column
+        # sum is exactly 1, i.e. the healthy case.
+        if h_res_logits is None:
+            h_res_logits = torch.zeros(*h_pre.shape[:-1], n * n)
+        self._h_res_logits = h_res_logits
+
+    def _compute_h(self, proj, r):
+        return self._h_pre, self._h_post, self._h_res_logits
 
     def compute_mappings(self, x):
+        # Mirrors the real module: _compute_h yields the raw logits, the Sinkhorn
+        # projection then turns them into h_res. Going through self._compute_h is
+        # what lets the monitor's instance-attribute shadowing see the logits.
+        self._compute_h(None, None)
         return self._h_pre, self._h_post, self._h_res
 
-    def forward(self, hidden_states, mhc_recompute_manager=None):  # pragma: no cover - unused
+    def fused_h_res_h_post_bda(
+        self,
+        h_res,
+        original_residual,
+        h_post,
+        layer_output_with_bias,
+        dropout_prob=0.0,
+        training=True,
+        fused=False,
+    ):
+        x, bias = layer_output_with_bias
+        n = self.n
+        leading = list(original_residual.shape[:-1])
+        C = original_residual.shape[-1] // n
+        mixed = torch.bmm(
+            h_res.reshape(-1, n, n).transpose(1, 2),
+            original_residual.reshape(-1, n, C),
+        ).reshape(*leading, n, C)
+        xb = x if bias is None else x + bias
+        return (h_post.unsqueeze(-1) * xb.unsqueeze(-2) + mixed).reshape(*leading, n * C)
+
+    def forward(self, hidden_states):  # pragma: no cover - unused
         return hidden_states, self._h_res, self._h_post
 
 
 class FakeLayer(nn.Module):
-    def __init__(self, layer_number, attn, mlp):
+    """Stand-in for HyperConnectionTransformerLayer with the two hc modules."""
+
+    def __init__(self, attn, mlp, layer_number=1):
         super().__init__()
         self.layer_number = layer_number
         self.self_attention_hyper_connection = attn
@@ -54,7 +88,7 @@ def _mhc_model(layers):
 
 class MHCMetricsTest(unittest.TestCase):
     def test_amax_gain_row_vs_col(self):
-        # [[1,2],[3,4]] -> row sums [3,7] -> max abs 7 (fwd); col sums [4,6] -> 6 (bwd).
+        # [[1,2],[3,4]] -> row sums [3,7] -> max abs 7; col sums [4,6] -> 6.
         m = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]])
         self.assertAlmostEqual(mhc_metrics.amax_gain(m, dim=-1).item(), 7.0, places=5)
         self.assertAlmostEqual(mhc_metrics.amax_gain(m, dim=-2).item(), 6.0, places=5)
@@ -71,8 +105,88 @@ class MHCMetricsTest(unittest.TestCase):
         self.assertAlmostEqual(mean.item(), 1.5, places=5)
         self.assertAlmostEqual(std.item(), h.std().item(), places=6)
 
+    def test_stream_concentration_bounds(self):
+        # Uniform across streams -> 1 (lower bound); all mass on one stream -> n.
+        uniform = torch.full((3, 4), 0.7)
+        one_hot = torch.tensor([[1.0, 0.0, 0.0, 0.0]] * 3)
+        self.assertAlmostEqual(
+            mhc_metrics.h_post_structure_stats(uniform)["h_post_stream_concentration"].item(),
+            1.0,
+            places=5,
+        )
+        self.assertAlmostEqual(
+            mhc_metrics.h_post_structure_stats(one_hot)["h_post_stream_concentration"].item(),
+            4.0,
+            places=5,
+        )
 
-class MHCMonitorTest(unittest.TestCase):
+    def test_token_std_zero_when_gate_is_constant(self):
+        const = torch.full((8, 4), 1.0)
+        varying = torch.tensor([[0.2] * 4, [1.8] * 4])
+        self.assertAlmostEqual(mhc_metrics.h_post_structure_stats(const)["h_post_token_std"].item(), 0.0, places=6)
+        self.assertGreater(mhc_metrics.h_post_structure_stats(varying)["h_post_token_std"].item(), 0.5)
+
+    def test_branch_residual_share_against_explicit_terms(self):
+        # h_res = identity -> residual term is exactly the incoming streams, so
+        # the share reduces to b / (b + ‖x_l‖_F) with b = ‖h_post‖₂·‖x‖₂.
+        n, c = 2, 3
+        h_res = torch.eye(n).reshape(1, n, n)
+        streams = torch.tensor([[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]])
+        h_post = torch.tensor([[3.0, 4.0]])  # ‖·‖₂ = 5
+        x = torch.tensor([[0.0, 0.0, 2.0]])  # ‖·‖₂ = 2
+        stats = mhc_metrics.branch_residual_share(h_res, streams.reshape(1, n * c), h_post, x)
+        branch = 5.0 * 2.0
+        residual = 5.0**0.5  # ‖streams‖_F = √5
+        expected = branch / (branch + residual)
+        self.assertAlmostEqual(stats["branch_residual_share"].item(), expected, places=4)
+        self.assertAlmostEqual(stats["branch_residual_share_max"].item(), expected, places=4)
+
+    def test_branch_residual_share_zero_gate_kills_branch(self):
+        n, c = 4, 5
+        h_res = torch.eye(n).reshape(1, n, n)
+        streams = torch.randn(1, n * c)
+        x = torch.randn(1, c)
+        stats = mhc_metrics.branch_residual_share(h_res, streams, torch.zeros(1, n), x)
+        self.assertAlmostEqual(stats["branch_residual_share"].item(), 0.0, places=6)
+
+    def test_branch_residual_share_zero_residual_token_stays_bounded(self):
+        # An all-zero token (padding) drives the residual norm to 0. The raw
+        # ratio would hit the epsilon floor and return ~1e6, hijacking the token
+        # mean; the bounded share must read 1.0 instead.
+        n, c = 2, 3
+        h_res = torch.eye(n).reshape(1, n, n).expand(2, n, n)
+        streams = torch.cat([torch.ones(1, n * c), torch.zeros(1, n * c)])
+        stats = mhc_metrics.branch_residual_share(h_res, streams, torch.ones(2, n), torch.ones(2, c))
+        self.assertAlmostEqual(stats["branch_residual_share_max"].item(), 1.0, places=6)
+        self.assertLessEqual(stats["branch_residual_share"].item(), 1.0)
+        self.assertGreater(stats["branch_residual_share"].item(), 0.5)
+
+    def test_branch_residual_share_all_zero_token_is_zero(self):
+        # Both terms zero must not divide by zero; the eps guard makes it 0.
+        n, c = 2, 3
+        stats = mhc_metrics.branch_residual_share(
+            torch.zeros(1, n, n), torch.zeros(1, n * c), torch.zeros(1, n), torch.zeros(1, c)
+        )
+        self.assertAlmostEqual(stats["branch_residual_share"].item(), 0.0, places=6)
+
+    def test_logits_extrema_preserve_signed_raw_range(self):
+        logits = torch.tensor([[-200.0, -18.0, 0.0, 7.5]])
+        stats = mhc_metrics.h_res_logits_extrema(logits)
+        self.assertAlmostEqual(stats["h_res_logits_min"].item(), -200.0, places=6)
+        self.assertAlmostEqual(stats["h_res_logits_max"].item(), 7.5, places=6)
+
+    def test_logits_extrema_are_detached_fp32_scalars(self):
+        logits = torch.tensor([[-3.0, 2.0]], dtype=torch.float16, requires_grad=True)
+        stats = mhc_metrics.h_res_logits_extrema(logits)
+        for value in stats.values():
+            self.assertEqual(tuple(value.shape), ())
+            self.assertEqual(value.dtype, torch.float32)
+            self.assertFalse(value.requires_grad)
+
+
+class _MHCFixture:
+    """Shared setup for the monitor test cases (mixed into TestCase subclasses)."""
+
     def setUp(self):
         training_logs.reset()
         # Discovery uses isinstance against the real classes; point them at the fakes.
@@ -92,70 +206,403 @@ class MHCMonitorTest(unittest.TestCase):
         def make_hc():
             return FakeHC(
                 n=n,
-                layer_number=layer_number,
                 h_pre=torch.full((s, b, n), 0.5),
                 h_post=torch.ones(s, b, n),
-                h_res=ident,
+                h_res=ident.clone(),  # own storage, not a view of the shared eye
             )
 
-        return FakeLayer(layer_number=layer_number, attn=make_hc(), mlp=make_hc())
+        return FakeLayer(attn=make_hc(), mlp=make_hc(), layer_number=layer_number)
 
     def _drive(self, targets, x_dim):
         # Fire each wrapped compute_mappings (grad enabled -> _should_monitor passes).
-        for _, _, mod, _, _ in targets:
+        for _, _, mod in targets:
             mod.compute_mappings(torch.randn(4, 2, x_dim))
 
-    def test_identity_composite_stays_unit_gain(self):
-        n, s, b = 4, 2, 3
-        layer = self._identity_layer(n, s, b, layer_number=1)
-        model = _mhc_model([layer])
-
-        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
-        targets = monitor._prepare_layers(model, chunk_id=0)
-        self.assertTrue(targets)
+    def _prepare_and_attach(self, monitor, model):
+        targets = monitor._prepare_layers(model)
         monitor.allocate_buffers(torch.device("cpu"))
         monitor._attach_hooks(targets)
+        return targets
+
+
+class MHCGateTest(_MHCFixture, unittest.TestCase):
+    def test_gate_and_amax_metrics_are_recorded(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self.assertTrue(targets)
 
         self._drive(targets, x_dim=n * 8)
         monitor.step()
 
         latest = training_logs.get_latest(prefix="mhc_health")
         for comp in ("attn", "mlp"):
-            for key in (
-                "h_pre_mean",
-                "h_pre_std",
-                "h_post_mean",
-                "h_post_std",
-                "amax_gain_fwd",
-                "amax_gain_bwd",
-                "composite_amax_gain_fwd",
-                "composite_amax_gain_bwd",
-            ):
+            for key in ("h_pre_mean", "h_pre_std", "h_post_mean", "h_post_std"):
                 self.assertIn(f"mhc_health/layer_0/{comp}_{key}", latest)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_amax_gain_fwd"], 1.0, places=4)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_fwd"], 1.0, places=4)
-            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_bwd"], 1.0, places=4)
             # h_pre == 0.5 everywhere, h_post == 1.0 everywhere.
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_mean"], 0.5, places=5)
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_mean"], 1.0, places=5)
-        # global aggregate is derived too.
-        self.assertIn("mhc_health/global_attn_amax_gain_fwd", latest)
+            # Both amax gains are emitted per layer and globally.
+            for key in ("amax_gain_fwd", "amax_gain_bwd"):
+                self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_{key}"], 1.0, places=4)
+                self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_{key}"], 1.0, places=4)
 
-    def test_remove_hooks_restores_compute_mappings(self):
+    def test_amax_gain_axes_are_not_swapped(self):
+        # An asymmetric h_res pins the convention. Streams mix as
+        # `out = h_res^T @ x` (see HyperConnectionModule.apply_h_res), so _fwd
+        # must read the COLUMN sums of h_res (1.5 here) and _bwd the ROW sums
+        # (1.0 here) — single layer and composite agree. Identity matrices cannot
+        # tell the two apart, which is how the fwd/bwd label mix-up stayed
+        # invisible on this backend.
+        n, s, b = 2, 1, 1
+        h_res = torch.tensor([[0.75, 0.25], [0.75, 0.25]]).reshape(1, 1, n, n).expand(s, b, n, n).contiguous()
+        hc = FakeHC(n=n, h_pre=torch.full((s, b, n), 0.5), h_post=torch.ones(s, b, n), h_res=h_res)
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = MHCHealthMonitor()
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_fwd"], 1.5, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_bwd"], 1.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_fwd_max"], 1.5, places=5)
+        self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_bwd_max"], 1.0, places=5)
+
+    def test_h_post_structure_keys_recorded(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            # h_post is constant 1.0 -> equal across streams and across tokens.
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_stream_concentration"], 1.0, places=4)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_token_std"], 0.0, places=5)
+
+
+class MHCLogitsTest(_MHCFixture, unittest.TestCase):
+    def test_logits_gradient_extrema_are_unscaled_without_changing_backward(self):
+        n, s, b = 2, 1, 1
+        source = torch.zeros(s, b, n * n, requires_grad=True)
+        logits = source * 1.0
+        hc = FakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.5),
+            h_post=torch.ones(s, b, n),
+            h_res=torch.eye(n).reshape(s, b, n, n),
+            h_res_logits=logits,
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=self._identity_layer(n, s, b).mlp_hyper_connection)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        self._prepare_and_attach(monitor, model)
+
+        _, _, captured = hc._compute_h(None, None)
+        weight = torch.tensor([[[2.0, -7.0, 4.0, 1.5]]])
+        loss_scale = 16.0
+        (captured * weight * loss_scale).sum().backward()
+
+        # The hook observes but never modifies the autograd gradient.
+        self.assertTrue(torch.allclose(source.grad, weight * loss_scale))
+        monitor.finalize_scaled_grad_metrics(SimpleNamespace(scale=torch.tensor(loss_scale)))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for key in (
+            "mhc_health/layer_0/attn_h_res_logits_grad_min",
+            "mhc_health/global_attn_h_res_logits_grad_min",
+        ):
+            self.assertAlmostEqual(latest[key], -7.0, places=5)
+        for key in (
+            "mhc_health/layer_0/attn_h_res_logits_grad_max",
+            "mhc_health/global_attn_h_res_logits_grad_max",
+        ):
+            self.assertAlmostEqual(latest[key], 4.0, places=5)
+
+    def test_logits_gradient_hook_skips_no_grad_recompute_forward(self):
+        n, s, b = 2, 1, 1
+        source = torch.zeros(s, b, n * n, requires_grad=True)
+        hc = FakeHC(
+            n=n,
+            h_pre=torch.full((s, b, n), 0.5),
+            h_post=torch.ones(s, b, n),
+            h_res=torch.eye(n).reshape(s, b, n, n),
+            h_res_logits=source * 1.0,
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=self._identity_layer(n, s, b).mlp_hyper_connection)])
+        monitor = MHCHealthMonitor()
+        self._prepare_and_attach(monitor, model)
+
+        with torch.no_grad():
+            hc._compute_h(None, None)
+        min_key = "mhc_health/layer_0/attn_h_res_logits_grad_min"
+        max_key = "mhc_health/layer_0/attn_h_res_logits_grad_max"
+        self.assertEqual(monitor._gpu_cnt[min_key], 0)
+        self.assertEqual(monitor._gpu_cnt[max_key], 0)
+
+        _, _, replay_logits = hc._compute_h(None, None)
+        replay_logits.sum().backward()
+        self.assertEqual(monitor._gpu_cnt[min_key], 1)
+        self.assertEqual(monitor._gpu_cnt[max_key], 1)
+        monitor.step()
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest[min_key], 1.0, places=5)
+        self.assertAlmostEqual(latest[max_key], 1.0, places=5)
+
+    def test_logits_extrema_are_recorded_and_reduce_by_extremum_across_layers(self):
+        # layer_0 has zero logits; layer_1 spans [-104, 7.5]. The global series
+        # must reduce by MIN / MAX so an extreme layer is not averaged away.
+        n, s, b = 4, 2, 3
+        extreme = (
+            torch.tensor(
+                [[-25.7, 7.5, -100.0, -61.0], [-33.4, 0.0, -89.0, -48.0]]
+                + [[-34.0, -24.9, -104.0, 0.0], [-79.4, -72.6, -104.0, 0.0]]
+            )
+            .reshape(1, 1, n * n)
+            .expand(s, b, n * n)
+        )
+
+        def sick_hc():
+            return FakeHC(
+                n=n,
+                h_pre=torch.full((s, b, n), 0.5),
+                h_post=torch.ones(s, b, n),
+                h_res=torch.eye(n).reshape(1, 1, n, n).expand(s, b, n, n).contiguous(),
+                h_res_logits=extreme.clone(),
+            )
+
+        model = _mhc_model(
+            [
+                self._identity_layer(n, s, b, layer_number=1),
+                FakeLayer(attn=sick_hc(), mlp=sick_hc(), layer_number=2),
+            ]
+        )
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_logits_min"], 0.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_logits_min"], -104.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_logits_min"], -104.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_res_logits_max"], 0.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_logits_max"], 7.5, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_logits_max"], 7.5, places=5)
+
+
+class MHCCompositeTest(_MHCFixture, unittest.TestCase):
+    def test_composite_is_built_in_layer_order_not_call_order(self):
+        # The composite must be a layer-ordered product: under recompute the
+        # hooks fire in the reverse-layer backward replay, so call order is not
+        # layer order. Here the hooks are fired in reverse on purpose.
+        n, s, b = 4, 1, 1
+        mats = [
+            torch.tensor([[0.9, 0.1, 0.0, 0.0], [0.1, 0.9, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
+            torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.5, 0.0, 0.0], [0.0, 0.0, 0.5, 0.5], [0.0, 0.0, 0.5, 0.5]]),
+            torch.tensor([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]),
+        ]
+
+        def row_gain(m):
+            return m.sum(dim=-1).abs().max().item()
+
+        def col_gain(m):
+            return m.sum(dim=-2).abs().max().item()
+
+        components = ("attn", "mlp")
+        branches = [
+            (layer_idx, component, mat.transpose(0, 1))
+            for layer_idx, mat in enumerate(mats)
+            for component in components
+        ]
+
+        expected_fwd = {}
+        prefix = None
+        for layer_idx, component, op in branches:
+            prefix = op if prefix is None else torch.matmul(op, prefix)
+            expected_fwd[(layer_idx, component)] = row_gain(prefix)
+
+        expected_bwd = {}
+        suffix = None
+        for layer_idx, component, op in reversed(branches):
+            suffix = op if suffix is None else torch.matmul(suffix, op)
+            expected_bwd[(layer_idx, component)] = col_gain(suffix)
+        # Guard against a vacuous test: reversing the physical branch order differs.
+        wrong_prefix = None
+        for _, _, op in reversed(branches):
+            wrong_prefix = op if wrong_prefix is None else torch.matmul(op, wrong_prefix)
+        self.assertNotAlmostEqual(expected_fwd[(2, "mlp")], row_gain(wrong_prefix), places=4)
+
+        def layer_for(mat, layer_number):
+            def make_hc():
+                return FakeHC(
+                    n=n,
+                    h_pre=torch.full((s, b, n), 0.5),
+                    h_post=torch.ones(s, b, n),
+                    h_res=mat.reshape(1, 1, n, n).expand(s, b, n, n).contiguous(),
+                )
+
+            return FakeLayer(attn=make_hc(), mlp=make_hc(), layer_number=layer_number)
+
+        model = _mhc_model([layer_for(m, i + 1) for i, m in enumerate(mats)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(list(reversed(targets)), x_dim=n * 8)  # deliberately out of order
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in components:
+            for idx in range(len(mats)):
+                key = (idx, comp)
+                self.assertAlmostEqual(
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_fwd_max"],
+                    expected_fwd[key],
+                    places=4,
+                )
+                self.assertAlmostEqual(
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_bwd_max"],
+                    expected_bwd[key],
+                    places=4,
+                )
+            self.assertAlmostEqual(
+                latest[f"mhc_health/global_{comp}_composite_amax_gain_fwd_max"],
+                max(value for (idx, component), value in expected_fwd.items() if component == comp),
+                places=4,
+            )
+            self.assertAlmostEqual(
+                latest[f"mhc_health/global_{comp}_composite_amax_gain_bwd_max"],
+                max(value for (idx, component), value in expected_bwd.items() if component == comp),
+                places=4,
+            )
+
+    def test_composite_is_one_for_identity_chain(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b, layer_number=i + 1) for i in range(3)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for idx in range(3):
+                self.assertAlmostEqual(
+                    latest[f"mhc_health/layer_{idx}/{comp}_composite_amax_gain_fwd_max"], 1.0, places=5
+                )
+
+    def test_composite_snapshot_is_cleared_each_step(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        self.assertTrue(monitor._h_res_snapshot)
+        monitor.step()
+        # Stale matrices must not survive into the next step's product.
+        self.assertFalse(monitor._h_res_snapshot)
+
+    def test_composite_aggregates_each_microbatch_before_snapshot_overwrite(self):
+        n, s, b = 2, 1, 1
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        amplified = torch.diag(torch.tensor([3.0, 1.0])).reshape(1, 1, n, n)
+        for _, _, mod in targets:
+            mod._h_res = amplified
+        self._drive(targets, x_dim=n * 8)
+        monitor.finalize_composite_microbatch()
+        self.assertFalse(monitor._h_res_snapshot)
+
+        identity = torch.eye(n).reshape(1, 1, n, n)
+        for _, _, mod in targets:
+            mod._h_res = identity
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_composite_amax_gain_fwd_max"], 3.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/mlp_composite_amax_gain_fwd_max"], 9.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_composite_amax_gain_bwd_max"], 9.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/mlp_composite_amax_gain_bwd_max"], 3.0, places=5)
+
+
+class MHCTeardownTest(_MHCFixture, unittest.TestCase):
+    def test_branch_residual_share_is_recorded_from_bda(self):
+        n, s, b, c = 4, 2, 3, 6
+        model = _mhc_model([self._identity_layer(n, s, b)])
+
+        monitor = MHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        streams = torch.randn(s, b, n * c)
+        x = torch.randn(s, b, c)
+        for _, _, mod in targets:
+            mod.fused_h_res_h_post_bda(
+                h_res=mod._h_res,
+                original_residual=streams,
+                h_post=mod._h_post,
+                layer_output_with_bias=(x, None),
+                dropout_prob=0.0,
+                training=True,
+                fused=False,
+            )
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for key in ("branch_residual_share", "branch_residual_share_max"):
+                self.assertIn(f"mhc_health/layer_0/{comp}_{key}", latest)
+            # h_post == 1 everywhere so the branch norm is √n·‖x‖ and h_res is the
+            # identity, hence the share must sit strictly inside (0, 1].
+            share = latest[f"mhc_health/layer_0/{comp}_branch_residual_share"]
+            self.assertGreater(share, 0.0)
+            self.assertLessEqual(share, 1.0)
+            self.assertGreaterEqual(latest[f"mhc_health/layer_0/{comp}_branch_residual_share_max"], share)
+
+    def test_branch_residual_share_is_recorded_from_positional_bda_call(self):
+        # Megatron's TransformerLayer passes these positionally; the keyword-with-
+        # positional-fallback reader must cover both.
+        n, s, b, c = 4, 1, 1, 5
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = MHCHealthMonitor()
+        targets = self._prepare_and_attach(monitor, model)
+
+        for _, _, mod in targets:
+            mod.fused_h_res_h_post_bda(
+                mod._h_res, torch.randn(s, b, n * c), mod._h_post, (torch.randn(s, b, c), None), 0.0, True, False
+            )
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertIn("mhc_health/layer_0/attn_branch_residual_share", latest)
+
+    def test_remove_hooks_restores_all_wrapped_methods(self):
         n, s, b = 4, 2, 3
         layer = self._identity_layer(n, s, b)
         model = _mhc_model([layer])
         monitor = MHCHealthMonitor()
-        targets = monitor._prepare_layers(model, chunk_id=0)
-        monitor.allocate_buffers(torch.device("cpu"))
-        original = layer.self_attention_hyper_connection.compute_mappings
-        monitor._attach_hooks(targets)
-        self.assertIsNot(layer.self_attention_hyper_connection.compute_mappings, original)
+        hc = layer.self_attention_hyper_connection
+        original = hc.compute_mappings
+        self._prepare_and_attach(monitor, model)
+        self.assertIsNot(hc.compute_mappings, original)
+        self.assertIn("fused_h_res_h_post_bda", vars(hc))
         monitor.remove_hooks()
-        # falls back to the (bound) class method
-        self.assertEqual(layer.self_attention_hyper_connection.compute_mappings.__func__, FakeHC.compute_mappings)
+        self.assertNotIn("fused_h_res_h_post_bda", vars(hc))
+        # falls back to the (bound) class methods after deleting the instance attrs
+        self.assertEqual(hc.compute_mappings.__func__, FakeHC.compute_mappings)
+        self.assertEqual(hc._compute_h.__func__, FakeHC._compute_h)
+        self.assertEqual(hc.fused_h_res_h_post_bda.__func__, FakeHC.fused_h_res_h_post_bda)
         self.assertEqual(monitor._wrapped, [])
-        self.assertEqual(monitor._composite, {})
+        self.assertEqual(monitor._h_res_snapshot, {})
 
     def test_no_graph_retention(self):
         n, s, b = 4, 2, 3
@@ -165,22 +612,23 @@ class MHCMonitorTest(unittest.TestCase):
         h_pre = leaf + 0.5
         h_post = leaf + 1.0
         h_res = ident * (leaf.sum() + 1.0)  # requires_grad, has grad_fn
-        hc = FakeHC(n=n, layer_number=1, h_pre=h_pre, h_post=h_post, h_res=h_res)
-        layer = FakeLayer(layer_number=1, attn=hc, mlp=hc)
-        model = _mhc_model([layer])
+        hc = FakeHC(n=n, h_pre=h_pre, h_post=h_post, h_res=h_res)
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
 
         monitor = MHCHealthMonitor()
-        targets = monitor._prepare_layers(model, chunk_id=0)
-        monitor.allocate_buffers(torch.device("cpu"))
-        monitor._attach_hooks(targets)
-        for _, _, mod, _, _ in targets:
+        targets = self._prepare_and_attach(monitor, model)
+        for _, _, mod in targets:
             mod.compute_mappings(torch.randn(4, 2, n * 8))
 
-        stored = monitor._composite[0]
-        self.assertFalse(stored.requires_grad)
-        self.assertIsNone(stored.grad_fn)
+        # The 0-dim accumulators and the composite snapshots must not be graph-
+        # tracked: if the wrapper forgot to detach, the graph stays pinned
+        # through them until backward.
+        for key, acc in monitor._gpu_acc.items():
+            self.assertFalse(acc.requires_grad, msg=key)
+        for key, mat in monitor._h_res_snapshot.items():
+            self.assertFalse(mat.requires_grad, msg=str(key))
+            self.assertIsNone(mat.grad_fn, msg=str(key))
         monitor.step()
-        self.assertEqual(monitor._composite, {})  # cleared between steps
 
 
 class MHCMonitorNoOpTest(unittest.TestCase):


### PR DESCRIPTION
megatron 侧的 mhc_health 此前只有 8 个指标, 且 composite 与 fwd/bwd 轴的 语义与 paddlefleet 不一致, 两个后端的曲线无法放在一起看。本次把 schema、
口径与归约方式全部对齐, 使同名指标跨后端可比。

补齐 8 条指标 (对应 mhc_metrics 里新增的三个计算函数):
- 结构: h_post_stream_concentration / h_post_token_std
- 写入占比: branch_residual_share / branch_residual_share_max (来自 fused_h_res_h_post_bda 的入参, 因此 fused / checkpoint / dropout 三条 路径覆盖一致)
- Sinkhorn 输入 logits: h_res_logits_min / max 与其 activation gradient 的 min / max (来自 _compute_h)

修正 fwd/bwd 轴。apply_h_res 实际算的是 h_res^T @ residual
(hyper_connection.py:483), 所以按存储布局的 h_res 上列和才是前向增益: fwd 由 dim=-1 改为 dim=-2, bwd 反之。单位矩阵分辨不出行和与列和, 这是
标签对调一直没被发现的原因, 回归测试改用非对称 h_res 钉住该约定。

composite 改为 paddlefleet 的口径: token-mean 的 h_res^T 快照 → flush 时 按层序做前缀 / 后缀乘积 → max 归约, 指标名加 _max 后缀。副作用是不再有
per-token [s*b, n, n] 跨 microbatch 驻留, 且 recompute 的逆序重放不再影响 结果。注意这改变了原有两条 composite 曲线的含义与 key 名。

三处 megatron 特有差异 (已写入注释与文档):
- use_fused_mhc 时 compute_mappings 走 fused_proj_rms_compute_h 而跳过 _compute_h, 四条 h_res_logits* 累加器为空、不落盘。
- finalize_scaled_grad_metrics 兼容 scale / _scale 两个属性名; bf16 不缩放, 不传 scaler 即 no-op。
- 无 MTP 过滤: MTP block 不在 decoder.layers 内, discovery 走不到。