### PR TITLE
feat(paddlefleet): mhc monitor 兼容 dHC / iHC 超连接变体

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,9 +428,10 @@ Massive activations 是 pre-norm Transformer 的**架构副产品**，独立于�
 
 > 详细文档: [mhc_health.md](./docs/mhc_health.md)
 
-监控 mHC (Manifold-Constrained Hyper-Connections) 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
-以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。
-只在模型开启 mHC 层时生效，mHC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
+监控 hyper-connection 层的三个 per-token 映射 `h_pre` / `h_post` / `h_res`，
+以及 `x_{l+1} = H_resᵀ x_l + H_postᵀ F(H_pre x_l)` 两项的相对大小。覆盖三种 HC 变体
+（mHC 双随机 / dHC 对角 / iHC 恒等；iHC 无 mixing logits，`h_res_logits_*` 系列不发）。
+HC 类无法 import 或模型不含 `HyperConnectionTransformerLayer` 时该 monitor 为
 彻底 no-op。每层含两个 hyper-connection 模块（`attn` / `mlp`），各产出以下 29 个指标，
 指标名以 `attn_` / `mlp_` 前缀区分；`branch_residual_share_max`、`h_res_logits_max`、
 `h_res_logits_grad_max`、`composite_amax_gain_{fwd,bwd}_max`、`h_{pre,post}_logits_max`、

--- a/docs/mhc_health.md
+++ b/docs/mhc_health.md
@@ -22,10 +22,13 @@ x_{l+1} = H_res^T @ x_l + H_post^T · F(H_pre @ x_l)
 通过在 `internal_medicine_monitors` 中加入 `mhc_health`（或 `all`）启用。启用它在**任何**模型上都是安全的——
 以下任一情况下它彻底 no-op（不 wrap 任何模块、不声明/产生任何指标、不抛异常）：
 
-1. **mHC 类无法 import**：`setup_mhc_monitor` 在 import 失败时将类名绑定为 `None`，直接返回 `model`。
-2. **模型未使用 mHC 层**：discovery 用 `isinstance(layer, HyperConnectionTransformerLayer)` 与
-   `isinstance(mod, HyperConnectionModule)` 精确匹配（不做 duck-typing），普通 `TransformerLayer` 或
-   `IdentityOp` 占位符都不会被匹配。
+1. **HC 类无法 import**：`setup_mhc_monitor` 在 import 失败时将类名绑定为 `None`，直接返回 `model`。
+2. **模型未使用 hyper-connection 层**：discovery 用 `isinstance(layer, HyperConnectionTransformerLayer)` 与
+   `isinstance(mod, (HyperConnectionModule, DiagonalHyperConnectionModule, IdentityHyperConnectionModule))`
+   精确匹配（不做 duck-typing），普通 `TransformerLayer` 或 `IdentityOp` 占位符都不会被匹配。三种变体共用同一
+   监控 API：`compute_mappings` 均返回 `(h_pre, h_post, h_res)`；区别仅在 `_compute_h` 的返回元数——mHC 返回
+   Sinkhorn 输入 logits、dHC 返回 `diag_embed` 前的 sigmoid 对角向量、iHC 无 logits（2 元组），故 iHC 不发
+   `h_res_logits_*` 系列指标。
 
 ```yaml
 internal_medicine_monitors:

--- a/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/mhc_monitor.py
@@ -26,8 +26,10 @@ Forward hooks are not enough, so three bound methods are wrapped instead (see
 ``mhc_metrics`` for what each metric means):
 
 - ``compute_mappings`` — ``h_pre`` is not in ``forward``'s return value.
-- ``_compute_h``       — the mixing logits only exist before the Sinkhorn
-  projection, and wrapping here also sidesteps the ``use_fused_mhc`` fork.
+- ``_compute_h``       — the mixing logits (mHC: Sinkhorn input; dHC: the
+  sigmoid diagonal before ``diag_embed``; iHC: none, 2-tuple return) only
+  exist inside this call, and wrapping here also sidesteps the
+  ``use_fused_mhc`` fork.
 - ``fused_h_res_h_post_bda`` — the only point where both update terms are
   visible.
 """
@@ -56,11 +58,42 @@ logger = logging.getLogger(__name__)
 # (non-mHC model, or a PaddleFleet build without hyper-connections). Bind to
 # None on import failure and gate every code path on that.
 try:
-    from paddlefleet.transformer.hyper_connection import HyperConnectionModule
+    from paddlefleet.transformer.hyper_connection import (
+        DiagonalHyperConnectionModule,
+        HyperConnectionModule,
+        IdentityHyperConnectionModule,
+    )
     from paddlefleet.transformer.transformer_layer import HyperConnectionTransformerLayer
 except Exception:  # pragma: no cover - environment dependent
     HyperConnectionModule = None
+    DiagonalHyperConnectionModule = None
+    IdentityHyperConnectionModule = None
     HyperConnectionTransformerLayer = None
+
+
+# All three HC variants share the monitored API surface: ``compute_mappings``
+# returns ``(h_pre, h_post, h_res)`` with ``h_res`` shaped ``[..., n, n]``
+# (mHC: doubly stochastic; dHC: per-token diagonal; iHC: broadcast identity),
+# and ``fused_h_res_h_post_bda`` has the same signature. The only divergence
+# is ``_compute_h``'s arity — iHC has no h_res logits at all (see
+# ``_make_logits_capture``) — which the wrappers handle, so one type tuple
+# serves discovery and every guard below.
+def _hc_module_types() -> tuple:
+    """The three HC module classes, in preference order; empty if unavailable.
+
+    A function, not a module-level constant: the optional import and the unit
+    tests swap the module attributes at runtime, so discovery must resolve
+    them on every call.
+    """
+    return tuple(
+        t
+        for t in (
+            HyperConnectionModule,
+            DiagonalHyperConnectionModule,
+            IdentityHyperConnectionModule,
+        )
+        if t is not None
+    )
 
 
 _METRIC_NAMES = (
@@ -228,7 +261,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         real classes rather than duck-typing, so a plain ``TransformerLayer``
         (or an ``IdentityOp`` placeholder) is never matched.
         """
-        if HyperConnectionTransformerLayer is None or HyperConnectionModule is None:
+        if HyperConnectionTransformerLayer is None or not _hc_module_types():
             return []
         layers = get_decoder_layers(chunk)
         if not layers:
@@ -247,7 +280,7 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         for item in monitor_layers:
             for comp, attr in _COMPONENTS:
                 mod = getattr(item.layer, attr, None)
-                if not isinstance(mod, HyperConnectionModule):
+                if not isinstance(mod, _hc_module_types()):
                     continue
                 entries.append((item.idx, comp, mod))
         return entries
@@ -518,6 +551,15 @@ class PaddleMHCHealthMonitor(PaddleProbe):
         ``_compute_h`` does not return and are therefore rebuilt from its own
         ``(proj, r)`` arguments plus ``mod``'s ``alpha`` / ``bias`` — see
         ``gate_logits_extrema``.
+
+        The residual-mixing return value differs across the three HC variants:
+        for mHC it is the n×n Sinkhorn input (the saturation sentinel the
+        monitor exists for); for dHC it is the ``[..., n]`` sigmoid diagonal
+        vector (same sentinel semantics, pre-``diag_embed``); iHC has **no**
+        mixing logits at all — ``_compute_h`` returns a 2-tuple, so its
+        ``h_res_logits_*`` metrics are never recorded (flush skips unrecorded
+        keys), and ``h_{pre,post}_logits_*`` are equally skipped by the early
+        return.
         """
 
         def wrapped(proj, r):
@@ -525,6 +567,9 @@ class PaddleMHCHealthMonitor(PaddleProbe):
             if not self._should_monitor():
                 return out
             try:
+                if len(out) < 3:
+                    # iHC: H_res is a fixed identity, there is nothing to saturate.
+                    return out
                 _h_pre, _h_post, h_res_logits = out
                 if not h_res_logits.stop_gradient:
 
@@ -635,8 +680,8 @@ def setup_mhc_monitor(
     Multi-chunk (VPP / interleaved 1F1B) safe: declares the schema across all
     chunks before ``allocate_buffers`` locks it, then attaches.
     """
-    # No-op guarantee #1: mHC classes unavailable -> touch nothing.
-    if HyperConnectionTransformerLayer is None or HyperConnectionModule is None:
+    # No-op guarantee #1: HC classes unavailable -> touch nothing.
+    if HyperConnectionTransformerLayer is None or not _hc_module_types():
         logger.info("[PaddleMHCMonitor] Hyper-connection classes unavailable; skipping.")
         return model
 

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -79,6 +79,18 @@ class FakeHC(nn.Layer):
         return hidden_states, self._h_res, self._h_post
 
 
+class FakeIHC(FakeHC):
+    """Stand-in for ``IdentityHyperConnectionModule``: no h_res logits at all.
+
+    ``_compute_h`` returns a 2-tuple, mirroring the real iHC module; the monitor
+    must discover it, record the shared metrics, and stay silent on the
+    ``h_res_logits_*`` series.
+    """
+
+    def _compute_h(self, proj, r):
+        return self._h_pre, self._h_post
+
+
 class FakeLayer(nn.Layer):
     """Stand-in for HyperConnectionTransformerLayer with the two hc modules."""
 
@@ -807,6 +819,48 @@ class MHCMonitorTest(unittest.TestCase):
             # h_post is constant 1.0 -> equal across streams and across tokens.
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_stream_concentration"], 1.0, places=4)
             self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_token_std"], 0.0, places=5)
+
+    def test_ihc_two_tuple_compute_h_skips_logits_but_records_rest(self):
+        # IdentityHyperConnectionModule: _compute_h returns (h_pre, h_post), no
+        # mixing logits exist. The monitor must discover it alongside a regular
+        # 3-tuple mHC module, record every non-logits metric for both, and emit
+        # nothing for the iHC's h_res_logits_* series.
+        n, s, b = 4, 2, 3
+        ident = paddle.eye(n).reshape([1, 1, n, n]).expand([s, b, n, n])
+        ihc = FakeIHC(
+            n=n,
+            h_pre=paddle.full([s, b, n], 0.5),
+            h_post=paddle.ones([s, b, n]),
+            h_res=paddle.assign(ident),
+        )
+        model = _mhc_model([FakeLayer(attn=ihc, mlp=self._identity_layer(n, s, b).mlp_hyper_connection)])
+
+        orig_ident = mhc_monitor.IdentityHyperConnectionModule
+        mhc_monitor.IdentityHyperConnectionModule = FakeIHC
+        try:
+            monitor = PaddleMHCHealthMonitor(log_per_layer=True, log_global=True)
+            targets = self._prepare_and_attach(monitor, model)
+            # Both the iHC (attn) and the 3-tuple HC (mlp) module are discovered.
+            self.assertEqual(len(targets), 2)
+
+            self._drive(targets, x_dim=n * 8)
+            monitor.step()
+        finally:
+            mhc_monitor.IdentityHyperConnectionModule = orig_ident
+
+        latest = training_logs.get_latest(prefix="mhc_health")
+        for comp in ("attn", "mlp"):
+            # Shared metrics flow normally for both module kinds.
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_pre_mean"], 0.5, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_h_post_mean"], 1.0, places=5)
+            self.assertAlmostEqual(latest[f"mhc_health/layer_0/{comp}_amax_gain_fwd"], 1.0, places=5)
+        # iHC has no mixing logits: the series must simply not be emitted.
+        self.assertNotIn("mhc_health/layer_0/attn_h_res_logits_min", latest)
+        self.assertNotIn("mhc_health/layer_0/attn_h_res_logits_max", latest)
+        self.assertNotIn("mhc_health/layer_0/attn_h_res_logits_grad_min", latest)
+        self.assertNotIn("mhc_health/global_attn_h_res_logits_min", latest)
+        # The 3-tuple module's logits series is still recorded.
+        self.assertIn("mhc_health/layer_0/mlp_h_res_logits_min", latest)
 
     def test_remove_hooks_restores_both_wrapped_methods(self):
         n, s, b = 4, 2, 3


### PR DESCRIPTION
## Summary
- discovery 从仅匹配 `HyperConnectionModule` 扩展为同时匹配 `DiagonalHyperConnectionModule` / `IdentityHyperConnectionModule`（`_hc_module_types()` 类型元组，避免 duck-typing）
- `_make_logits_capture` 兼容 iHC 的 `_compute_h` 2 元组返回（无 mixing logits），iHC 不发 `h_res_logits_*` 系列；mHC（Sinkhorn 输入）与 dHC（sigmoid 对角）不受影响
- 热路径无新增 D2H 同步 / 集合通信，metric schema 仍在注册期声明（monitor-hook-perf-rules 合规）
- 测试：新增 `FakeIHC` + `test_ihc_two_tuple_compute_h_skips_logits_but_records_rest`；README / mhc_health.md 同步三种变体覆盖范围说明

## Test plan

- [x] pre-commit（ruff + ruff-format）通过
- [x] `pytest tests/test_mhc_paddlefleet_monitor.py`（29 passed）
- [x] `pytest tests/test_paddlefleet_monitors.py tests/test_core_monitoring.py`（82 passed）
- [ ] 真机验证