### PR TITLE
feat(mhc): paddlefleet 补齐 Eq. (7) 的 alpha / bias / 门控 logits 13 指标

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
-- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
+- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 29 指标，megatron 后端 16 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 - **APE Health** — CSA/HCA compressor APE 参数健康监控 (P0 级 7 指标；仅 paddlefleet)
 - **Attn Update** — QK 乘积增量 `Δ₂ = ΔW_q W_kᵗ + W_q ΔW_kᵗ` / `Δ₃ = ΔW_q ΔW_kᵗ` 的谱监控 (每项 3 指标；仅权重，不挂 forward hook)
@@ -430,10 +430,14 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
 以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。
 只在模型开启 mHC 层时生效，mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
-彻底 no-op。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 16 个指标，
+彻底 no-op。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 29 个指标，
 指标名以 `attn_` / `mlp_` 前缀区分；`branch_residual_share_max`、`h_res_logits_max`、
-`h_res_logits_grad_max`、`composite_amax_gain_{fwd,bwd}_max` 取极大值，`h_res_logits_min` 与
-`h_res_logits_grad_min` 取极小值，其余按 token/batch 求均值。
+`h_res_logits_grad_max`、`composite_amax_gain_{fwd,bwd}_max`、`h_{pre,post}_logits_max`、
+`bias_{pre,post,res}_abs_max` 取极大值，`h_res_logits_min`、`h_res_logits_grad_min` 与
+`h_{pre,post}_logits_min` 取极小值，其余按 token/batch 求均值。
+
+第 17-29 条对应论文 Eq. (7) 的静态与 pre-sigmoid 部分（`alpha` / `bias` / 门控 logits），
+**目前仅 paddlefleet 后端实现**，megatron 后端仍为前 16 条。
 
 | # | 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
 |---|------|--------|------|------|----------|
@@ -453,8 +457,22 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 | 14 | `{c}_h_res_logits_grad_max` | `mhc_health/layer_{i}/{c}_h_res_logits_grad_max` | `max dL/dz` | 每层+全局 | 同上取最大值。AMP loss scale 被反除，不除 gradient accumulation。按 **max** 归约 |
 | 15 | `{c}_composite_amax_gain_fwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_fwd_max` | 入口到当前 branch 的 attention/MLP 交错 prefix 最大绝对行和 | 每层+全局 | 按 **max** 跨 microbatch/层归约 |
 | 16 | `{c}_composite_amax_gain_bwd_max` | `mhc_health/layer_{i}/{c}_composite_amax_gain_bwd_max` | 当前 branch 到模型尾部的 attention/MLP 交错 suffix 最大绝对列和 | 每层+全局 | 按 **max** 跨 microbatch/层归约 |
+| 17 | `{c}_h_pre_logits_min` | `mhc_health/layer_{i}/{c}_h_pre_logits_min` | `min(r·proj[:n]·α_pre + b_pre)` | 每层+全局 | `H_pre` 进 sigmoid 前的 logit 最小值，判断聚合门是否饱和到 0。按 **min** 归约 |
+| 18 | `{c}_h_pre_logits_max` | `mhc_health/layer_{i}/{c}_h_pre_logits_max` | 同上取最大值 | 每层+全局 | 判断聚合门是否饱和到 1。按 **max** 归约 |
+| 19 | `{c}_h_post_logits_min` | `mhc_health/layer_{i}/{c}_h_post_logits_min` | `min(r·proj[n:2n]·α_post + b_post)` | 每层+全局 | `H_post` 的 pre-sigmoid logit 最小值（因子 2 在 sigmoid 之外，不进 logit）。按 **min** 归约 |
+| 20 | `{c}_h_post_logits_max` | `mhc_health/layer_{i}/{c}_h_post_logits_max` | 同上取最大值 | 每层+全局 | 扩展门饱和哨兵。按 **max** 归约 |
+| 21 | `{c}_alpha_pre` | `mhc_health/layer_{i}/{c}_alpha_pre` | `α_pre`（标量参数） | 每层+全局 | 动态映射门控因子，从 `mhc_init_gating_factor` 起漂移 |
+| 22 | `{c}_alpha_post` | `mhc_health/layer_{i}/{c}_alpha_post` | `α_post` | 每层+全局 | 同上 |
+| 23 | `{c}_alpha_res` | `mhc_health/layer_{i}/{c}_alpha_res` | `α_res` | 每层+全局 | 同上；直接决定 Sinkhorn 输入 logits 的尺度 |
+| 24 | `{c}_bias_pre_mean` | `mhc_health/layer_{i}/{c}_bias_pre_mean` | `mean(bias[:n])` | 每层+全局 | `b_pre` 静态偏置均值（初始为 0） |
+| 25 | `{c}_bias_pre_abs_max` | `mhc_health/layer_{i}/{c}_bias_pre_abs_max` | `max\|bias[:n]\|` | 每层+全局 | 单元素跑飞哨兵。按 **max** 归约 |
+| 26 | `{c}_bias_post_mean` | `mhc_health/layer_{i}/{c}_bias_post_mean` | `mean(bias[n:2n])` | 每层+全局 | `b_post` 均值 |
+| 27 | `{c}_bias_post_abs_max` | `mhc_health/layer_{i}/{c}_bias_post_abs_max` | `max\|bias[n:2n]\|` | 每层+全局 | 同上取极值。按 **max** 归约 |
+| 28 | `{c}_bias_res_mean` | `mhc_health/layer_{i}/{c}_bias_res_mean` | `mean(bias[2n:])` | 每层+全局 | `b_res` 均值 |
+| 29 | `{c}_bias_res_abs_max` | `mhc_health/layer_{i}/{c}_bias_res_abs_max` | `max\|bias[2n:]\|` | 每层+全局 | 同上取极值。按 **max** 归约 |
 
-`{c}` ∈ `{attn, mlp}`。
+`{c}` ∈ `{attn, mlp}`。第 21-29 条是 step 级参数量，在 `on_optimizer_begin`（optimizer step 之前）读一次参数，
+不在热路径，且仅在本 step 确实跑过被监控的 forward 时记录。
 
 指标公式、采集路径、健康判读及论文 composite 定义统一维护在
 [`docs/mhc_health.md`](docs/mhc_health.md)，README 不再重复展开。

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -63,9 +63,10 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 
 ## 监控指标
 
-每个 hc 模块产出 16 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 8 个），指标名以
+每个 hc 模块产出 29 个指标（本节均为 paddlefleet 后端；megatron 后端未随本次改动调整，仍是 16 个），指标名以
 `attn_` / `mlp_` 前缀区分。`branch_residual_share_max`、`h_res_logits_max`、`h_res_logits_grad_max`、
-`composite_amax_gain_{fwd,bwd}_max` 取极大值，`h_res_logits_min` 与 `h_res_logits_grad_min` 取极小值，其余按 token/batch 求均值
+`composite_amax_gain_{fwd,bwd}_max`、`h_{pre,post}_logits_max`、`bias_{pre,post,res}_abs_max` 取极大值，
+`h_res_logits_min`、`h_res_logits_grad_min` 与 `h_{pre,post}_logits_min` 取极小值，其余按 token/batch 求均值
 （并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，
 `{c}` ∈ `{attn, mlp}`；对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
 
@@ -152,6 +153,53 @@ hook 热路径只在 GPU 上计算 fp32 min/max 并写 0 维 accumulator。AMP �
 `on_optimizer_begin`（`scaler.step/update` 之前）用本 step loss scale 统一反除；不除 gradient accumulation，保留每个
 microbatch 在真实反向路径上的 activation-gradient 量级。recompute 的首次 forward 运行于 `no_grad`，由现有
 `_should_monitor()` 跳过；grad-enabled backward replay 再注册 hook，因此不会重复采集 checkpoint 的首次执行。
+
+### 门控 logits 范围（h_pre / h_post，pre-sigmoid）
+
+Eq. (8) 的 `H_pre = σ(·)`、`H_post = 2σ(·)` 把值域压进 `(0,1)` / `(0,2)`，饱和后从激活值已经看不出来
+logit 有多极端。这两对指标读的是 sigmoid **之前**的 Eq. (7) 结果：
+
+```
+h_pre_logits  = r · proj[..., :n]    · α_pre  + b_pre
+h_post_logits = r · proj[..., n:2n]  · α_post + b_post
+```
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_h_pre_logits_min` | `min` 上式 | 聚合门是否饱和到 0。按 **min** 归约 |
+| `{c}_h_pre_logits_max` | `max` 上式 | 聚合门是否饱和到 1。按 **max** 归约 |
+| `{c}_h_post_logits_min` | `min` 上式 | 扩展门下饱和哨兵。按 **min** 归约 |
+| `{c}_h_post_logits_max` | `max` 上式 | 扩展门上饱和哨兵。按 **max** 归约 |
+
+`_compute_h` 只返回激活后的门，所以这四条由 monitor 在 wrap 点用它自己的入参 `(proj, r)` 加模块的
+`alpha` / `bias` **按同一行公式重算**（`mhc_metrics.gate_logits_extrema`），不是对 sigmoid 求逆——求逆会
+把所有饱和元素丢成 `±inf`，恰好丢掉这两条指标存在的意义。代价是与模型实现耦合：`_compute_h` 里
+`h` 的构成方式一旦改变，这四条会静默算错，改模型时必须同步。`H_post` 的因子 2 在 sigmoid 之外，不进 logit。
+
+调用方没有传 `proj` / `r` 时（stub、或未来绕过该签名的 fused 路径）这四个累加器保持为空，不写值。
+
+### Eq. (7) 静态参数（alpha / bias）
+
+论文 Eq. (7) 的静态半边：三个标量门控因子 `α_pre` / `α_post` / `α_res`，以及一个 `[n² + 2n]` 的
+`bias`——它按切片承担论文的 `b^pre`（`[:n]`）/ `b^post`（`[n:2n]`）/ `b^res`（`[2n:]`），因此分片统计而不是
+合成一个数。
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_alpha_pre` / `{c}_alpha_post` / `{c}_alpha_res` | 参数值 | 动态映射门控因子，从 `mhc_init_gating_factor` 起漂移；`α_res` 直接决定 Sinkhorn 输入 logits 的尺度 |
+| `{c}_bias_{pre,post,res}_mean` | `mean(bias 切片)` | 静态偏置整体位置（初始为 0） |
+| `{c}_bias_{pre,post,res}_abs_max` | `max abs(bias 切片)` | 单元素跑飞哨兵，均值会掩盖它。按 **max** 归约 |
+
+采集在 `on_optimizer_begin`（经 `finalize_scaled_grad_metrics`）读一次参数，不在热路径——否则 9 条 × 层数 ×
+2 component × microbatch 数会平白多出上万次 kernel launch。选这个钩子而不是 flush 是因为它在
+`optimizer.step()` **之前**，读到的是本 step forward 实际用的参数值；`_flush_buffers` 保留为兜底路径（`on_step_end`
+在 optimizer step 之后，走兜底时记到的是更新后的值，比同 step 其余曲线晚一次更新）。两处都调也只记一次。
+参数在 TP 各 rank 上是同一份副本（`HyperConnectionModule` 用普通 `nn.Linear` 并把参数标记为
+`is_distributed=False`），所以不需要任何 collective。
+
+只有本 step 真正跑过被监控的 forward 才记录（`_captured_this_step`），这样 `monitor_interval > 1` 时参数曲线
+与激活曲线落在同一批 step 上。注意命名是 `bias_*_abs_max` 而不是 `bias_*_absmax`：`training_logs` 的
+max/min 分类器按 `_max` 后缀字面匹配。
 
 ### 复合映射（composite_amax_gain_{fwd,bwd}_max）
 

--- a/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_metrics.py
@@ -8,6 +8,9 @@ helpers for the ``mhc_health`` monitor, operating on the three mappings a
 - ``h_post`` [..., n]     — stream expansion gate (2 * sigmoid)
 - ``h_res``  [..., n, n]  — Sinkhorn doubly-stochastic residual-mixing matrix
 
+``gate_logits_extrema`` and ``mapping_param_stats`` reach one step further back,
+to the ``alpha`` / ``bias`` / pre-sigmoid-logit terms of paper Eq. (7).
+
 All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
 ``.cpu()``), so they are safe on a forward hot path. See
 ``.claude/skills/monitor-hook-perf-rules``.
@@ -38,6 +41,68 @@ def h_res_logits_extrema(h_res_logits: paddle.Tensor) -> dict[str, paddle.Tensor
         "h_res_logits_min": logits.min(),
         "h_res_logits_max": logits.max(),
     }
+
+
+def gate_logits_extrema(
+    proj: paddle.Tensor,
+    r: paddle.Tensor,
+    alpha_pre: paddle.Tensor,
+    alpha_post: paddle.Tensor,
+    bias: paddle.Tensor,
+    n: int,
+) -> dict[str, paddle.Tensor]:
+    """Min/max of the *pre-sigmoid* ``H_pre`` / ``H_post`` logits (paper Eq. 7).
+
+    Keep in sync with ``HyperConnectionModule._compute_h``: if the model changes
+    how ``h`` is formed, these four series go silently wrong.
+    """
+    proj32 = proj.detach().astype("float32")
+    r32 = r.detach().astype("float32")
+    bias32 = bias.detach().astype("float32")
+    pre = r32 * proj32[..., :n] * alpha_pre.detach().astype("float32") + bias32[:n]
+    post = r32 * proj32[..., n : 2 * n] * alpha_post.detach().astype("float32") + bias32[n : 2 * n]
+    return {
+        "h_pre_logits_min": pre.min(),
+        "h_pre_logits_max": pre.max(),
+        "h_post_logits_min": post.min(),
+        "h_post_logits_max": post.max(),
+    }
+
+
+def mapping_param_stats(
+    alpha_pre: paddle.Tensor,
+    alpha_post: paddle.Tensor,
+    alpha_res: paddle.Tensor,
+    bias: paddle.Tensor,
+    n: int,
+) -> dict[str, paddle.Tensor]:
+    """The static half of paper Eq. (7): the gating factors and the bias terms.
+
+    ``alpha_*`` are per-module scalars. ``bias`` is a single ``[n^2 + 2n]``
+    parameter whose slices are the paper's ``b^pre`` / ``b^post`` / ``b^res``, so
+    they are reported per slice rather than as one number. ``mean`` shows where
+    the slice sits (it starts at 0 and drifts), ``abs_max`` catches a single
+    runaway entry the mean would hide.
+
+    Step-level quantities: record once per optimizer step, not per microbatch.
+    """
+    alpha = {
+        "alpha_pre": alpha_pre,
+        "alpha_post": alpha_post,
+        "alpha_res": alpha_res,
+    }
+    stats = {name: value.detach().astype("float32").mean() for name, value in alpha.items()}
+
+    b = bias.detach().astype("float32")
+    slices = {
+        "pre": b[:n],
+        "post": b[n : 2 * n],
+        "res": b[2 * n :],
+    }
+    for name, part in slices.items():
+        stats[f"bias_{name}_mean"] = part.mean()
+        stats[f"bias_{name}_abs_max"] = part.abs().max()
+    return stats
 
 
 def gate_stats(h: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -1,6 +1,6 @@
 """mHC Health Monitor for PaddleFleet.
 
-Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 16
+Per hyper-connection module (a layer has two: ``attn`` and ``mlp``) we emit 29
 series, name-prefixed by component:
 
     {attn,mlp}_h_pre_mean   {attn,mlp}_h_pre_std
@@ -11,6 +11,16 @@ series, name-prefixed by component:
     {attn,mlp}_h_res_logits_min  {attn,mlp}_h_res_logits_max
     {attn,mlp}_h_res_logits_grad_min  {attn,mlp}_h_res_logits_grad_max
     {attn,mlp}_composite_amax_gain_fwd_max  {attn,mlp}_composite_amax_gain_bwd_max
+    {attn,mlp}_h_pre_logits_min   {attn,mlp}_h_pre_logits_max
+    {attn,mlp}_h_post_logits_min  {attn,mlp}_h_post_logits_max
+    {attn,mlp}_alpha_pre  {attn,mlp}_alpha_post  {attn,mlp}_alpha_res
+    {attn,mlp}_bias_pre_mean   {attn,mlp}_bias_pre_abs_max
+    {attn,mlp}_bias_post_mean  {attn,mlp}_bias_post_abs_max
+    {attn,mlp}_bias_res_mean   {attn,mlp}_bias_res_abs_max
+
+The last 13 cover paper Eq. (7) — the ``alpha`` / ``bias`` / pre-sigmoid-logit
+terms that feed Eq. (8) — and were added for the algorithm side. The nine
+parameter series are step-level and are read once per flush, off the hot path.
 
 Forward hooks are not enough, so three bound methods are wrapped instead (see
 ``mhc_metrics`` for what each metric means):
@@ -32,9 +42,11 @@ from .layer_discovery import get_decoder_layers, iter_monitor_layers
 from .mhc_metrics import (
     amax_gain,
     branch_residual_share,
+    gate_logits_extrema,
     gate_stats,
     h_post_structure_stats,
     h_res_logits_extrema,
+    mapping_param_stats,
 )
 
 logger = logging.getLogger(__name__)
@@ -68,6 +80,32 @@ _METRIC_NAMES = (
     "h_res_logits_grad_max",
     "composite_amax_gain_fwd_max",
     "composite_amax_gain_bwd_max",
+    "h_pre_logits_min",
+    "h_pre_logits_max",
+    "h_post_logits_min",
+    "h_post_logits_max",
+    "alpha_pre",
+    "alpha_post",
+    "alpha_res",
+    "bias_pre_mean",
+    "bias_pre_abs_max",
+    "bias_post_mean",
+    "bias_post_abs_max",
+    "bias_res_mean",
+    "bias_res_abs_max",
+)
+
+# Read once per flush from the module parameters, not from the hot path.
+_PARAM_METRICS = (
+    "alpha_pre",
+    "alpha_post",
+    "alpha_res",
+    "bias_pre_mean",
+    "bias_pre_abs_max",
+    "bias_post_mean",
+    "bias_post_abs_max",
+    "bias_res_mean",
+    "bias_res_abs_max",
 )
 
 # Extrema, not means: a worst case that a mean over 43 layers would bury. The
@@ -80,9 +118,21 @@ _MAX_METRICS = frozenset(
         "h_res_logits_grad_max",
         "composite_amax_gain_fwd_max",
         "composite_amax_gain_bwd_max",
+        "h_pre_logits_max",
+        "h_post_logits_max",
+        "bias_pre_abs_max",
+        "bias_post_abs_max",
+        "bias_res_abs_max",
     }
 )
-_MIN_METRICS = frozenset({"h_res_logits_min", "h_res_logits_grad_min"})
+_MIN_METRICS = frozenset(
+    {
+        "h_res_logits_min",
+        "h_res_logits_grad_min",
+        "h_pre_logits_min",
+        "h_post_logits_min",
+    }
+)
 
 # (component_name, layer attribute) — attn runs before mlp in the layer forward.
 _COMPONENTS = (
@@ -148,6 +198,14 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         self._h_res_snapshot: dict[tuple[int, str], paddle.Tensor] = {}
         # MTP layers are off the main trunk and must not enter the product.
         self._mtp_layer_ids: set[int] = set()
+        # (layer_idx, component, module) for the step-level parameter series.
+        self._param_targets: list[tuple[int, str, nn.Layer]] = []
+        # Set by the capture wrapper: whether this step's forward was monitored.
+        # A plain bool assignment, so it costs nothing on the hot path, and it
+        # keeps the parameter series on exactly the steps the rest are on
+        # (`_should_monitor()` cannot answer that at flush time — `step()` has
+        # already incremented `step_count` by then).
+        self._captured_this_step = False
         # Gradient hooks see AMP-scaled activation gradients. The callback
         # finalizes these accumulators with this step's scale before flush.
         self._grad_metrics_finalized = False
@@ -224,9 +282,10 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                 orig = mod.compute_mappings
                 mod.compute_mappings = self._make_capture(orig, layer_idx, comp)
                 self._wrapped.append((mod, "compute_mappings", orig))
+                self._param_targets.append((layer_idx, comp, mod))
                 orig_h = getattr(mod, "_compute_h", None)
                 if orig_h is not None:
-                    mod._compute_h = self._make_logits_capture(orig_h, layer_idx, comp)
+                    mod._compute_h = self._make_logits_capture(orig_h, layer_idx, comp, mod)
                     self._wrapped.append((mod, "_compute_h", orig_h))
                 orig_bda = getattr(mod, "fused_h_res_h_post_bda", None)
                 if orig_bda is None:
@@ -255,6 +314,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             except AttributeError:
                 setattr(mod, attr, orig)
         self._wrapped = []
+        self._param_targets = []
         self._h_res_snapshot.clear()
         super().remove_hooks()
 
@@ -319,6 +379,11 @@ class PaddleMHCHealthMonitor(PaddleProbe):
 
     def finalize_scaled_grad_metrics(self, scaler=None) -> None:
         """Remove AMP loss scaling from this step's logits-gradient extrema."""
+        # `on_optimizer_begin` is the last hook before `optimizer_step()`, so it
+        # is also where the Eq. (7) parameters still hold the values this step's
+        # forward actually used. Called outside the guard below and idempotent
+        # within a step, so the `_flush_buffers` fallback stays harmless.
+        self.finalize_param_metrics()
         if self._grad_metrics_finalized:
             return
         scale = getattr(scaler, "_scale", None) if scaler is not None else None
@@ -329,8 +394,54 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                     self._gpu_acc[key].divide_(scale)
         self._grad_metrics_finalized = True
 
+    def finalize_param_metrics(self) -> None:
+        """Record the step-level ``alpha`` / ``bias`` series from the parameters.
+
+        Cold path: once per step, so nine tiny reductions per module instead of
+        per microbatch. Skipped entirely when this step's forward was not
+        monitored, which keeps these series sampled on the same steps as the
+        activation ones under ``monitor_interval > 1`` — ``_should_monitor()``
+        cannot answer that here, because ``step()`` increments ``step_count``
+        before ``_flush_buffers`` runs.
+
+        Read point is ``on_optimizer_begin`` (via ``finalize_scaled_grad_metrics``),
+        i.e. *before* ``optimizer.step()``, so the values line up with the forward
+        that produced this step's activation metrics. A caller that only drives
+        ``step()`` (direct users, and PaddleFormers' ``on_step_end`` runs after
+        the optimizer) falls back to the flush path and therefore logs the
+        post-update value — one update later than the rest of the step's series.
+
+        The parameters are replicated across TP ranks (``HyperConnectionModule``
+        uses a plain ``nn.Linear`` and marks its params ``is_distributed=False``),
+        so no collective is needed — every rank holds the same values.
+        """
+        if not self._captured_this_step:
+            return
+        try:
+            for layer_idx, component, mod in self._param_targets:
+                try:
+                    with paddle.no_grad():
+                        stats = mapping_param_stats(
+                            mod.alpha_pre,
+                            mod.alpha_post,
+                            mod.alpha_res,
+                            mod.bias,
+                            int(mod.n),
+                        )
+                    for name, value in stats.items():
+                        self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+                except Exception as e:
+                    # Per module, so one module without the Eq. (7) parameters
+                    # cannot silence the series for every other layer.
+                    if self.verbose:
+                        logger.error(f"[PaddleMHCMonitor] Error mapping params {layer_idx}/{component}: {e}")
+        finally:
+            self._captured_this_step = False
+
     def _flush_buffers(self) -> None:
         # Direct users and non-AMP trainers may not emit on_optimizer_begin.
+        # finalize_scaled_grad_metrics also covers the parameter series, so this
+        # is the fallback read point for both.
         self.finalize_scaled_grad_metrics()
         self.finalize_composite_microbatch()
         super()._flush_buffers()
@@ -349,6 +460,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                 return out
             try:
                 h_pre, h_post, h_res = out
+                self._captured_this_step = True
                 with paddle.no_grad():
                     h_pre = h_pre.detach()
                     h_post = h_post.detach()
@@ -378,8 +490,15 @@ class PaddleMHCHealthMonitor(PaddleProbe):
 
         return wrapped
 
-    def _make_logits_capture(self, orig, layer_idx: int, component: str):
-        """Wrap ``_compute_h`` to record the saturation sentinel."""
+    def _make_logits_capture(self, orig, layer_idx: int, component: str, mod):
+        """Wrap ``_compute_h`` to record the saturation sentinels.
+
+        Two families come from here: the residual-mixing logits (the real return
+        value) and the pre-sigmoid ``H_pre`` / ``H_post`` logits, which
+        ``_compute_h`` does not return and are therefore rebuilt from its own
+        ``(proj, r)`` arguments plus ``mod``'s ``alpha`` / ``bias`` — see
+        ``gate_logits_extrema``.
+        """
 
         def wrapped(proj, r):
             out = orig(proj, r)  # the real mappings the model consumes — returned unchanged
@@ -406,8 +525,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                         except Exception as e:
                             if self.verbose:
                                 logger.error(
-                                    f"[PaddleMHCMonitor] Error logits gradient "
-                                    f"layer {layer_idx}/{component}: {e}"
+                                    f"[PaddleMHCMonitor] Error logits gradient layer {layer_idx}/{component}: {e}"
                                 )
                         return grad
 
@@ -415,6 +533,21 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                 with paddle.no_grad():
                     for name, value in h_res_logits_extrema(h_res_logits).items():
                         self.record_layer_metric(layer_idx, f"{component}_{name}", value)
+                    # proj / r are the only route to the pre-sigmoid pre/post
+                    # logits; a caller that does not supply them (a stub, or a
+                    # future fused path that bypasses this signature) simply
+                    # leaves those four accumulators empty.
+                    if proj is not None and r is not None:
+                        gate_logits = gate_logits_extrema(
+                            proj,
+                            r,
+                            mod.alpha_pre,
+                            mod.alpha_post,
+                            mod.bias,
+                            int(mod.n),
+                        )
+                        for name, value in gate_logits.items():
+                            self.record_layer_metric(layer_idx, f"{component}_{name}", value)
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMHCMonitor] Error logits layer {layer_idx}/{component}: {e}")

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -25,7 +25,7 @@ PaddleMHCHealthMonitor = mhc_monitor.PaddleMHCHealthMonitor
 class FakeHC(nn.Layer):
     """Stand-in for HyperConnectionModule exposing compute_mappings."""
 
-    def __init__(self, n, h_pre, h_post, h_res, h_res_logits=None):
+    def __init__(self, n, h_pre, h_post, h_res, h_res_logits=None, alpha=0.1, bias=None):
         super().__init__()
         self.n = n
         self._h_pre = h_pre
@@ -36,6 +36,12 @@ class FakeHC(nn.Layer):
         if h_res_logits is None:
             h_res_logits = paddle.zeros([*h_pre.shape[:-1], n * n])
         self._h_res_logits = h_res_logits
+        # Eq. (7) parameters, same layout as the real module: three scalar gating
+        # factors plus one [n^2 + 2n] bias whose slices are b_pre / b_post / b_res.
+        self.alpha_pre = paddle.full([1], alpha)
+        self.alpha_post = paddle.full([1], alpha)
+        self.alpha_res = paddle.full([1], alpha)
+        self.bias = paddle.zeros([n * n + 2 * n]) if bias is None else bias
 
     def _compute_h(self, proj, r):
         return self._h_pre, self._h_post, self._h_res_logits
@@ -176,6 +182,46 @@ class MHCMetricsTest(unittest.TestCase):
         stats = mhc_metrics.h_res_logits_extrema(logits)
         self.assertAlmostEqual(float(stats["h_res_logits_min"]), -200.0, places=6)
         self.assertAlmostEqual(float(stats["h_res_logits_max"]), 7.5, places=6)
+
+    def test_gate_logits_extrema_matches_explicit_formula(self):
+        # pre  = r * proj[:n]     * alpha_pre  + b_pre  = 2*[1,-2]*0.5  + 0.25
+        # post = r * proj[n:2n]   * alpha_post + b_post = 2*[3,-4]*-1.0 + 1.0
+        n = 2
+        proj = paddle.to_tensor([[[1.0, -2.0, 3.0, -4.0, 0.0, 0.0, 0.0, 0.0]]], dtype="float32")
+        r = paddle.to_tensor([[[2.0]]], dtype="float32")
+        bias = paddle.to_tensor([0.25, 0.25, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0], dtype="float32")
+        stats = mhc_metrics.gate_logits_extrema(proj, r, paddle.full([1], 0.5), paddle.full([1], -1.0), bias, n)
+        self.assertAlmostEqual(float(stats["h_pre_logits_min"]), -1.75, places=5)
+        self.assertAlmostEqual(float(stats["h_pre_logits_max"]), 1.25, places=5)
+        self.assertAlmostEqual(float(stats["h_post_logits_min"]), -5.0, places=5)
+        self.assertAlmostEqual(float(stats["h_post_logits_max"]), 9.0, places=5)
+
+    def test_gate_logits_survive_saturation_a_sigmoid_inverse_would_lose(self):
+        # A logit of -200 saturates h_pre to exactly 0 in fp32, so recovering it
+        # from the activated gate is impossible. Reading it pre-sigmoid must work.
+        n = 1
+        proj = paddle.to_tensor([[-200.0, 0.0, 0.0]], dtype="float32")
+        r = paddle.ones([1, 1], dtype="float32")
+        stats = mhc_metrics.gate_logits_extrema(proj, r, paddle.ones([1]), paddle.ones([1]), paddle.zeros([3]), n)
+        self.assertAlmostEqual(float(stats["h_pre_logits_min"]), -200.0, places=4)
+        self.assertAlmostEqual(float(paddle.nn.functional.sigmoid(proj[..., :n]).max()), 0.0, places=6)
+
+    def test_mapping_param_stats_slices_the_shared_bias(self):
+        # n = 2 -> bias is [b_pre(2), b_post(2), b_res(4)].
+        n = 2
+        bias = paddle.to_tensor([1.0, -3.0, 0.5, 0.5, 2.0, -8.0, 0.0, 0.0], dtype="float32")
+        stats = mhc_metrics.mapping_param_stats(
+            paddle.full([1], 0.1), paddle.full([1], 0.2), paddle.full([1], 0.3), bias, n
+        )
+        self.assertAlmostEqual(float(stats["alpha_pre"]), 0.1, places=6)
+        self.assertAlmostEqual(float(stats["alpha_post"]), 0.2, places=6)
+        self.assertAlmostEqual(float(stats["alpha_res"]), 0.3, places=6)
+        self.assertAlmostEqual(float(stats["bias_pre_mean"]), -1.0, places=6)
+        self.assertAlmostEqual(float(stats["bias_pre_abs_max"]), 3.0, places=6)
+        self.assertAlmostEqual(float(stats["bias_post_mean"]), 0.5, places=6)
+        self.assertAlmostEqual(float(stats["bias_post_abs_max"]), 0.5, places=6)
+        self.assertAlmostEqual(float(stats["bias_res_mean"]), -1.5, places=6)
+        self.assertAlmostEqual(float(stats["bias_res_abs_max"]), 8.0, places=6)
 
     def test_logits_extrema_are_detached_fp32_scalars(self):
         logits = paddle.to_tensor([[-3.0, 2.0]], dtype="float16")
@@ -385,6 +431,118 @@ class MHCMonitorTest(unittest.TestCase):
             self.assertAlmostEqual(latest[f"mhc_health/layer_1/{comp}_h_res_logits_max"], 7.5, places=5)
             self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_res_logits_max"], 7.5, places=5)
 
+    def test_gate_logits_are_recorded_from_compute_h_arguments(self):
+        # alpha = 0.1, bias = 0, r = 1 -> logits are proj/10 on the pre and post
+        # slices: pre [1, -2], post [3, -4].
+        n, s, b = 2, 1, 1
+        layer = self._identity_layer(n, s, b)
+        model = _mhc_model([layer])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        proj = paddle.to_tensor([[[10.0, -20.0, 30.0, -40.0, 0.0, 0.0, 0.0, 0.0]]], dtype="float32")
+        r = paddle.ones([s, b, 1], dtype="float32")
+        for _, _, mod in targets:
+            mod._compute_h(proj, r)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_logits_min"], -2.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_logits_max"], 1.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_logits_min"], -4.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_logits_max"], 3.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_pre_logits_min"], -2.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_h_post_logits_max"], 3.0, places=5)
+
+    def test_gate_logits_skipped_when_compute_h_gets_no_proj(self):
+        # The stub call path (proj=r=None) must not raise and must leave the four
+        # accumulators empty rather than writing a bogus value.
+        n, s, b = 2, 1, 1
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = PaddleMHCHealthMonitor()
+        targets = self._prepare_and_attach(monitor, model)
+        for _, _, mod in targets:
+            mod._compute_h(None, None)
+        self.assertEqual(monitor._gpu_cnt["mhc_health/layer_0/attn_h_pre_logits_min"], 0)
+        monitor.step()
+        self.assertNotIn("mhc_health/layer_0/attn_h_pre_logits_min", training_logs.get_latest(prefix="mhc_health"))
+
+    def test_mapping_param_metrics_are_recorded_once_per_step(self):
+        n, s, b = 2, 1, 1
+        bias = paddle.to_tensor([1.0, -3.0, 0.5, 0.5, 2.0, -8.0, 0.0, 0.0], dtype="float32")
+
+        def make_hc():
+            return FakeHC(
+                n=n,
+                h_pre=paddle.full([s, b, n], 0.5),
+                h_post=paddle.ones([s, b, n]),
+                h_res=paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n]),
+                alpha=0.25,
+                bias=bias,
+            )
+
+        model = _mhc_model([FakeLayer(attn=make_hc(), mlp=make_hc())])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        # Two microbatches: the parameters are step-level, so they must still be
+        # recorded exactly once, and a second finalize must be a no-op.
+        self._drive(targets, x_dim=n * 8)
+        self._drive(targets, x_dim=n * 8)
+        monitor.finalize_param_metrics()
+        monitor.finalize_param_metrics()
+        self.assertEqual(monitor._gpu_cnt["mhc_health/layer_0/attn_alpha_pre"], 1)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for key in ("alpha_pre", "alpha_post", "alpha_res"):
+                self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_{key}"], 0.25, places=6)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_bias_pre_mean"], -1.0, places=6)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_bias_pre_abs_max"], 3.0, places=6)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_bias_post_mean"], 0.5, places=6)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_bias_res_mean"], -1.5, places=6)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_bias_res_abs_max"], 8.0, places=6)
+            self.assertAlmostEqual(latest[f"mhc_health/global_{comp}_alpha_res"], 0.25, places=6)
+
+    def test_mapping_param_metrics_read_before_the_optimizer_update(self):
+        # `on_optimizer_begin` fires before optimizer.step(), so the value logged
+        # for this step must be the one its forward used, not the updated one.
+        n, s, b = 2, 1, 1
+
+        def make_hc():
+            return FakeHC(
+                n=n,
+                h_pre=paddle.full([s, b, n], 0.5),
+                h_post=paddle.ones([s, b, n]),
+                h_res=paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n]),
+                alpha=0.25,
+            )
+
+        model = _mhc_model([FakeLayer(attn=make_hc(), mlp=make_hc())])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+
+        self._drive(targets, x_dim=n * 8)
+        monitor.finalize_scaled_grad_metrics()  # on_optimizer_begin
+        for _, _, mod in targets:  # optimizer.step() moves the parameters
+            mod.alpha_pre = paddle.full([1], 9.0)
+        monitor.step()  # on_step_end, i.e. after the update
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_alpha_pre"], 0.25, places=6)
+
+    def test_mapping_param_metrics_skipped_on_unmonitored_step(self):
+        # No forward ran, so the parameter series must not emit a lone sample the
+        # activation series has no counterpart for.
+        n, s, b = 2, 1, 1
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = PaddleMHCHealthMonitor()
+        self._prepare_and_attach(monitor, model)
+        monitor.step()
+        self.assertNotIn("mhc_health/layer_0/attn_alpha_pre", training_logs.get_latest(prefix="mhc_health"))
+
     def test_composite_is_built_in_layer_order_not_call_order(self):
         # Regression test for what retired the previous composite metric: it was
         # accumulated in call order, which under recompute is the reverse-layer
@@ -506,9 +664,7 @@ class MHCMonitorTest(unittest.TestCase):
 
         latest = training_logs.get_latest(prefix="mhc_health")
         for comp in ("attn", "mlp"):
-            self.assertAlmostEqual(
-                latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_fwd_max"], 1.0, places=5
-            )
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_composite_amax_gain_fwd_max"], 1.0, places=5)
             self.assertNotIn(f"mhc_health/layer_1/{comp}_composite_amax_gain_fwd_max", latest)
 
     def test_composite_snapshot_is_cleared_each_step(self):
@@ -542,18 +698,10 @@ class MHCMonitorTest(unittest.TestCase):
         monitor.step()
 
         latest = training_logs.get_latest(prefix="mhc_health")
-        self.assertAlmostEqual(
-            latest["mhc_health/layer_0/attn_composite_amax_gain_fwd_max"], 3.0, places=5
-        )
-        self.assertAlmostEqual(
-            latest["mhc_health/layer_0/mlp_composite_amax_gain_fwd_max"], 9.0, places=5
-        )
-        self.assertAlmostEqual(
-            latest["mhc_health/layer_0/attn_composite_amax_gain_bwd_max"], 9.0, places=5
-        )
-        self.assertAlmostEqual(
-            latest["mhc_health/layer_0/mlp_composite_amax_gain_bwd_max"], 3.0, places=5
-        )
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_composite_amax_gain_fwd_max"], 3.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/mlp_composite_amax_gain_fwd_max"], 9.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/attn_composite_amax_gain_bwd_max"], 9.0, places=5)
+        self.assertAlmostEqual(latest["mhc_health/layer_0/mlp_composite_amax_gain_bwd_max"], 3.0, places=5)
 
     def test_branch_residual_share_is_recorded_from_bda(self):
         n, s, b, c = 4, 2, 3, 6


### PR DESCRIPTION
算法侧需要打印 mHC 论文 Eq. (7) 的中间量，此前 `mhc_health` 只覆盖 Eq. (8) 的三个输出映射。
paddlefleet 后端每 hc 模块从 16 条扩到 29 条。

## 新增指标

**门控 logits（4 条，热路径）**

- `h_pre_logits_min` / `h_pre_logits_max`
- `h_post_logits_min` / `h_post_logits_max`

进 sigmoid 前的门控 logit 极值。`_compute_h` 只返回激活后的门，故在 wrap 点用它自己的`(proj, r)` 加模块的 `alpha` / `bias` 按同一行公式重算：

```
h_pre_logits  = r * proj[..., :n]   * alpha_pre  + bias[:n]
h_post_logits = r * proj[..., n:2n] * alpha_post + bias[n:2n]
```

与 `_compute_h` 的实现耦合一行公式，模型侧改动时必须同步（docstring 与 docs 已标注）。

**Eq. (7) 静态参数（9 条，冷路径）**

- `alpha_pre` / `alpha_post` / `alpha_res`
- `bias_pre_mean` / `bias_pre_abs_max`
- `bias_post_mean` / `bias_post_abs_max`
- `bias_res_mean` / `bias_res_abs_max`

`bias` 是单个 `[n^2 + 2n]` 参数，按切片 `[:n]` / `[n:2n]` / `[2n:]` 对应论文的`b^pre` / `b^post` / `b^res`，因此分片统计而不是合成一个数。

## 采集时机

参数类 9 条是 step 级量（参数只在 `optimizer.step()` 改，梯度累积的各 microbatch 读到的是同一个值），在 `on_optimizer_begin`（optimizer step **之前**）读一次：

- 避开热路径——若按 microbatch 记，43 层 × 2 component × 16 microbatch × 9 ≈ 1.2 万次无信息量的 kernel launch；
- 读到的值与本 step forward 实际使用的参数一致。`on_step_end` 在 optimizer step 之后，走`_flush_buffers` 兜底路径时记到的是更新后的值，会比同 step 其余曲线晚一次更新。

`_captured_this_step` 保证只在跑过被监控 forward 的 step 记录，使参数曲线与激活曲线在`monitor_interval > 1` 时落在同一批 step 上（flush 时不能用 `_should_monitor()`：`step()` 已先`step_count += 1`，答案偏一拍）。两条路径都调也只记一次。

## 其他

- 命名用 `bias_*_abs_max` 而非 `bias_*_absmax`：`training_logs` 的 max/min 分类器按 `_max`后缀字面匹配，`absmax` 匹配不上会退化成 mean 平滑。
- 参数在 TP 各 rank 上是同一份副本（`HyperConnectionModule` 用普通 `nn.Linear`，参数标`is_distributed=False`），无需任何 collective。
- megatron 后端未改动，仍为 16 条。

## 测试

新增 7 个单测：公式对齐、饱和场景（`sigmoid` 求逆会失效而本实现不会）、`bias` 切片、从 `_compute_h` 入参记录、无 `proj` 时留空不写值、一步只记一次、optimizer 更新前读取。

`INTERNAL_MEDICINE_TEST_BACKEND=all` 全量 318 passed，`pre-commit run --all-files` 通过。