### PR TITLE
add mhc vector metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
-- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 29 指标，megatron 后端 16 指标；仅在开启 mHC 层时生效)
+- **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 29 标量指标 + `n²+2n` 条逐元素映射序列，megatron 后端 16 指标；仅在开启 mHC 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 - **APE Health** — CSA/HCA compressor APE 参数健康监控 (P0 级 7 指标；仅 paddlefleet)
 - **Attn Update** — QK 乘积增量 `Δ₂ = ΔW_q W_kᵗ + W_q ΔW_kᵗ` / `Δ₃ = ΔW_q ΔW_kᵗ` 的谱监控 (每项 3 指标；仅权重，不挂 forward hook)
@@ -473,6 +473,20 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 
 `{c}` ∈ `{attn, mlp}`。第 21-29 条是 step 级参数量，在 `on_optimizer_begin`（optimizer step 之前）读一次参数，
 不在热路径，且仅在本 step 确实跑过被监控的 forward 时记录。
+
+除上述 29 个标量外，paddlefleet 后端还额外产出 **每元素展开的映射序列**（`n² + 2n` 条 / hc 模块，`n = 4` 时 24 条，
+每层两个模块共 48 条）——即把 `h_res` 的 4×4 矩阵和 `h_pre` / `h_post` 两条 n 维向量逐元素记录，供还原论文
+Figure 10 那类映射热图使用：
+
+| 指标 | 日志键 | 公式 | 级别 | 诊断意义 |
+|------|--------|------|------|----------|
+| `{c}_h_res_cell{k}` | `mhc_health/layer_{i}/{c}_h_res_cell{k}` | `mean_t(h_res[t, r, c])`，`k = r·n + c` 行主序 | 仅每层 | 残差混合矩阵的单个 cell。`h_res` 按 `compute_mappings` 返回的朝向记录（与 `amax_gain_fwd` 读的列和同一朝向，**非** composite 链式用的转置） |
+| `{c}_h_pre_idx{j}` | `mhc_health/layer_{i}/{c}_h_pre_idx{j}` | `mean_t(h_pre[t, j])` | 仅每层 | 第 `j` 条流的聚合门开度 |
+| `{c}_h_post_idx{j}` | `mhc_health/layer_{i}/{c}_h_post_idx{j}` | `mean_t(h_post[t, j])` | 仅每层 | 第 `j` 条流的扩展门开度 |
+
+这三组走 `declare_layer_vector` / `record_layer_vector`：
+热路径上每个映射只有一次 `add_`，而不是每个元素一个 kernel；并且**不派生 `global_*` 键**——单个 cell 在
+43 层上的均值没有判读意义。`log_per_layer=False` 时这三组整体不产出。
 
 指标公式、采集路径、健康判读及论文 composite 定义统一维护在
 [`docs/mhc_health.md`](docs/mhc_health.md)，README 不再重复展开。

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -70,6 +70,45 @@ wrapper 不保留任何跨调用状态，只有固定的 0 维累加器。规则
 （并在 flush 时对 microbatch/rank 求均值）。日志键形如 `mhc_health/layer_{i}/{c}_{name}`，
 `{c}` ∈ `{attn, mlp}`；对应的 `mhc_health/global_{c}_{name}` 由逐层累加器在 flush 时自动派生。
 
+此外还有一组**逐元素展开的映射序列**（`n² + 2n` 条 / hc 模块），见下方「逐元素映射序列」。
+
+### 逐元素映射序列（h_res cell / h_pre、h_post per-stream）
+
+上面 29 个标量都是对 `h_res` / `h_pre` / `h_post` 做了某种聚合（均值、极值、行列和）之后的读数，
+因此无法回答「矩阵长什么样」——例如 `h_res` 是否退化成近似单位矩阵（各流互不混合）、还是某一列吸走了
+全部质量。论文 Figure 10 那类映射热图需要的是矩阵本身，所以这组指标把三个映射**逐元素**记录下来：
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `{c}_h_res_cell{k}` | `mean_t( h_res[t, r, c] )`，`k = r·n + c`（行主序） | 残差混合矩阵的单个 cell。对角元 = 该流的自我保留，非对角元 = 跨流混合 |
+| `{c}_h_pre_idx{j}` | `mean_t( h_pre[t, j] )` | 第 `j` 条流的聚合门开度 |
+| `{c}_h_post_idx{j}` | `mean_t( h_post[t, j] )` | 第 `j` 条流的扩展门开度 |
+
+**朝向**：`h_res_cell{k}` 记录的是 `compute_mappings` 返回的 `h_res` 本身，即与 `amax_gain_fwd`
+读列和时同一个朝向，**不是** composite 乘积链用的 `h_resᵀ`（见「amax-gain」一节）。读热图时
+行索引 `r = k // n`、列索引 `c = k % n`；按本文档的约定，**列**和是前向增益、**行**和是反向增益。
+
+**行/列和不必单独出指标**：mHC 的 `h_res` 经 Sinkhorn 投影后是双随机矩阵，行和与列和恒为 1
+（这也是 `amax_gain_{fwd,bwd}` 作为不变量守卫的依据）。论文 Figure 10 里标在 HC 那一行的
+forward/backward gain 之所以有信息量，是因为原始 HC 的映射没有这个约束；mHC 这一行标的就是 1.00。
+
+**实现方式**：这三组走 `declare_layer_vector` / `record_layer_vector`（与 `moe_health` 的 per-expert
+占比同一机制），而不是 `n² + 2n` 次 `record_layer_metric`。两个后果：
+
+- 热路径上每个映射只有一次向量 `add_`。若逐元素标量记录，`n = 4` 时每个模块每 microbatch 要多 24 次
+  kernel launch，43 层 × 2 模块 × 16 microbatch ≈ 33k 次/step，直接违反
+  `.claude/skills/monitor-hook-perf-rules` 的启动预算。
+- 向量指标**不参与 `global_*` 派生**：单个 cell 在 43 层上求均值没有判读意义。跨层视图交给 viewer
+  自己从各层曲线汇总。
+
+`h_res` 的 token 均值本来就要为 composite 乘积算一次（`_h_res_snapshot`），这组指标复用同一个 reduce，
+只多出一次 transpose 之外的 reshape，没有额外的归约开销。
+
+`log_per_layer=False` 时这三组整体不产出（`declare_layer_vector` 直接 return）。
+key 数量：`n = 4`、43 层、2 模块 = 2064 条逐层序列，是本 monitor 标量部分（29 × 2 × 43 ≈ 2494）的同量级。
+`cell` / `idx` 这两个 tag 刻意选了任何标量指标名都不含的词——`_s{j}` 会和已有的 `h_pre_std` 共享前缀，
+`_stream{j}` 会和 `h_post_stream_concentration` 冲突，都会破坏下游按前缀分组的逻辑。
+
 ### 门控统计（h_pre / h_post）
 
 | 指标 | 公式 | 诊断意义 |

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -108,6 +108,11 @@ _PARAM_METRICS = (
     "bias_res_abs_max",
 )
 
+def _vector_metric_specs(n: int) -> tuple[tuple[str, str, int], ...]:
+    """``(metric_name, elem_tag, size)`` for the per-element mapping series."""
+    return (("h_res", "cell", n * n), ("h_pre", "idx", n), ("h_post", "idx", n))
+
+
 # Extrema, not means: a worst case that a mean over 43 layers would bury. The
 # `_max` / `_min` suffixes keep training_logs' classifier in agreement on the
 # full key too.
@@ -270,9 +275,14 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             entries = self._find_hc_modules(chunk)
             if not entries:
                 continue
-            for global_idx, comp, _ in entries:
+            for global_idx, comp, mod in entries:
                 for name in _METRIC_NAMES:
                     self.declare_layer_metric(global_idx, f"{comp}_{name}")
+                # `n` is static module metadata, so reading it at declare time
+                # costs no hot-path sync and keeps the schema fixed (Rule 3).
+                for name, tag, size in _vector_metric_specs(int(getattr(mod, "n", 0) or 0)):
+                    if size > 0:
+                        self.declare_layer_vector(global_idx, f"{comp}_{name}", size, elem_tag=tag)
             all_targets.append(entries)
         return all_targets
 
@@ -478,11 +488,20 @@ class PaddleMHCHealthMonitor(PaddleProbe):
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_fwd", amax_gain(h_res, axis=-2))
                     self.record_layer_metric(layer_idx, f"{component}_amax_gain_bwd", amax_gain(h_res, axis=-1))
 
-                    # Token-mean snapshot of the *operator* for the composite product.
+                    # Token-mean of every mapping element. One reduce feeds both
+                    # the per-cell series and the composite product's snapshot.
                     n = int(h_res.shape[-1])
-                    self._h_res_snapshot[(layer_idx, component)] = (
-                        h_res.astype("float32").reshape([-1, n, n]).mean(axis=0).transpose([1, 0])
+                    res_mean = h_res.astype("float32").reshape([-1, n, n]).mean(axis=0)
+                    self.record_layer_vector(layer_idx, f"{component}_h_res", res_mean.reshape([-1]))
+                    self.record_layer_vector(
+                        layer_idx, f"{component}_h_pre", h_pre.astype("float32").reshape([-1, n]).mean(axis=0)
                     )
+                    self.record_layer_vector(
+                        layer_idx, f"{component}_h_post", h_post.astype("float32").reshape([-1, n]).mean(axis=0)
+                    )
+
+                    # Token-mean snapshot of the *operator* for the composite product.
+                    self._h_res_snapshot[(layer_idx, component)] = res_mean.transpose([1, 0])
             except Exception as e:
                 if self.verbose:
                     logger.error(f"[PaddleMHCMonitor] Error layer {layer_idx}/{component}: {e}")

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -1,4 +1,5 @@
 import importlib
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -322,6 +323,62 @@ class MHCMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["mhc_health/global_attn_amax_gain_bwd"], 1.0, places=5)
         self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_fwd_max"], 1.5, places=5)
         self.assertAlmostEqual(latest["mhc_health/global_attn_composite_amax_gain_bwd_max"], 1.0, places=5)
+
+    def test_per_element_mapping_series_are_recorded_row_major(self):
+        # The n^2 + 2n per-element curves. An asymmetric h_res pins the layout:
+        # cell{i} is row-major over h_res *as compute_mappings returns it*, so a
+        # stray transpose (the orientation the composite product needs) would
+        # swap cell1 and cell2.
+        n, s, b = 2, 2, 3
+        h_res = paddle.to_tensor([[0.1, 0.2], [0.3, 0.4]]).reshape([1, 1, n, n]).expand([s, b, n, n])
+        hc = FakeHC(
+            n=n,
+            h_pre=paddle.to_tensor([0.25, 0.75]).reshape([1, 1, n]).expand([s, b, n]),
+            h_post=paddle.to_tensor([1.0, 2.0]).reshape([1, 1, n]).expand([s, b, n]),
+            h_res=paddle.assign(h_res),
+        )
+        model = _mhc_model([FakeLayer(attn=hc, mlp=hc)])
+
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            for i, expected in enumerate((0.1, 0.2, 0.3, 0.4)):
+                key = f"mhc_health/layer_0/{comp}_h_res_cell{i}"
+                self.assertIn(key, latest)
+                self.assertAlmostEqual(latest[key], expected, places=5)
+            for j, (pre, post) in enumerate(((0.25, 1.0), (0.75, 2.0))):
+                self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_idx{j}"], pre, places=5)
+                self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_idx{j}"], post, places=5)
+
+        # Vector metrics must not spawn `global_*` keys: the mean of one cell over
+        # layers has no reading, and the flush-time derivation would emit it.
+        self.assertNotIn("mhc_health/global_attn_h_res_cell0", latest)
+        # The composite product still reads the transposed operator, unchanged by
+        # sharing the token-mean reduce with the new series.
+        self.assertIn("mhc_health/layer_0/attn_composite_amax_gain_fwd_max", latest)
+
+    def test_per_element_series_count_matches_n(self):
+        n, s, b = 4, 2, 3
+        model = _mhc_model([self._identity_layer(n, s, b)])
+        monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+        targets = self._prepare_and_attach(monitor, model)
+        self._drive(targets, x_dim=n * 8)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        # Exact `<tag><digits>` suffixes, not a substring test: `_h_pre_s` would
+        # also catch the scalar `h_pre_std`, which is what the `idx` tag avoids.
+        elem_re = re.compile(r"_(?:h_res_cell|h_pre_idx|h_post_idx)\d+$")
+        for comp in ("attn", "mlp"):
+            for tag, expected in (("h_res_cell", n * n), ("h_pre_idx", n), ("h_post_idx", n)):
+                found = [k for k in latest if re.search(rf"/{comp}_{tag}\d+$", k)]
+                self.assertEqual(len(found), expected, tag)
+        # 2 components x (n^2 + 2n) = 48 new per-layer keys at n=4.
+        self.assertEqual(len([k for k in latest if elem_re.search(k)]), 48)
 
     def test_logits_gradient_extrema_are_unscaled_without_changing_backward(self):
         n, s, b = 2, 1, 1


### PR DESCRIPTION
## 背景

现有 mHC monitor 的 29 个标量指标都是对 `h_res` / `h_pre` / `h_post` 做过聚合（均值、极值、行列和）
之后的读数，回答不了「矩阵长什么样」——`h_res` 是否退化成近似单位矩阵（各流互不混合），还是某一列
吸走了全部质量。论文 Figure 10 那类映射热图需要矩阵本身。

## 改动

paddlefleet 后端在 29 个标量之外，额外产出**逐元素展开的映射序列**（`n² + 2n` 条 / hc 模块，
`n=4` 时 24 条，每层两个模块共 48 条）：

- `{c}_h_res_cell{k}` —— `mean_t(h_res[t, r, c])`，`k = r·n + c` 行主序
- `{c}_h_pre_idx{j}` / `{c}_h_post_idx{j}` —— 各流的聚合门 / 扩展门开度

实现要点：

- 走 `declare_layer_vector` / `record_layer_vector`（同 `moe_health` 的 per-expert 占比机制），
  热路径上每个映射只有一次向量 `add_`。若逐元素标量记录，`n=4` 时 43 层 × 2 模块 × 16 microbatch
  ≈ 33k 次 kernel launch/step，违反 `monitor-hook-perf-rules` 的启动预算。
- 复用 composite 乘积本来就要算的 `_h_res_snapshot` token-mean reduce，只多一次 reshape，
  无额外归约开销。
- 向量指标**不派生 `global_*`**：单个 cell 在 43 层上求均值没有判读意义。
- `n` 在 declare 时从模块元数据读取，热路径无同步、schema 固定。
- `log_per_layer=False` 时整体不产出。
- `cell` / `idx` 两个 tag 刻意避开已有标量名前缀（`_s{j}` 会撞 `h_pre_std`，`_stream{j}` 会撞
  `h_post_stream_concentration`），以免破坏下游按前缀分组。

朝向按 `compute_mappings` 返回的 `h_res` 本身记录（与 `amax_gain_fwd` 读列和同朝向），
**不是** composite 链用的转置。

同步更新 `README.md` 与 `docs/mhc_health.md`。

## 验证

`python -m pytest tests/test_mhc_paddlefleet_monitor.py -q` → **38 passed**，其中新增两例：

- `test_per_element_mapping_series_are_recorded_row_major` —— 用非对称 `h_res` 钉住行主序布局，
  误加转置会让 cell1/cell2 互换；同时断言 `global_attn_h_res_cell0` 不存在、composite 读数不变。
- `test_per_element_series_count_matches_n` —— `n=4` 时精确匹配 `<tag><digits>` 后缀，校验 48 条新键。

## 影响面

仅新增监控指标，不改动训练数值逻辑与前反向计算。`_h_res_snapshot` 的取值与转置朝向保持不变
（已由 composite 用例覆盖）。新增逐层键 `n=4`、43 层、2 模块 = 2064 条，与本 monitor 标量部分
（29 × 2 × 43 ≈ 2494）同量级。