### PR TITLE
feat(paddlefleet): 新增 kda_health 监控模块

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 训练时模型健康的实时监控框架，通过 forward hook 零侵入式采集指标，不影响训练梯度。
 
-包含九大监控模块：
+包含十大监控模块：
 - **[MoE Health](./docs/moe_specialist.md)** — MoE 专家系统健康监控 (13 指标)
 - **[QK Stats](./docs/qk_logits.md)** — 注意力 QK 统计监控 (9 指标 + CSA/HCA 层 2 项)
 - **[Massive Activation Health](./docs/massive_activation.md)** — Residual Stream Massive Activation 健康监控 (20 指标)
 - **[PLE Health](./docs/ple_health.md)** — Per-Layer Embedding 健康监控 (7 指标)
 - **[mHC Health](./docs/mhc_health.md)** — Manifold-Constrained Hyper-Connections 映射监控 (每 hc 模块 14 指标；仅在开启 mHC 层时生效)
+- **[KDA Health](./docs/kda_health.md)** — Kimi Delta Attention 线性注意力层的衰减/写入/读出三通路监控 (8 指标；仅 paddlefleet；仅在模型含 KDA 层时生效)
 - **VHA Health** — Virtual Head Attention 的 Q Premix (近恒等虚拟头扩展) 与 Linear Postmix (`I + A Bᵗ` 低秩跨头融合) 结构监控 (仅 paddlefleet；仅在 `use_vha_attention` 时生效)
 - **APE Health** — CSA/HCA compressor APE 参数健康监控 (P0 级 7 指标；仅 paddlefleet)
 - **Attn Update** — QK 乘积增量 `Δ₂ = ΔW_q W_kᵗ + W_q ΔW_kᵗ` / `Δ₃ = ΔW_q ΔW_kᵗ` 的谱监控 (每项 3 指标；仅权重，不挂 forward hook)
@@ -140,7 +141,7 @@ setup_internal_medicine()
 {monitor_name}/global_{metric_name}                     # 全局聚合指标
 ```
 
-- `monitor_name`: `ape_health` | `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health` | `attn_update` | `mlp_update`
+- `monitor_name`: `ape_health` | `moe_health` | `qk_stats` | `massive_act` | `ple_health` | `mhc_health` | `vha_health` | `attn_update` | `mlp_update` | `kda_health`
 - `global_idx`: 全局层索引。优先取模块自带的 `layer.layer_number`（0-based 全局编号）；取不到时回退到
   `pp_rank × local_layers + local_idx`。`num_empty_layers_add_in_head > 0` 时所有层号整体偏移该值，看板对号要减掉
 - `_mtp`: 仅 MTP layer 带有的层类型标记，随指标走现有聚合和日志链路

--- a/docs/kda_health.md
+++ b/docs/kda_health.md
@@ -1,0 +1,184 @@
+# KDA Health Monitor
+
+监控 KDA (Kimi Delta Attention) 层的健康状况。KDA 是一个**固定容量的联想记忆**：状态
+`S_t ∈ R^{d_k × d_v}` 不随序列增长，全部历史都压在里面。
+
+```
+S_t = (I - β_t k_t k_tᵀ) Diag(α_t) S_{t-1} + β_t k_t v_tᵀ,     õ_t = S_tᵀ q_t
+```
+
+它由三条通路支撑，缺一条这层就不再做序列建模：
+
+| 通路 | 由谁控制 | 功能 |
+|------|----------|------|
+| **衰减** | `α_t ∈ (0,1)^{d_k}`，channel-wise | 每个 key 通道的记忆时间尺度。channel-wise 的功能目的是让同一头内不同通道承担不同时间尺度，短程与长程信息共存而不互相冲刷 |
+| **写入** | `β_t ∈ (0,1)` | delta rule 的写入强度，即 `S` 朝 `k_t ↦ v_t` 自我纠正的步长 |
+| **读出** | `Sigmoid(W_g x_t)` 输出门 + head-wise RMSNorm | `õ_t` 有多少进入残差流 |
+
+衰减门的映射（fp32，`kda_gate`）：
+
+```
+g = lower_bound · Sigmoid(exp(A_log) · (z + dt_bias))      # gate_lower_bound 已设置
+g = -exp(A_log) · Softplus(z + dt_bias)                    # gate_lower_bound = None
+α = exp(g)
+```
+
+`z` 是 `f_b_proj` 输出的 raw decay logit。时间尺度 `τ ≈ -1/g`（token 数）。
+
+---
+
+## 开关与 no-op 保证
+
+通过在 `internal_medicine_monitors` 中加入 `kda_health`（或 `all`）启用。启用它在**任何**模型上都是安全的——
+以下任一情况下它彻底 no-op（不挂 hook、不声明/产生任何指标、不抛异常）：
+
+1. **模型未使用 KDA 层**：`is_kda_layer` 检查 token mixer 上是否同时存在 `f_b_proj` 与
+   `gate_lower_bound` 两个属性——这两个属性在整个 paddlefleet 里只出现在 `kimi_delta_attention.py`。
+   与 `layer_discovery` 里其它 attention 的判定风格一致，不 import 生产类，因此模块被移动或重命名
+   时也不会静默退化成"发现不到任何 KDA 层"。
+2. **不会误判 GDN**：GDN 是可选的 `attention_layer_type`，与 KDA 共用 `A_log` / `dt_bias` /
+   `conv1d` / `in_proj`，所以判定必须用这两个 KDA 独有属性，而不是任何单个通用属性。
+   用 `hasattr` 而非真值判断：`gate_lower_bound=None` 是合法配置（选择无下界的 softplus gate）。
+
+```yaml
+internal_medicine_monitors:
+    kda_health: true
+```
+
+---
+
+## 采集方式：两个 forward post hook + 一次参数读取
+
+`α` / `β` / `gate` 都是 `KimiDeltaAttention.forward` 的**局部变量**，不在任何子模块的返回里，
+但都能从产生它们的投影上拿到：
+
+| 采集点 | 拿到什么 | 用于 |
+|--------|----------|------|
+| `attn.f_b_proj` | raw decay logit `z`，`[b,s,v_dim]`（SP 下 `[s,b,v_dim]`） | 衰减 4 项 + `A_log_mean` |
+| `attn.in_proj` | `qkvbz`，按 `[qkv \| beta \| gate]` 切分 | 写入 2 项 + 读出 1 项 |
+| `attn.g_b_proj` | 低秩输出门的 logit（仅 `use_full_rank_gate=False` 时挂） | 读出 1 项 |
+
+`beta` 与 `gate` 都是 **pre-sigmoid logit**（sigmoid 折进 kernel，`use_beta_sigmoid_in_kernel=True`），
+监控侧补 `sigmoid`，fp32。`g` 用 `kda_metrics.kda_log_decay` 在 `no_grad` 下对 detach 后的 `z` 重算，
+公式与 `kimi_delta_attention.kda_gate` 逐字对齐；门的形式（`safe_gate` / `lower_bound`）从层上读，
+**不硬编码 `-5.0`**，所以 `gate_lower_bound=None` 的配置也按它自己的口径测量。
+
+**不挂 `conv1d`**：`use_fused_kernels` 为真时走 `causal_conv1d` 函数而非 `self.conv1d.forward`，hook 挂不上；
+L2Norm 也折进了 kernel。所以 conv / q / k 的**激活**幅度在 fused 路径上根本不可达。
+
+**不 wrap 任何绑定方法**，因此没有 recompute 重放去重、也没有 `RecomputeWithoutOutput` 的显存持有约束
+需要论证。热路径纪律见 `.claude/skills/monitor-hook-perf-rules`：hook 内无 D2H 同步、无集合通信，
+schema 在 `allocate_buffers` 前一次性声明。
+
+---
+
+## 监控指标
+
+每层 8 个指标，按上面三条通路 + 一个归因参数组织。日志键形如
+`kda_health/layer_{i}/{attn_type}_{name}`，KDA 层的 `{attn_type}` 是 `kda`；对应的
+`kda_health/global_{attn_type}_{name}` 由逐层累加器在 flush 时自动派生。
+
+**三条硬性设计约束**（这套指标只有 8 项，是这三条筛出来的结果）：
+
+1. **不引入拍出来的阈值。** 任何 `mean(1[x < thr])` 形式的比例指标都要求先知道真实分布才能定 `thr`，
+   定偏了就恒为 0 或恒为 1。一条都没有。
+2. **不依赖被监控方的内部实现常量。** kernel 的 `chunk_size=64`、sub-chunk `BC=16` 是实现细节而非配置项；
+   指标定义里出现这类常量，kernel 一改指标就静默失效——读数照出、含义已错，比没有指标更糟。
+3. **极值只在结构轴（head / channel）上取，绝不在 token 轴上取。**先沿 token 轴平均消掉样本量的影响，
+   再沿结构轴取极值。理由：min/max 累加器跨整个 optimizer step 的全部 microbatch，token 轴样本量随梯度
+   累积步数增长，而 `g ∈ (g_min, 0)`、`σ(β) ∈ (0,1)` 都是**有界量**，样本一多必然饱和到边界变成恒定读数。
+   结构轴的宽度（head 数、channel 数）是固定的。
+
+### 通路一：衰减 —— 记忆时间尺度（4 项）
+
+回答：状态记得住东西吗？记多久？通道之间有分工吗？门还在看输入吗？最陡的通道有多陡？
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `alpha_log_mean` | `mean(g)` | 时间尺度的**中心位置**，记忆寿命的总量指标。趋 `g_min` = 状态每步几乎清空，`S` 退化成只看最近一两个 token 的局部窗口，固定容量的联想记忆白搭；趋 `0` = 从不遗忘，历史 kv 关联无限累积进固定大小的 `S`，必然过载互相干扰。重点看漂移趋势而非绝对值 |
+| `alpha_channel_spread` | `mean_{t,h}( std_d(g[t,h,:]) )` | 时间尺度的**跨通道多样性**。channel-wise 门的功能目的就是让通道承担不同时间尺度；→0 意味着整个头塌到单一时间尺度，短程与长程信息共用一个衰减率、互相冲刷。**不可替代**——`alpha_log_mean` 对"全通道同一个值"和"通道间分散但均值相同"完全不可分 |
+| `alpha_token_spread` | `std_t( mean_{h,d} g )` | 衰减门的**输入敏感性**。`α` 是 data-dependent 的，这是 KDA 能"按内容决定记多久"的全部来源；→0 说明门与当前 token 解耦、退化成常数衰减的固定线性 RNN。与前两项正交：门冻结时均值和通道分散度都可以保持正常 |
+| `alpha_log_channel_min` | `min_{h,d}( mean_t g )`，按 **min** 归约 | **最陡衰减通道**的平均 log 保留率。两个作用：(a) 时间尺度分布的左端位置，与 `alpha_log_mean` 一起给出分布跨度；(b) chunkwise 数值风险的输入量——intra-chunk 计算要把 key 按倒数累计衰减 `1/Γ` 重新缩放，这一项越负、倒数放大越剧烈。**故意不乘任何 tile 长度**（约束 2）：要估溢出余量时，用当时 kernel 的实际 tile 跨度乘一下，再和 BF16 上限 `ln ≈ 88.7` 比 |
+
+### 通路二：写入（2 项）
+
+回答：新信息还在往状态里写吗？有没有 head 整体停写？
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `beta_mean` | `mean(σ(β))` | delta rule 的平均写入步长。与 `alpha_log_mean` 一起构成"写入 vs 衰减"的收支平衡——写入远小于衰减时状态趋于空，远大于时状态被单 token 主导 |
+| `beta_head_min` | `min_h( mean_t σ(β) )`，按 **min** 归约 | 写入最弱 head 的平均步长。`β→0` 时 `S_t ≈ Diag(α) S_{t-1}`，该 head 只在衰减旧状态、不再写入新 kv 关联，它的序列混合彻底失效。**`beta_mean` 发现不了这件事**：96 个 value head 里 6 个停写、其余在 0.5，`beta_mean` = 0.469，相对健康态只降 6%，在图上与正常波动分不开。先对 token 平均再取 head 最小（约束 3），所以不会被单个 outlier token 拉到 0 |
+
+### 通路三：读出（1 项）
+
+| 指标 | 公式 | 诊断意义 |
+|------|------|----------|
+| `out_gate_mean` | `mean(σ(gate))` | 输出门开度。前两条通路全部正常、这一项趋 0，则状态算得再好也不进残差流，整层的计算被丢弃 |
+
+### 归因参数（1 项）
+
+| 指标 | 诊断意义 |
+|------|----------|
+| `A_log_mean` | per-head log-scale `A`。`exp(A)` 直接乘在门的 sigmoid 输入上，是通路一异常的**归因入口**：`alpha_log_mean` 或 `alpha_log_channel_min` 漂移时，先分清是 `z` 的分布变了还是 `A` 把整条 sigmoid 拉陡了。它是参数读取，无需自己的 hook，挂在衰减 hook 里以保持同一采集节奏 |
+
+### 归约方式
+
+| 归约 | 指标 |
+|------|------|
+| mean（6 项） | `alpha_log_mean`、`alpha_channel_spread`、`alpha_token_spread`、`beta_mean`、`out_gate_mean`、`A_log_mean` |
+| **min**（2 项） | `alpha_log_channel_min`、`beta_head_min` |
+
+两个 min 指标的名字都以 `_min` 结尾，因此 `PaddleProbe.MIN_AGGREGATED` 与
+`training_logs._is_min_metric` 的判定天然一致（有回归测试守这条命名契约）——不一致会让跨 rank 聚合
+把本该取 min 的量做成平均。
+
+---
+
+## 并行与重算
+
+**TP**：KDA 沿 head 维切分（`num_key_heads % tp == 0`、`num_value_heads % tp == 0`），
+`α` / `β` / `gate` / conv 全部按 head 切。所以：
+
+- mean 类：每 rank 观测到相同数量的样本（等分 head × 相同 token 数），flush 时 `gather_and_aggregate`
+  对 per-rank mean 求平均是数学正确的。
+- min 类：极值取在**本 rank 的 head/channel 子集**上，flush 时的全局 min 正好等于全局结构轴上的 min。
+
+八项指标全部落在这两类里，**零 hook 内通信、零 flush 通信**。（`dt_bias` 是 per-channel 且
+`is_distributed`，本地 absmax ≠ 全局，所以 `dt_bias_absmax` 这类指标暂未纳入——它会引入 flush 时的
+跨 TP 归约。）
+
+**SP**：`config.sequence_parallel` 时 `in_proj` / `f_b_proj` 的输出是 `[s/tp, b, dim]`，
+forward 里才转回 `[b, s, dim]`。本 monitor 的统计全是 elementwise + 全局 reduce，对 s/b 轴顺序不敏感；
+`_as_tokens` 按**尾维**展平而不依赖前两维的含义，所以两种布局都正确。
+
+**CP**：`cp_size > 1` 时 KDA 强制 `batch == 1` 且要求 contiguous 切分。每 rank 只看到自己那段 token，
+等长，mean 仍正确；两个 min 指标先在本 rank token 段上求平均再取结构轴极值，跨 rank min 得到的是
+"各 rank token 段平均后的最坏 head/channel"——与"全序列平均后取最坏"不完全等价（同一个 head 在各 rank
+被分别取 min），但等长切分下偏差是二阶的，且方向保守，读数不会比真值更乐观。
+
+**重算**：两个 hook 挂在 `in_proj` / `f_b_proj` 上，不在 `recompute_rms_norm_gated` 的选择性重算段内。
+`_should_monitor()` 的 grad 门（`PaddleProbe`）在 `recompute_granularity="full"` 时会跳过 `no_grad`
+下的真前向、在反向重放时采集；本 monitor 没有任何依赖执行顺序的指标，所以不需要额外排序或去重。
+
+**MTP**：discovery 走 `iter_monitor_layers` + `mark_mtp_layers`，MTP KDA 层的 key 自动带 `_mtp` 后缀。
+
+---
+
+## 与 KDA–MLA 混合栈的层标签
+
+Kimi-Linear / K3 是 3 KDA + 1 全局注意力的交错结构。`layer_discovery` 为这类栈补了第三条 `attn_type`
+规则（原有两条是 `csa_compress_ratios` 与 `sliding_window`，KDA 混合栈两条都不满足）：
+
+- KDA 层 → `"kda"`
+- 同栈的全局层 → `"mla"`（`MQALatentAttention`）或 `"global"`（其他）
+
+全局层的标签在 `iter_monitor_layers` 里赋予，因为那是唯一能看到整个栈的地方：单看一层无法区分
+"KDA 混合栈里的全局层"（必须打标签，否则和 KDA 层共用一张图）和"同质栈里的普通层"（必须保持不打标签，
+否则存量 run 丢 metric key）。检测扫描**完整层列表**而非 `matches` 筛过的子集——`qk_stats` 主动排除了
+KDA 层，若只看子集它就看不到任何 `"kda"`，同一个物理层会因 monitor 不同而带不同的 key。
+
+没有这条规则时，KDA 层和全局层的 `massive_act` / `moe_health` / `mlp_update` 统计会混进同一张图。
+
+`qk_stats` 的 discovery 也相应排除了 KDA 层：KDA 是线性注意力，没有 QK logits、没有 softmax、
+没有 `core_attention` 可挂。此前它会通过 `has_attention` 谓词、声明完整 schema，然后永远不记录任何值
+（hook 只在 `core_attention` 存在时才挂），每个 KDA 层白占十几个永远为空的累加器。

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -6,6 +6,7 @@ from .ape_monitor import PaddleAPEHealthMonitor, setup_ape_monitor
 from .attn_update_monitor import PaddleAttnUpdateMonitor, setup_attn_update_monitor
 from .base import PaddleProbe
 from .gather import install_gather_fn
+from .kda_monitor import PaddleKDAHealthMonitor, setup_kda_monitor
 from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_massive_activation_monitor
 from .mhc_monitor import PaddleMHCHealthMonitor, setup_mhc_monitor
 from .mlp_update_monitor import PaddleMLPUpdateMonitor, setup_mlp_update_monitor
@@ -24,6 +25,7 @@ _MONITOR_MAP = {
     "vha_health": setup_vha_monitor,
     "attn_update": setup_attn_update_monitor,
     "mlp_update": setup_mlp_update_monitor,
+    "kda_health": setup_kda_monitor,
 }
 
 _MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
@@ -137,4 +139,6 @@ __all__ = [
     "setup_attn_update_monitor",
     "PaddleMLPUpdateMonitor",
     "setup_mlp_update_monitor",
+    "PaddleKDAHealthMonitor",
+    "setup_kda_monitor",
 ]

--- a/src/internal_medicine/backends/paddlefleet/kda_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/kda_metrics.py
@@ -1,0 +1,104 @@
+"""KDA (Kimi Delta Attention) metric compute functions.
+
+Pure, stateless tensor helpers for the ``kda_health`` monitor, grouped by the
+pathway they measure: decay (``alpha``), write (``beta``), read (output gate).
+What each metric means is in ``docs/kda_health.md``.
+
+All functions return 0-dim GPU tensors and never sync the host (no ``.item()`` /
+``.cpu()``), so they are safe on a forward hot path. See
+``.claude/skills/monitor-hook-perf-rules``.
+"""
+
+import paddle
+
+DECAY_METRICS = (
+    "alpha_log_mean",
+    "alpha_channel_spread",
+    "alpha_token_spread",
+    "alpha_log_channel_min",
+)
+WRITE_METRICS = ("beta_mean", "beta_head_min")
+READ_METRICS = ("out_gate_mean",)
+PARAM_METRICS = ("A_log_mean",)
+
+#: Metric names reduced by min instead of mean, for ``Probe.MIN_AGGREGATED``.
+MIN_METRICS = frozenset({"alpha_log_channel_min", "beta_head_min"})
+
+ALL_METRICS = DECAY_METRICS + WRITE_METRICS + READ_METRICS + PARAM_METRICS
+
+
+def _as_tokens(x: paddle.Tensor, last_dim: int) -> paddle.Tensor:
+    """Flatten ``[..., last_dim]`` to ``[tokens, last_dim]``.
+
+    Keyed off the trailing dimension, not the leading ones: with
+    ``sequence_parallel`` the projections hand back ``[s, b, d]`` instead of
+    ``[b, s, d]``, and every statistic here pools both of those axes anyway.
+    """
+    return x.reshape([-1, last_dim])
+
+
+def kda_log_decay(
+    z: paddle.Tensor,
+    A_log: paddle.Tensor,
+    dt_bias: paddle.Tensor | None,
+    safe_gate: bool,
+    lower_bound: float | None,
+    num_heads: int,
+    head_dim: int,
+) -> paddle.Tensor:
+    """Raw decay logits -> per-step log decay ``g``, shaped ``[tokens, hv, dk]``.
+
+    Mirrors ``kimi_delta_attention.kda_gate`` in fp32. ``safe_gate`` /
+    ``lower_bound`` are read off the layer rather than hardcoded, so a run with
+    ``gate_lower_bound=None`` gets the unbounded softplus form it actually uses.
+    """
+    x = _as_tokens(z.astype("float32"), num_heads * head_dim).reshape([-1, num_heads, head_dim])
+    if dt_bias is not None:
+        x = x + dt_bias.astype("float32").reshape([num_heads, head_dim])
+    a = A_log.astype("float32").exp().reshape([num_heads, 1])
+    if safe_gate:
+        if lower_bound is None:
+            raise ValueError("safe_gate=True requires lower_bound to be set")
+        return lower_bound * paddle.nn.functional.sigmoid(a * x)
+    return -a * paddle.nn.functional.softplus(x)
+
+
+def decay_gate_stats(g: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Memory-time-scale statistics of the log decay ``g`` ``[tokens, hv, dk]``."""
+    g = g.astype("float32")
+    per_token = g.mean(axis=[-2, -1])
+    return {
+        "alpha_log_mean": g.mean(),
+        # std along the channel axis first, then pool tokens and heads: a std over
+        # everything at once cannot tell channel diversity from token variation.
+        "alpha_channel_spread": g.std(axis=-1).mean(),
+        # std over a length-1 axis is undefined; report 0 rather than NaN.
+        "alpha_token_spread": per_token.std() if per_token.shape[0] > 1 else paddle.zeros(()),
+        # Token-mean before the extremum, so one outlier token cannot pin the
+        # reading to the gate's bound. Same rule as beta_head_min below.
+        "alpha_log_channel_min": g.mean(axis=0).min(),
+    }
+
+
+def write_gate_stats(beta_logit: paddle.Tensor, num_heads: int) -> dict[str, paddle.Tensor]:
+    """Write-pathway statistics from the pre-sigmoid ``beta`` ``[..., hv]``.
+
+    The sigmoid is folded into the kernel (``use_beta_sigmoid_in_kernel=True``),
+    so it is applied here; fp32 matches the promotion the layer does first.
+    """
+    beta = paddle.nn.functional.sigmoid(_as_tokens(beta_logit.astype("float32"), num_heads))
+    return {
+        "beta_mean": beta.mean(),
+        "beta_head_min": beta.mean(axis=0).min(),
+    }
+
+
+def read_gate_stats(gate_logit: paddle.Tensor, gate_width: int) -> dict[str, paddle.Tensor]:
+    """Read-pathway statistic from the pre-sigmoid output gate."""
+    gate = paddle.nn.functional.sigmoid(_as_tokens(gate_logit.astype("float32"), gate_width))
+    return {"out_gate_mean": gate.mean()}
+
+
+def param_stats(A_log: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """Attribution parameter for the decay pathway: ``exp(A_log)`` scales the gate."""
+    return {"A_log_mean": A_log.detach().astype("float32").mean()}

--- a/src/internal_medicine/backends/paddlefleet/kda_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/kda_monitor.py
@@ -1,0 +1,244 @@
+"""KDA (Kimi Delta Attention) health monitor for PaddleFleet.
+
+Watches the three pathways that make KDA's fixed-capacity associative memory
+work - decay (``alpha``), write (``beta``), read (the output gate) - plus one
+attribution parameter. Eight metrics per layer; see ``docs/kda_health.md``.
+
+Collection is plain ``forward_post_hook``s plus one parameter read. None of
+``alpha`` / ``beta`` / the output gate is returned by any submodule
+(``KimiDeltaAttention.forward`` keeps them as locals), but all three are
+recoverable from the projections that produce them:
+
+- ``f_b_proj`` output is the raw decay logit ``z``
+- ``in_proj`` output packs ``[qkv | beta | gate]``; the last two are what we need
+  (``gate`` only when ``use_full_rank_gate``, otherwise it comes from ``g_b_proj``)
+
+Nothing here wraps a bound method, so there is no recompute-replay dedupe and no
+``RecomputeWithoutOutput`` lifetime constraint to reason about. Hot-path
+discipline: see ``.claude/skills/monitor-hook-perf-rules``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import paddle
+from paddle import nn
+
+from . import kda_metrics
+from .base import PaddleProbe
+from .layer_discovery import get_attention_module, get_decoder_layers, is_kda_layer, iter_monitor_layers
+
+logger = logging.getLogger(__name__)
+
+
+def _unwrap(output):
+    """PaddleFleet linear layers return ``(out, bias)``; take the tensor."""
+    if isinstance(output, (tuple, list)):
+        return output[0]
+    return output
+
+
+class PaddleKDAHealthMonitor(PaddleProbe):
+    """Monitor the decay / write / read pathways of KDA layers."""
+
+    METRIC_PREFIX = "kda_health"
+    MAX_AGGREGATED: set[str] = set()
+    MIN_AGGREGATED: set[str] = set(kda_metrics.MIN_METRICS)
+
+    def __init__(
+        self,
+        log_per_layer: bool = True,
+        log_global: bool = True,
+        monitor_interval: int = 1,
+        verbose: bool = False,
+        sample_layers: list[int] | None = None,
+    ):
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=monitor_interval,
+            verbose=verbose,
+        )
+        self.sample_layers = set(sample_layers) if sample_layers else None
+        self._failed_layers: set[int] = set()
+
+    # ------------------------------------------------------------------
+    # Setup: discover -> declare -> allocate -> attach
+    # ------------------------------------------------------------------
+
+    def _init_parallel_state(self):
+        try:
+            from paddlefleet.parallel_state import get_pipeline_model_parallel_rank
+
+            self.pp_rank = get_pipeline_model_parallel_rank()
+        except Exception:
+            pass
+
+    def _find_targets(self, model):
+        layers = get_decoder_layers(model)
+        if not layers:
+            return []
+
+        monitor_layers = iter_monitor_layers(layers, is_kda_layer, pp_rank=self.pp_rank)
+        mtp_layer_ids = [item.idx for item in monitor_layers if item.is_mtp]
+        if mtp_layer_ids:
+            self.mark_mtp_layers(mtp_layer_ids)
+
+        targets = []
+        for item in monitor_layers:
+            if self.sample_layers and item.idx not in self.sample_layers:
+                continue
+            targets.append((item.idx, get_attention_module(item.layer), item.attn_type))
+        return targets
+
+    def register_hooks(self, model: nn.Layer):
+        self._init_parallel_state()
+        targets = self._find_targets(model)
+        if not targets:
+            logger.info("[PaddleKDAMonitor] No KDA layers found; skipping.")
+            return
+
+        for layer_idx, _attn, attn_type in targets:
+            for name in kda_metrics.ALL_METRICS:
+                self.declare_layer_metric(layer_idx, name, attn_type=attn_type)
+
+        self.allocate_buffers()
+
+        for layer_idx, attn, attn_type in targets:
+            self.hooks.append(
+                attn.f_b_proj.register_forward_post_hook(self._make_decay_hook(layer_idx, attn, attn_type))
+            )
+            self.hooks.append(
+                attn.in_proj.register_forward_post_hook(self._make_in_proj_hook(layer_idx, attn, attn_type))
+            )
+            if not attn.use_full_rank_gate:
+                # Low-rank output gate: it never passes through in_proj.
+                self.hooks.append(
+                    attn.g_b_proj.register_forward_post_hook(self._make_gate_hook(layer_idx, attn, attn_type))
+                )
+
+        logger.info(f"[PaddleKDAMonitor] Registered {len(self.hooks)} hooks on {len(targets)} KDA layers.")
+
+    # ------------------------------------------------------------------
+    # Hooks (the hot path)
+    # ------------------------------------------------------------------
+
+    def _record(self, layer_idx: int, attn_type, stats: dict) -> None:
+        for name, value in stats.items():
+            self.record_layer_metric(layer_idx, name, value, attn_type=attn_type)
+
+    def _log_failure(self, layer_idx: int, exc: Exception) -> None:
+        if self.verbose and layer_idx not in self._failed_layers:
+            logger.error(f"[PaddleKDAMonitor] Error at layer {layer_idx}: {exc}")
+            self._failed_layers.add(layer_idx)
+
+    def _make_decay_hook(self, layer_idx: int, attn, attn_type):
+        """``f_b_proj`` output is the raw decay logit ``z``; derive ``g`` from it.
+
+        ``A_log`` is recorded here too: it is a parameter read, so it needs no hook
+        of its own, and piggybacking keeps it on exactly the same cadence as the
+        decay metrics it is meant to explain.
+        """
+
+        def hook(_layer, _input, output):
+            if not self._should_monitor():
+                return None
+            try:
+                z = _unwrap(output).detach()
+                with paddle.no_grad():
+                    g = kda_metrics.kda_log_decay(
+                        z,
+                        attn.A_log,
+                        attn.dt_bias,
+                        # Read the gate form off the layer, never hardcode -5.0:
+                        # gate_lower_bound=None selects the unbounded softplus form.
+                        safe_gate=attn.gate_lower_bound is not None,
+                        lower_bound=attn.gate_lower_bound,
+                        num_heads=attn.num_v_heads_local_tp,
+                        head_dim=attn.value_head_dim,
+                    )
+                    self._record(layer_idx, attn_type, kda_metrics.decay_gate_stats(g))
+                    self._record(layer_idx, attn_type, kda_metrics.param_stats(attn.A_log))
+            except Exception as exc:
+                self._log_failure(layer_idx, exc)
+            return None
+
+        return hook
+
+    def _make_in_proj_hook(self, layer_idx: int, attn, attn_type):
+        """Slice ``beta`` (and the full-rank output gate) out of ``in_proj``.
+
+        Channel layout is ``[qkv | beta | gate]``, matching the ``split_sizes``
+        that ``KimiDeltaAttention.forward`` builds. Widths are read off the layer
+        so a TP shard slices its own local widths.
+        """
+
+        def hook(_layer, _input, output):
+            if not self._should_monitor():
+                return None
+            try:
+                qkvbz = _unwrap(output).detach()
+                beta_start = attn.conv_dim_local_tp
+                beta_end = beta_start + attn.num_v_heads_local_tp
+                with paddle.no_grad():
+                    beta = qkvbz[..., beta_start:beta_end]
+                    self._record(
+                        layer_idx,
+                        attn_type,
+                        kda_metrics.write_gate_stats(beta, attn.num_v_heads_local_tp),
+                    )
+                    if attn.use_full_rank_gate:
+                        gate = qkvbz[..., beta_end : beta_end + attn.v_dim_local_tp]
+                        self._record(
+                            layer_idx,
+                            attn_type,
+                            kda_metrics.read_gate_stats(gate, attn.v_dim_local_tp),
+                        )
+            except Exception as exc:
+                self._log_failure(layer_idx, exc)
+            return None
+
+        return hook
+
+    def _make_gate_hook(self, layer_idx: int, attn, attn_type):
+        """Low-rank output gate: ``g_b_proj`` output is the gate logit."""
+
+        def hook(_layer, _input, output):
+            if not self._should_monitor():
+                return None
+            try:
+                with paddle.no_grad():
+                    gate = _unwrap(output).detach()
+                    self._record(
+                        layer_idx,
+                        attn_type,
+                        kda_metrics.read_gate_stats(gate, attn.v_dim_local_tp),
+                    )
+            except Exception as exc:
+                self._log_failure(layer_idx, exc)
+            return None
+
+        return hook
+
+
+def setup_kda_monitor(
+    model,
+    log_per_layer: bool = True,
+    log_global: bool = True,
+    monitor_interval: int = 1,
+    verbose: bool = False,
+    sample_layers: list[int] | None = None,
+    monitor_dict: dict | None = None,
+):
+    monitor = PaddleKDAHealthMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+        sample_layers=sample_layers,
+    )
+    monitor.register_hooks(model)
+    if monitor_dict is not None:
+        monitor_dict["kda_health"] = monitor
+    return model

--- a/src/internal_medicine/backends/paddlefleet/layer_discovery.py
+++ b/src/internal_medicine/backends/paddlefleet/layer_discovery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +18,12 @@ class MonitorLayer:
     is_mtp: bool = False
     # Attention kind tag for stacks that mix kinds across layers. Which config
     # field describes the mix decides the value space (see classify_attn_type):
+    #   - KDA hybrid stack                 -> ``"kda"`` on the linear-attention
+    #     layers, ``"mla"`` / ``"global"`` on the interleaved global ones
     #   - ``csa_compress_ratios`` present  -> ``"mla"`` / ``"mqa"`` /
     #     ``"window"`` / ``"csa"`` / ``"hca"``
     #   - ``sliding_window`` present       -> ``"swa"`` / ``"full"``
-    #   - neither                          -> ``None`` (homogeneous stack; keeps
+    #   - none of the above                -> ``None`` (homogeneous stack; keeps
     #     the legacy untagged metric keys)
     # Monitors prepend this to the metric name so statistics of different
     # attention kinds never mix in one chart.
@@ -50,6 +52,21 @@ _RATIO_KINDS = {
     WINDOW_RATIO: "window",
     HCA_RATIO: "hca",
 }
+
+# Both names are required because GDN (``gated_delta_net``, a selectable
+# ``attention_layer_type``) shares ``A_log`` / ``dt_bias`` / ``conv1d`` /
+# ``in_proj`` with KDA and must not match.
+_KDA_ATTRS = ("f_b_proj", "gate_lower_bound")
+
+
+def is_kda_layer(layer) -> bool:
+    """True when this layer's token mixer is Kimi Delta Attention."""
+    attn = get_attention_module(layer)
+    if attn is None:
+        return False
+    # ``hasattr``, not truthiness: ``gate_lower_bound=None`` is a valid config
+    # (it selects the unbounded softplus gate).
+    return all(hasattr(attn, name) for name in _KDA_ATTRS)
 
 
 def _flatten_model_chunks(model) -> list[object] | None:
@@ -160,12 +177,17 @@ def _compress_ratio_meta(attn) -> tuple[str, int | None, int | None, bool] | Non
 def attn_meta(layer) -> tuple[str | None, int | None, int | None, bool]:
     """Return ``(attn_type, compress_ratio, window_size, has_indexer)``.
 
-    Ratio-described stacks are classified from ``compress_ratio``; otherwise the
-    ``is_swa`` flag is used (see :func:`classify_attn_type`).
+    KDA layers are recognised by class; ratio-described stacks are classified
+    from ``compress_ratio``; otherwise the ``is_swa`` flag is used (see
+    :func:`classify_attn_type`).
     """
     attn = get_attention_module(layer)
     if attn is None:
         return (None, None, None, False)
+    if is_kda_layer(layer):
+        # KDA has no softmax logits, no compress ratio and no window; the tag is
+        # the only piece of metadata that applies.
+        return ("kda", None, None, False)
     by_ratio = _compress_ratio_meta(attn)
     if by_ratio is not None:
         return by_ratio
@@ -178,22 +200,30 @@ def attn_meta(layer) -> tuple[str | None, int | None, int | None, bool]:
 def classify_attn_type(layer) -> str | None:
     """Classify a transformer layer's attention kind.
 
-    Which config field describes the layer mix decides the value space; the two
+    Which config field describes the layer mix decides the value space; the
     mechanisms are independent and never both apply:
 
-    1. ``csa_compress_ratios`` (flagged by
+    1. **KDA hybrid stacks** (Kimi-Linear / Kimi-K3): a layer whose token mixer
+       is Kimi Delta Attention (see :func:`is_kda_layer`) is tagged ``"kda"``. The interleaved global
+       layers get their tag from :func:`iter_monitor_layers`, which is the only
+       place that sees the whole stack — ``"mla"`` for ``MQALatentAttention``,
+       ``"global"`` for anything else. Neither of the two mechanisms below fires
+       on these stacks (no ``csa_compress_ratios``, no ``sliding_window``), so
+       without this rule every layer would come back ``None`` and KDA metrics
+       would share one chart with the global layers'.
+    2. ``csa_compress_ratios`` (flagged by
        ``experimental_attention_variant="dsv4_hybrid"``): the per-layer kind
        implied by the ratio — ``"mla"`` (-2), ``"mqa"`` (-1), ``"window"`` (0),
        ``"csa"`` (2..127), ``"hca"`` (128). ``is_swa`` is useless here because
        it is derived from ``config.sliding_window``, which these configs do not
        set, so every layer would look like ``"full"``.
-    2. ``config.sliding_window`` (+ ``window_attn_skip_freq``): the ``is_swa``
+    3. ``config.sliding_window`` (+ ``window_attn_skip_freq``): the ``is_swa``
        flag that ``Attention.__init__`` computes per layer → ``"swa"`` /
        ``"full"``.
 
-    Returns ``None`` when neither field is present (homogeneous stack), which
-    callers treat as "do not tag metrics with attention kind" so those runs keep
-    their existing metric key layout.
+    Returns ``None`` when none of them apply (homogeneous stack), which callers
+    treat as "do not tag metrics with attention kind" so those runs keep their
+    existing metric key layout.
     """
     return attn_meta(layer)[0]
 
@@ -234,6 +264,41 @@ def _absolute_mtp_idx(wrapper, layer, mtp_local_idx: int) -> int | None:
     if not isinstance(local, int) or local < 0:
         local = mtp_local_idx
     return num_hidden_layers + local
+
+
+def _global_layer_tag(layer) -> str:
+    """Tag for a non-KDA attention layer inside a KDA hybrid stack.
+
+    KDA hybrids pair ``KimiDeltaAttention`` with ``MQALatentAttention`` for the
+    periodic global layers (``gpt_layer_specs.py``), so name that case ``"mla"``.
+    Anything else gets the neutral ``"global"`` rather than a guess.
+    """
+    attn = get_attention_module(layer)
+    return "mla" if type(attn).__name__ == "MQALatentAttention" else "global"
+
+
+def _retag_kda_hybrid(monitor_layers: list[MonitorLayer], all_layers: list[object]) -> list[MonitorLayer]:
+    """Give the global layers of a KDA hybrid stack an explicit tag.
+
+    ``attn_meta`` only sees one layer, so it cannot tell a global layer of a KDA
+    hybrid (which must be tagged, or its metrics share a chart with the KDA
+    layers') from a layer of a homogeneous stack (which must stay untagged, or
+    existing runs lose their metric keys). This is the only place that sees the
+    whole stack, so the stack-level decision is made here. No-op unless the stack
+    contains at least one KDA layer.
+
+    Detection scans ``all_layers``, not the matched subset: a monitor that
+    deliberately excludes KDA layers from its own predicate (``qk_stats`` has no
+    logits to read there) must still tag its global layers the same way every
+    other monitor does, or the same physical layer would carry different metric
+    keys depending on which monitor emitted them.
+    """
+    if not any(is_kda_layer(layer) for layer in all_layers):
+        return monitor_layers
+    return [
+        item if item.attn_type is not None else replace(item, attn_type=_global_layer_tag(item.layer))
+        for item in monitor_layers
+    ]
 
 
 def iter_monitor_layers(
@@ -292,5 +357,4 @@ def iter_monitor_layers(
             continue
         monitor_layers.append(_make(idx, layer, True))
 
-    return monitor_layers
-
+    return _retag_kda_hybrid(monitor_layers, layers)

--- a/src/internal_medicine/backends/paddlefleet/qk_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/qk_monitor.py
@@ -11,7 +11,7 @@ import paddle
 import paddle.nn as nn
 
 from .base import PaddleProbe
-from .layer_discovery import MLA_RATIO, MQA_RATIO, get_decoder_layers, iter_monitor_layers
+from .layer_discovery import MLA_RATIO, MQA_RATIO, get_decoder_layers, is_kda_layer, iter_monitor_layers
 
 logger = logging.getLogger(__name__)
 
@@ -731,6 +731,10 @@ class PaddleQKStatsMonitor(PaddleProbe):
 
     def _find_attention_layers(self, model: nn.Layer) -> list[tuple[int, nn.Layer, object]]:
         def has_attention(layer):
+            # KDA layers are excluded on purpose: they are linear attention, so
+            # there are no QK logits, no softmax and no ``core_attention`` to hook.
+            if is_kda_layer(layer):
+                return False
             return hasattr(layer, "self_attn") or hasattr(layer, "self_attention")
 
         layers = get_decoder_layers(model)

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -15,6 +15,7 @@ AVAILABLE_MONITORS = {
         "vha_health",
         "attn_update",
         "mlp_update",
+        "kda_health",
     ],
 }
 

--- a/tests/test_paddlefleet_kda_monitor.py
+++ b/tests/test_paddlefleet_kda_monitor.py
@@ -1,0 +1,339 @@
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+importlib.import_module("_backend_env").skip_unless_backend("paddlefleet")
+
+try:
+    paddle = importlib.import_module("paddle")
+    nn = importlib.import_module("paddle.nn")
+except Exception as exc:  # pragma: no cover - depends on optional backend install
+    raise unittest.SkipTest(f"paddle backend unavailable: {exc}") from exc
+
+kda_metrics = importlib.import_module("internal_medicine.backends.paddlefleet.kda_metrics")
+kda_monitor = importlib.import_module("internal_medicine.backends.paddlefleet.kda_monitor")
+layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
+_training_logs_mod = importlib.import_module("internal_medicine.core.training_logs")
+training_logs = _training_logs_mod.training_logs
+TrainingLogs = _training_logs_mod.TrainingLogs
+
+PaddleKDAHealthMonitor = kda_monitor.PaddleKDAHealthMonitor
+
+HV = 4  # value heads
+DK = 8  # key/value head dim
+CONV_DIM = 3 * HV * DK  # q | k | v, all local to this fake rank
+
+
+class FakeLinear(nn.Layer):
+    """Stand-in for a PaddleFleet parallel linear: returns ``(out, bias)``."""
+
+    def __init__(self, out_width):
+        super().__init__()
+        self.out_width = out_width
+        self.next_output = None
+
+    def forward(self, x):
+        return self.next_output, None
+
+
+class FakeKDAAttention(nn.Layer):
+    """Stand-in for ``KimiDeltaAttention``: only the attributes the monitor reads.
+
+    Discovery is an attribute probe (``f_b_proj`` + ``gate_lower_bound``), so
+    carrying the attributes the monitor reads is enough to be found.
+    """
+
+    def __init__(self, use_full_rank_gate=True, gate_lower_bound=-5.0):
+        super().__init__()
+        self.num_v_heads_local_tp = HV
+        self.value_head_dim = DK
+        self.key_head_dim = DK
+        self.conv_dim_local_tp = CONV_DIM
+        self.v_dim_local_tp = HV * DK
+        self.use_full_rank_gate = use_full_rank_gate
+        self.gate_lower_bound = gate_lower_bound
+        self.A_log = paddle.zeros([HV], dtype="float32")
+        self.dt_bias = paddle.zeros([HV * DK], dtype="float32")
+        self.in_proj = FakeLinear(CONV_DIM + HV + (HV * DK if use_full_rank_gate else 0))
+        self.f_a_proj = FakeLinear(DK)
+        self.f_b_proj = FakeLinear(HV * DK)
+        if not use_full_rank_gate:
+            self.g_a_proj = FakeLinear(DK)
+            self.g_b_proj = FakeLinear(HV * DK)
+
+
+class FakeLayer(nn.Layer):
+    def __init__(self, attn):
+        super().__init__()
+        self.self_attn = attn
+
+
+def _model(layers):
+    return SimpleNamespace(decoder=SimpleNamespace(layers=nn.LayerList(layers)))
+
+
+def _fire(attn, z, beta_logit, gate_logit=None, tokens=6):
+    """Drive the fake projections so the monitor's hooks see real tensors."""
+    attn.f_b_proj.next_output = z
+    qkv = paddle.zeros([1, tokens, CONV_DIM], dtype="float32")
+    parts = [qkv, beta_logit]
+    if attn.use_full_rank_gate:
+        parts.append(gate_logit)
+    attn.in_proj.next_output = paddle.concat(parts, axis=-1)
+    attn.in_proj(None)
+    attn.f_b_proj(None)
+    if not attn.use_full_rank_gate:
+        attn.g_b_proj.next_output = gate_logit
+        attn.g_b_proj(None)
+
+
+class KDAGateMathTest(unittest.TestCase):
+    """kda_log_decay must reproduce the layer's own gate, both branches."""
+
+    def _reference(self, z, A_log, dt_bias, safe_gate, lower_bound):
+        # Transcribed from kimi_delta_attention.kda_gate.
+        x = z.astype("float32").reshape([-1, HV, DK]) + dt_bias.astype("float32").reshape([HV, DK])
+        a = A_log.astype("float32").exp().reshape([HV, 1])
+        if safe_gate:
+            return lower_bound * nn.functional.sigmoid(a * x)
+        return -a * nn.functional.softplus(x)
+
+    def _check(self, safe_gate, lower_bound):
+        paddle.seed(0)
+        z = paddle.randn([1, 5, HV * DK], dtype="float32") * 3.0
+        A_log = paddle.to_tensor([0.0, 0.7, -0.5, 1.2], dtype="float32")
+        dt_bias = paddle.randn([HV * DK], dtype="float32")
+        got = kda_metrics.kda_log_decay(z, A_log, dt_bias, safe_gate, lower_bound, num_heads=HV, head_dim=DK)
+        want = self._reference(z, A_log, dt_bias, safe_gate, lower_bound)
+        self.assertLess(float((got - want).abs().max()), 1e-5)
+
+    def test_matches_lower_bounded_branch(self):
+        self._check(safe_gate=True, lower_bound=-5.0)
+
+    def test_matches_unbounded_softplus_branch(self):
+        # gate_lower_bound=None配置: g has no floor, so the monitor must not
+        # silently assume -5.0.
+        self._check(safe_gate=False, lower_bound=None)
+
+    def test_lower_bounded_gate_stays_in_range(self):
+        z = paddle.linspace(-50.0, 50.0, HV * DK).reshape([1, 1, HV * DK])
+        g = kda_metrics.kda_log_decay(z, paddle.zeros([HV]), None, True, -5.0, num_heads=HV, head_dim=DK)
+        self.assertGreaterEqual(float(g.min()), -5.0)
+        self.assertLessEqual(float(g.max()), 0.0)
+
+    def test_safe_gate_without_bound_is_rejected(self):
+        with self.assertRaises(ValueError):
+            kda_metrics.kda_log_decay(paddle.zeros([1, 1, HV * DK]), paddle.zeros([HV]), None, True, None, HV, DK)
+
+
+class KDAMetricsTest(unittest.TestCase):
+    def test_channel_spread_separates_collapse_from_diversity(self):
+        # The whole point of alpha_channel_spread: two tensors with the SAME mean,
+        # one collapsed onto a single time scale and one spread across channels.
+        collapsed = paddle.full([10, HV, DK], -2.0, dtype="float32")
+        spread = paddle.concat([paddle.full([10, HV, DK // 2], -1.0), paddle.full([10, HV, DK // 2], -3.0)], axis=-1)
+        a = kda_metrics.decay_gate_stats(collapsed)
+        b = kda_metrics.decay_gate_stats(spread)
+        self.assertAlmostEqual(float(a["alpha_log_mean"]), float(b["alpha_log_mean"]), places=5)
+        self.assertAlmostEqual(float(a["alpha_channel_spread"]), 0.0, places=6)
+        self.assertGreater(float(b["alpha_channel_spread"]), 0.9)
+
+    def test_token_spread_is_zero_for_an_input_independent_gate(self):
+        # A gate frozen into a constant decay: identical across tokens.
+        frozen = paddle.tile(paddle.randn([1, HV, DK]), [12, 1, 1])
+        stats = kda_metrics.decay_gate_stats(frozen)
+        self.assertAlmostEqual(float(stats["alpha_token_spread"]), 0.0, places=5)
+
+        varying = paddle.randn([12, HV, DK])
+        self.assertGreater(float(kda_metrics.decay_gate_stats(varying)["alpha_token_spread"]), 0.0)
+
+    def test_channel_min_averages_tokens_before_taking_the_extremum(self):
+        # Constraint 3: a single outlier token must not pin the reading. One token
+        # dips to -5 on one channel; the channel mean over 10 tokens stays near 0.
+        g = paddle.zeros([10, HV, DK], dtype="float32").numpy()
+        g[0, 0, 0] = -5.0
+        stats = kda_metrics.decay_gate_stats(paddle.to_tensor(g))
+        self.assertAlmostEqual(float(stats["alpha_log_channel_min"]), -0.5, places=5)
+
+    def test_single_token_token_spread_is_defined(self):
+        # std over a length-1 axis is undefined; the helper must return 0, not NaN.
+        stats = kda_metrics.decay_gate_stats(paddle.randn([1, HV, DK]))
+        self.assertEqual(float(stats["alpha_token_spread"]), 0.0)
+
+    def test_beta_head_min_catches_dead_heads_that_the_mean_hides(self):
+        # 4 heads, 1 dead: the mean barely moves, the per-head min collapses.
+        logit = paddle.zeros([1, 20, HV], dtype="float32").numpy()
+        logit[:, :, :] = 0.0  # sigmoid(0) = 0.5 everywhere
+        logit[:, :, 0] = -20.0  # head 0 stops writing
+        stats = kda_metrics.write_gate_stats(paddle.to_tensor(logit), HV)
+        self.assertAlmostEqual(float(stats["beta_mean"]), 0.375, places=4)  # (3*0.5 + 0) / 4
+        self.assertLess(float(stats["beta_head_min"]), 1e-6)
+        # The mean alone would look like normal drift off 0.5; the min does not.
+        self.assertGreater(float(stats["beta_mean"]), 0.3)
+
+    def test_read_gate_mean_is_the_sigmoid_aperture(self):
+        stats = kda_metrics.read_gate_stats(paddle.zeros([1, 5, HV * DK]), HV * DK)
+        self.assertAlmostEqual(float(stats["out_gate_mean"]), 0.5, places=6)
+
+    def test_param_stats_reads_A_log(self):
+        stats = kda_metrics.param_stats(paddle.to_tensor([0.0, 2.0], dtype="float32"))
+        self.assertAlmostEqual(float(stats["A_log_mean"]), 1.0, places=6)
+
+
+class FakeGDNAttention(nn.Layer):
+    """Gated Delta Net shape: shares A_log/dt_bias/conv1d with KDA, no f_b_proj.
+
+    GDN is a selectable ``attention_layer_type`` in paddlefleet, so the probe has
+    to discriminate against it rather than keying off a generic decay attribute.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.A_log = paddle.zeros([HV], dtype="float32")
+        self.dt_bias = paddle.zeros([HV * DK], dtype="float32")
+        self.conv1d = nn.Conv1D(CONV_DIM, CONV_DIM, 4, groups=CONV_DIM)
+        self.in_proj = FakeLinear(CONV_DIM + HV)
+
+
+class KDADiscoveryTest(unittest.TestCase):
+    def test_kda_layer_is_tagged_and_others_are_not(self):
+        self.assertEqual(layer_discovery.classify_attn_type(FakeLayer(FakeKDAAttention())), "kda")
+        self.assertTrue(layer_discovery.is_kda_layer(FakeLayer(FakeKDAAttention())))
+        self.assertFalse(layer_discovery.is_kda_layer(FakeLayer(nn.Linear(4, 4))))
+
+    def test_gdn_shaped_layer_is_not_mistaken_for_kda(self):
+        self.assertFalse(layer_discovery.is_kda_layer(FakeLayer(FakeGDNAttention())))
+
+    def test_unbounded_gate_config_is_still_kda(self):
+        # gate_lower_bound=None selects the softplus branch; hasattr, not
+        # truthiness, is what the probe must use.
+        self.assertTrue(layer_discovery.is_kda_layer(FakeLayer(FakeKDAAttention(gate_lower_bound=None))))
+
+    def test_global_layers_of_a_hybrid_stack_get_tagged(self):
+        # A KDA/global mix must not leave the global layers untagged, or their
+        # metrics land in the same chart as the KDA layers'.
+        layers = [FakeLayer(FakeKDAAttention()), FakeLayer(nn.Linear(4, 4))]
+        items = layer_discovery.iter_monitor_layers(layers, lambda layer: True)
+        tags = [item.attn_type for item in items]
+        self.assertEqual(tags[0], "kda")
+        self.assertEqual(tags[1], "global")
+
+    def test_homogeneous_stack_keeps_untagged_keys(self):
+        # No KDA anywhere: tags must stay None so existing runs keep their keys.
+        items = layer_discovery.iter_monitor_layers([FakeLayer(nn.Linear(4, 4))], lambda layer: True)
+        self.assertEqual([item.attn_type for item in items], [None])
+
+
+class KDAMonitorTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    @staticmethod
+    def _inputs(tokens=6, beta_fill=0.0, gate_fill=0.0):
+        z = paddle.randn([1, tokens, HV * DK], dtype="float32")
+        beta = paddle.full([1, tokens, HV], beta_fill, dtype="float32")
+        gate = paddle.full([1, tokens, HV * DK], gate_fill, dtype="float32")
+        return z, beta, gate
+
+    def test_full_rank_gate_records_all_eight_metrics(self):
+        attn = FakeKDAAttention(use_full_rank_gate=True)
+        monitor = PaddleKDAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        # Two hooks only: f_b_proj and in_proj.
+        self.assertEqual(len(monitor.hooks), 2)
+
+        _fire(attn, *self._inputs())
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="kda_health")
+        for name in kda_metrics.ALL_METRICS:
+            self.assertIn(f"kda_health/layer_0/kda_{name}", latest, name)
+            self.assertIn(f"kda_health/global_kda_{name}", latest, name)
+
+    def test_low_rank_gate_uses_a_third_hook(self):
+        attn = FakeKDAAttention(use_full_rank_gate=False)
+        monitor = PaddleKDAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        self.assertEqual(len(monitor.hooks), 3)
+
+        _fire(attn, *self._inputs(gate_fill=0.0))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="kda_health")
+        self.assertAlmostEqual(latest["kda_health/layer_0/kda_out_gate_mean"], 0.5, places=5)
+
+    def test_layers_are_tagged_kda(self):
+        # The attn_type tag is what keeps KDA metrics out of the global layers'
+        # charts; without it every key would be untagged.
+        attn = FakeKDAAttention()
+        monitor = PaddleKDAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        _fire(attn, *self._inputs())
+        monitor.step()
+
+        keys = training_logs.get_latest(prefix="kda_health")
+        self.assertTrue(any("/kda_alpha_log_mean" in k for k in keys), keys)
+
+    def test_unbounded_gate_config_still_records(self):
+        # gate_lower_bound=None must not raise and must not be read as -5.0.
+        attn = FakeKDAAttention(gate_lower_bound=None)
+        monitor = PaddleKDAHealthMonitor(verbose=True)
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        _fire(attn, *self._inputs())
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="kda_health")
+        self.assertIn("kda_health/layer_0/kda_alpha_log_mean", latest)
+        self.assertEqual(monitor._failed_layers, set())
+
+    def test_monitor_interval_gates_collection(self):
+        attn = FakeKDAAttention()
+        monitor = PaddleKDAHealthMonitor(monitor_interval=0)
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        _fire(attn, *self._inputs())
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="kda_health"), {})
+
+    def test_remove_hooks_detaches_everything(self):
+        attn = FakeKDAAttention()
+        monitor = PaddleKDAHealthMonitor()
+        monitor.register_hooks(_model([FakeLayer(attn)]))
+        monitor.remove_hooks()
+        self.assertEqual(monitor.hooks, [])
+
+        _fire(attn, *self._inputs())
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="kda_health"), {})
+
+    def test_no_kda_layer_is_a_clean_noop(self):
+        plain = SimpleNamespace(decoder=SimpleNamespace(layers=nn.LayerList([nn.Linear(4, 4)])))
+        monitor = PaddleKDAHealthMonitor()
+        monitor.register_hooks(plain)
+        monitor.step()
+        self.assertEqual(monitor.hooks, [])
+        self.assertEqual(training_logs.get_latest(prefix="kda_health"), {})
+
+    def test_min_metric_naming_contract(self):
+        # training_logs picks the reduction from the key name, independently of
+        # MIN_AGGREGATED. The two must agree or cross-rank aggregation averages
+        # what should be a min.
+        for name in kda_metrics.MIN_METRICS:
+            key = f"kda_health/layer_0/kda_{name}"
+            self.assertTrue(TrainingLogs._is_min_metric(key), key)
+            self.assertFalse(TrainingLogs._is_max_metric(key), key)
+        for name in set(kda_metrics.ALL_METRICS) - set(kda_metrics.MIN_METRICS):
+            key = f"kda_health/layer_0/kda_{name}"
+            self.assertFalse(TrainingLogs._is_min_metric(key), key)
+            self.assertFalse(TrainingLogs._is_max_metric(key), key)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
KDA (Kimi Delta Attention) 层此前是完整的监控盲区: qk_stats 会为每个 KDA 层声明 10 个永远不写入的累加器, attn_update 因 W_q/W_k 融合进 in_proj 而直接跳过。本模块围绕 KDA 自身的三条通路给出 8 个指标:

- 衰减通路 (α): `alpha_log_mean` / `alpha_channel_spread` / `alpha_token_spread` / `alpha_log_channel_min`
- 写入通路 (β): `beta_mean` / `beta_head_min`
- 读出通路 (output gate): `out_gate_mean`
- 参数: `A_log_mean`

α/β/gate 都是 forward 的局部变量, 通过 `f_b_proj` 与 `in_proj` 的 forward post hook 取回, 并在 `kda_metrics.kda_log_decay` 中复现 `kda_gate` 的两个分支 (有下界的 sigmoid 与无下界的 softplus)。

三条设计约束: 不引入人工阈值; 不依赖 kernel 实现常量 (chunk_size / BC); 极值只在结构轴 (head/channel) 上取, token 轴先做平均——因为 min/max 累加器跨整个 optimizer step 的所有 microbatch, 而 g 与 σ(β) 有界, token 轴极值会饱和。

同时修正框架侧两处:
- `layer_discovery`: 增加 `is_kda_layer` 属性判定 (`f_b_proj` + `gate_lower_bound`, 两者在 paddlefleet 内只出现于 `kimi_delta_attention.py`, 可与共享 `A_log` / `dt_bias` / `conv1d` 的 GDN 区分), 以及 KDA-MLA 混合栈的 `attn_type` 标记, 避免两种层的指标落进同一张图。
- `qk_monitor`: discovery 排除 KDA 层, 不再声明恒空的累加器。

并行正确性: TP 沿 head 切, mean 类每 rank 样本数相同、min 类取在本 rank 结构轴子集上, 因此零 hook 内通信、零 flush 通信。SP 下 `_as_tokens` 按尾维展平, 不依赖 [b,s] / [s,b] 布局。

文档见 `docs/kda_health.md`; 测试 `tests/test_paddlefleet_kda_monitor.py`。

已合入 master (c85e7b8) 解决 README 模块列表冲突。本地 `pre-commit run --all-files` 通过, `pytest tests/` 344 passed。