### PR TITLE
perf(core): 用固定 schema 的 tensor all_reduce 取代跨 rank 的 all_gather_object

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,9 @@ PaddleFleet 后端还会直接从每次 router forward 的实际选择结果输�
 
 > **注**: 指标 27-28 (`expert_*_share`) 是**每层每专家一条曲线**的向量指标 (256 专家的
 > 18 层模型 = 9216 个键), 只在 `log_per_layer=true` 时输出, 且不派生 `global_*`。
-> **默认关闭**, 按需打开:
-> `setup_monitors(model, moe_health={"log_per_expert_share": True})`。
 > 键数是 `2 × num_experts` / 层 (512 专家 = 1024 键/层, 对比同层标量的 ~56 个),
-> 会主导 `gather_and_aggregate()` 跨全 world `all_gather_object` 的 pickle payload,
-> 数千卡规模下这部分开销显著, 因此只在排查具体是哪个专家不均衡时打开。
+> 但它们在 flush 时已在 GPU 上按 DP(+CP) 组归约完毕并 `mark_pre_aggregated`,
+> 逐元素键不进 `gather_and_aggregate()` 的 payload, 因此不再随卡数放大通信量。
 > 它们与 `assignment_load_*` / `gate_mass_*` 互补: 后者回答一层「有多不均衡」,
 > 前者回答「是哪个专家造成的、是否长期是同一个」。
 >

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ PaddleFleet 后端还会直接从每次 router forward 的实际选择结果输�
 
 > **注**: 指标 27-28 (`expert_*_share`) 是**每层每专家一条曲线**的向量指标 (256 专家的
 > 18 层模型 = 9216 个键), 只在 `log_per_layer=true` 时输出, 且不派生 `global_*`。
+> **默认关闭**, 按需打开:
+> `setup_monitors(model, moe_health={"log_per_expert_share": True})`。
+> 键数是 `2 × num_experts` / 层 (512 专家 = 1024 键/层, 对比同层标量的 ~56 个),
+> 会主导 `gather_and_aggregate()` 跨全 world `all_gather_object` 的 pickle payload,
+> 数千卡规模下这部分开销显著, 因此只在排查具体是哪个专家不均衡时打开。
 > 它们与 `assignment_load_*` / `gate_mass_*` 互补: 后者回答一层「有多不均衡」,
 > 前者回答「是哪个专家造成的、是否长期是同一个」。
 >
@@ -749,7 +754,7 @@ from internal_medicine import training_logs
 
 ### 跨卡聚合
 
-`training_logs.gather_and_aggregate()` 通过 `dist.all_gather_object` 收集所有 rank 的指标，然后按键名规则聚合：
+`training_logs.gather_and_aggregate()` 按键名规则做跨 rank 聚合：
 
 | 键名模式 | 聚合方式 |
 |----------|----------|
@@ -759,9 +764,21 @@ from internal_medicine import training_logs
 | 包含 `_min` 或以 `/min` 结尾 | `np.min(all_ranks)` |
 | 其他 | `np.mean(all_ranks)` |
 
+**通信实现**: 主路径是**固定 schema 的 tensor all_reduce**（SUM / MAX / MIN 各一次），
+上线量是 `O(全局 key 数)`，与卡数无关；4096 卡实测从 `all_gather_object` 的 43.7 s CPU
+降到 132 KB 通信 + 1.4 ms Python 开销。schema 在启动时于 **PP 组内** all_gather 一次得到
+（同一 PP stage 的各 rank 声明相同的 key）。每次 reduce 前有一次定长的
+`(schema 长度, crc32)` 探针：若各 rank 的 schema 不一致就打 warning 并永久回退到
+`all_gather_object`——**不猜、不 hang**。向量指标（`expert_*_share_eK` 等）更进一步，
+在 flush 时就在 GPU 上按 DP(+CP) 组归约完毕，逐元素 key 完全不进聚合路径。
+
+多卡正确性验证见 `tests/manual_verify_tensor_aggregate.py`（PP=1/2/4/8 × 8 卡，
+比对新旧两条路径逐 key 的一致性）。
+
 **`monitor_interval > 1` 时不要每步都调用**：`gather_and_aggregate()` 是全 world 的
-集合通信，只有采样步才可能产出指标，其余步跑的是一次空的 `all_gather_object`
-（6144 卡实测 872 ms/步）。调用方应当先问 `monitor.sampled_this_step`——它由
+集合通信，只有采样步才可能产出指标，其余步跑的是一次空通信（`all_gather_object`
+路径下 6144 卡实测 872 ms/步；换成 tensor all_reduce 后便宜很多，但仍是一次全局
+同步）。调用方应当先问 `monitor.sampled_this_step`——它由
 `step()` 在自增前锁存，是"刚结束这一步的 hook 有没有采样"的唯一权威答案：
 
 ```python

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -455,43 +455,55 @@ Layer 1: Hook 内部通信
   原则: 除正确性必需外，hook hot path 避免 NCCL collective
 
 Layer 2: 全局聚合 (gather_and_aggregate)
-  └── dist.all_gather_object(info_list, all_metrics)
-  范围: world_size（全部卡，跨节点）
+  ├── 主路径: 固定 schema 的 tensor all_reduce（SUM / MAX / MIN）
+  │   数据量: O(全局 key 数)，与卡数无关
+  └── 回退路径: dist.all_gather_object，数据量 O(key 数 × 卡数)
   频率: 每 log_interval 步
-  数据量: ~90 KB/rank (pickle 序列化的 Python dict)
 ```
 
-### 5.2 开销估算（以 80 层 MoE+PLE 模型，512 卡为例）
+### 5.2 两条路径的实测成本
 
-| 通信 | 频率 | 单次数据量 | 每步总通信量 | 影响 |
-|------|------|-----------|-------------|------|
-| QK hook 内通信 | — | 0 | 0 | 无；QK 主要成本是额外 QK stats 计算 |
-| PLE hook 内通信 | — | 0 | 0 | 无 |
-| MoE hook 内通信 | — | 0 | 0 | 无 |
-| `gather_and_aggregate` | 每 log_interval 步 | 90 KB × 512 rank | ~45 MB | **主要开销** |
+按 43 层模型、每层 197 个标量指标（PP=4 → 每 rank 11 层 ≈ 2167 个 key）实测：
 
-### 5.3 `gather_and_aggregate` 的特点
+**回退路径 `all_gather_object`**（723 KB/rank pickle，含 per-expert 向量时）：
+
+| world_size | payload | 反序列化 | 聚合循环 | CPU 合计 |
+|---|---|---|---|---|
+| 512 | 362 MB | 1.15 s | 2.96 s | **4.1 s** |
+| 4096 | 2.9 GB | 9.3 s | 34.5 s | **43.7 s** |
+
+去掉 per-expert 向量后（111 KB/rank）4096 卡仍是 **5.4 s**，其中聚合循环占 4.3 s。
+注意 payload 是每个 rank 都要驻留的，几千卡下本身就是 OOM 风险。
+
+**主路径 tensor all_reduce**：全局 8471 个 key → 16943 个 float64 = **132 KB 上线量，与卡数无关**；
+Python 侧（填向量 + 拆结果）实测 **1.4 ms/flush**。三次 all_reduce 在这个尺寸下是延迟主导，
+随卡数只有对数增长。
+
+### 5.3 主路径的机制
 
 ```python
-# 使用 dist.all_gather_object — CPU 侧序列化通信
-dist.all_gather_object(info_list, all_metrics)  # Gloo backend, pickle
+# 定长 float64 向量，缺失位用 0 / -inf / +inf 填充
+# SUM: [mean 值 (M)] + [presence mask (M)]
+# MAX: [resync flag] + [max 值 (X)]
+# MIN: [min 值 (I)]
 ```
 
 | 特性 | 说明 |
 |------|------|
-| 通信后端 | Gloo (CPU)，**不是** NCCL (GPU) |
-| 序列化 | Python pickle，有编解码开销 |
-| 同步模型 | 全局 barrier — 所有 rank 必须同时参与 |
-| 数据量 | ~90 KB/rank 级别，带宽不是瓶颈 |
-| 真正的开销 | **同步等待** — 最慢 rank 决定所有人的等待时间 |
+| schema 来源 | 启动时在 **PP 组内** all_gather key 列表（组宽 = pp_size，一次性） |
+| 数值语义 | 除以 presence mask ⇒ 与旧路径逐位一致的「持有该 key 的 rank 等权平均」 |
+| 一致性保护 | 每次 reduce 前先做一次定长 (schema 长度, crc32) 探针 |
+| 不一致时 | 打 warning 并永久回退到 `all_gather_object`，不猜、不 hang |
+| 迟到的 key | resync flag 让所有 rank 一致地重建一次 schema 并重算 |
+| 向量指标 | 在 flush 时于 GPU 上按 DP(+CP) 组归约，逐元素 key 直接不进聚合路径 |
 
-### 5.4 优化空间
+关键不变量：**所有分支都由已归约的量决定**，因此各 rank 的判断与 collective 序列必然一致。
 
-当前设计的通信开销在 `log_interval ≥ 10` 时完全可以接受。进一步优化方向：
+### 5.4 剩余优化空间
 
-1. **DP group 内聚合替代全局聚合**: PLE/MoE 指标在各 DP rank 上是对称的，只需 DP group 内取均值即可，无需跨 TP/PP group
-2. **NCCL 替代 Gloo**: 将 dict 预编码为 tensor，走 NCCL all_reduce 而非 all_gather_object
-3. **异步聚合**: 在下一步训练的 forward 开始时异步触发上一步的聚合
+1. **mHC 的 76 标量/层** 现在是 payload 里的第一名（197 中的 39%），可以审一遍哪些真的需要每层出
+2. **异步聚合**: 在下一步 forward 开始时才取上一步的聚合结果，用来吃掉 straggler 抖动
+3. 已完成: per-expert 向量移出 pickle 路径、标量走固定 schema tensor all_reduce
 
 ---
 

--- a/src/internal_medicine/backends/megatron/gather.py
+++ b/src/internal_medicine/backends/megatron/gather.py
@@ -1,4 +1,4 @@
-"""Megatron distributed gather function for training_logs."""
+"""Megatron distributed aggregation primitives for training_logs."""
 
 import logging
 
@@ -6,7 +6,11 @@ logger = logging.getLogger(__name__)
 
 
 def _torch_gather(local_metrics: dict) -> list:
-    """Gather metrics from all ranks using torch.distributed."""
+    """Gather metrics from all ranks using torch.distributed.
+
+    Legacy path: ``O(keys x world_size)`` pickled dicts. Kept as the fallback for
+    when the fixed-schema reduce below cannot be used.
+    """
     import torch.distributed as dist
 
     if not dist.is_initialized():
@@ -17,8 +21,79 @@ def _torch_gather(local_metrics: dict) -> list:
     return info_list
 
 
+def _torch_reduce(sum_vec: list, max_vec: list, min_vec: list):
+    """SUM / MAX / MIN all_reduce over the whole world, float64.
+
+    float64 keeps the crc32 schema checksum and the presence counts exact, and
+    the vectors are ``O(distinct keys)`` — tens of KB regardless of world size.
+    Called at flush time, never from a hook.
+    """
+    import torch
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        return None
+
+    device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+    reduced = []
+    for vec, op in (
+        (sum_vec, dist.ReduceOp.SUM),
+        (max_vec, dist.ReduceOp.MAX),
+        (min_vec, dist.ReduceOp.MIN),
+    ):
+        if not vec:
+            reduced.append([])
+            continue
+        tensor = torch.tensor(vec, dtype=torch.float64, device=device)
+        dist.all_reduce(tensor, op=op)
+        reduced.append(tensor.tolist())
+    return tuple(reduced)
+
+
+def _torch_schema_gather(local_keys: list) -> list:
+    """All_gather the key lists over the pipeline group.
+
+    Ranks sharing a pipeline stage own the same layers and declare the same keys,
+    so the pipeline group's union is already the world union — and the group is
+    ``pp_size`` wide, which keeps this one-off pickle cheap. training_logs
+    cross-checks a schema checksum on every reduce and falls back to
+    ``_torch_gather`` if the ranks disagree.
+    """
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        return None
+
+    group = None
+    try:
+        from megatron.core import parallel_state
+
+        group = parallel_state.get_pipeline_model_parallel_group()
+    except Exception:
+        logger.warning(
+            "[InternalMedicine/megatron] pipeline group unavailable; "
+            "syncing the metric schema over the full world instead (one-off, but large at scale)"
+        )
+
+    try:
+        group_size = dist.get_world_size(group=group)
+        # With PP=1 every rank already holds every layer, so the local key set
+        # *is* the global schema and there is nothing to union.
+        if group_size <= 1:
+            return [list(local_keys)]
+        gathered = [None] * group_size
+        dist.all_gather_object(gathered, list(local_keys), group=group)
+    except Exception as exc:
+        # Degrade to a local-only schema: the fixed-size probe in training_logs
+        # will notice if that disagrees across ranks and fall back to the legacy
+        # path, so this cannot turn into a hang or a wrong number.
+        logger.warning(f"[InternalMedicine/megatron] metric schema sync failed ({exc}); using local keys only")
+        return [list(local_keys)]
+    return gathered
+
+
 def install_gather_fn():
-    """Install the torch-based gather function into the global training_logs."""
+    """Install the torch-based aggregation primitives into the global training_logs."""
     from ...core.training_logs import training_logs
 
     try:
@@ -26,5 +101,7 @@ def install_gather_fn():
 
         if dist.is_initialized():
             training_logs.set_gather_fn(_torch_gather)
+            training_logs.set_schema_sync_fn(_torch_schema_gather)
+            training_logs.set_reduce_fn(_torch_reduce)
     except ImportError:
         pass

--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -40,6 +40,9 @@ class PaddleProbe(Probe):
         self._gpu_vec: dict[str, paddle.Tensor] = {}  # per-layer 向量累加器 [size]
         self._gpu_vec_cnt: dict[str, int] = {}
         self._vector_elem_keys: dict[str, list[str]] = {}  # 向量 key → 展开后的逐元素 key
+        # 向量指标的跨 rank 归约组，见 _vector_reduce_group()。None = 不归约（单卡/组不可用）。
+        self._vec_group = None
+        self._vec_group_resolved = False
         self._mtp_layer_ids: set[int] = set()
         self._buffers_allocated = False
 
@@ -106,6 +109,10 @@ class PaddleProbe(Probe):
         for k, size in self._vector_keys.items():
             self._gpu_vec[k] = paddle.zeros([size], dtype=dtype)
             self._gpu_vec_cnt[k] = 0
+        # 逐元素 key 的跨 rank 归约在 flush 时于 tensor 侧完成（见 _flush_gpu_buffer），
+        # 因此把它们从 gather_and_aggregate 的 all_gather_object payload 里摘掉
+        if self._vector_elem_keys:
+            training_logs.mark_pre_aggregated(key for elem_keys in self._vector_elem_keys.values() for key in elem_keys)
         self._buffers_allocated = True
         if self.verbose:
             logger.info(
@@ -257,6 +264,75 @@ class PaddleProbe(Probe):
             return True  # 显式 declare 的非逐层 key
         return self.log_per_layer
 
+    def _vector_reduce_group(self):
+        """向量指标的跨 rank 归约组：DP(+CP)，即持有相同层但看到不同 token 的那些 rank。
+
+        - TP rank 复算同一份路由，值本就相同，归约进来只是浪费；
+        - PP rank 持有不同的层，定长 collective 在它们之间形状都对不上，必然挂死；
+
+        所以 DP x CP 既是语义上正确的归约域，也是形状安全的那个。解析失败时返回
+        None，退化为「只信本 rank 的值」——向量指标本身在单 rank 上已是无偏估计
+        （整条归一化占比向量都在本 rank 上算全，跨 rank 平均只降噪）。
+        """
+        if self._vec_group_resolved:
+            return self._vec_group
+        self._vec_group_resolved = True
+        try:
+            import paddle.distributed as dist
+
+            if not dist.is_initialized():
+                return None
+            from paddlefleet.parallel_state import get_data_parallel_group
+
+            try:
+                self._vec_group = get_data_parallel_group(with_context_parallel=True)
+            except TypeError:  # 老版本签名里没有 with_context_parallel
+                self._vec_group = get_data_parallel_group()
+        except Exception as exc:
+            logger.warning(
+                f"[{self.METRIC_PREFIX}] 无法解析向量指标的 DP 归约组 ({exc}); "
+                f"逐元素曲线将只反映本 rank 的观测（噪声更大，但不影响标量指标）"
+            )
+            self._vec_group = None
+        return self._vec_group
+
+    def _vector_means_for_flush(self) -> dict[str, list[float]]:
+        """向量 key → 逐元素的全局均值（Python float）。
+
+        一次 collective 覆盖所有向量 key。形状只由 schema 决定（同一 PP stage 的各
+        rank 声明相同的层），刻意不按 ``cnt == 0`` 过滤 —— 否则各 rank 会带着不同
+        形状进同一个 collective 而挂死（同 tests/test_core_monitoring.py 里记录的
+        PP=4 死锁）。同组内各 rank 的 record 次数相同，故 SUM / nranks 等价于旧
+        路径「各 rank 均值再等权平均」的语义。
+
+        归约在 **float64** 上做，并单独走一次 D2H 而不与标量共用那次 concat：
+        旧路径是把 float32 的 per-rank 均值取回 Python 再用 float64 求平均，若这里
+        用 float32 归约，误差会随卡数累积（几千卡下相对误差可达 1e-6 量级），
+        单独用 float64 能把差异压回 float64 舍入水平。这是 step 边界的一次额外
+        D2H，不在 hook 热路径上。
+        """
+        order = list(self._vector_keys)
+        if not order:
+            return {}
+
+        flat = paddle.concat([(self._gpu_vec[k] / max(self._gpu_vec_cnt[k], 1)).astype("float64") for k in order])
+        group = self._vector_reduce_group()
+        if group is not None:
+            import paddle.distributed as dist
+
+            dist.all_reduce(flat, group=group)
+            flat = flat / float(group.nranks)
+
+        values = flat.cpu().tolist()
+        means: dict[str, list[float]] = {}
+        offset = 0
+        for k in order:
+            size = self._vector_keys[k]
+            if self._gpu_vec_cnt[k] > 0:
+                means[k] = values[offset : offset + size]
+            offset += size
+        return means
+
     def _flush_gpu_buffer(self) -> dict[str, float]:
         """单次批量 D2H：收集所有累加器 → 推导 global → concat→cpu→tolist → 重置。"""
         keys: list[str] = []
@@ -303,27 +379,19 @@ class PaddleProbe(Probe):
                     tensors.append(paddle.stack([self._gpu_acc[lk] for lk in active]).min())
                 keys.append(global_key)
 
-        # 5) 唯一 D2H 同步点：一次 concat → cpu → tolist（标量与向量共用）
-        vec_key_groups: list[list[str]] = []
-        vec_tensors: list[paddle.Tensor] = []
-        for k, elem_keys in self._vector_elem_keys.items():
-            cnt = self._gpu_vec_cnt[k]
-            if cnt == 0:
-                continue
-            vec_key_groups.append(elem_keys)
-            vec_tensors.append(self._gpu_vec[k] / cnt)
-
+        # 5) 标量的唯一 D2H 同步点：一次 concat → cpu → tolist
         out: dict[str, float] = {}
-        if tensors or vec_tensors:
-            flat = paddle.concat([t.reshape([-1]) for t in tensors] + vec_tensors)
-            vals = flat.cpu().tolist()
+        if tensors:
+            vals = paddle.concat([t.reshape([-1]) for t in tensors]).cpu().tolist()
             out = dict(zip(keys, vals, strict=False))
-            offset = len(keys)
-            for elem_keys in vec_key_groups:
-                out.update(zip(elem_keys, vals[offset : offset + len(elem_keys)], strict=False))
-                offset += len(elem_keys)
 
-        # 6) 重置所有累加器，为下一个 step 准备
+        # 6) 向量指标：float64 归约 + 自己的一次 D2H（见 _vector_means_for_flush）。
+        #    展开出来的逐元素 key 已是跨 rank 结果，不再进 all_gather_object
+        #    （allocate_buffers 里已 mark_pre_aggregated）。
+        for k, elements in self._vector_means_for_flush().items():
+            out.update(zip(self._vector_elem_keys[k], elements, strict=False))
+
+        # 7) 重置所有累加器，为下一个 step 准备
         for k in self._mean_keys:
             self._gpu_acc[k].zero_()
             self._gpu_cnt[k] = 0

--- a/src/internal_medicine/backends/paddlefleet/gather.py
+++ b/src/internal_medicine/backends/paddlefleet/gather.py
@@ -1,4 +1,4 @@
-"""PaddleFleet distributed gather function for training_logs."""
+"""PaddleFleet distributed aggregation primitives for training_logs."""
 
 import logging
 
@@ -6,7 +6,11 @@ logger = logging.getLogger(__name__)
 
 
 def _paddle_gather(local_metrics: dict) -> list:
-    """Gather metrics from all ranks using paddle.distributed."""
+    """Gather metrics from all ranks using paddle.distributed.
+
+    Legacy path: ``O(keys x world_size)`` pickled dicts. Kept as the fallback for
+    when the fixed-schema reduce below cannot be used.
+    """
     import paddle.distributed as dist
 
     if not dist.is_initialized():
@@ -16,8 +20,80 @@ def _paddle_gather(local_metrics: dict) -> list:
     return info_list
 
 
+def _paddle_reduce(sum_vec: list, max_vec: list, min_vec: list):
+    """SUM / MAX / MIN all_reduce over the whole world, float64.
+
+    float64 keeps the crc32 schema checksum and the presence counts exact, and
+    the vectors are ``O(distinct keys)`` — tens of KB regardless of world size.
+    Called at flush time, never from a hook, so it does not contend with the
+    hot-path streams the monitor rules are about.
+    """
+    import paddle
+    import paddle.distributed as dist
+
+    if not dist.is_initialized():
+        return None
+
+    reduced = []
+    for vec, op in (
+        (sum_vec, dist.ReduceOp.SUM),
+        (max_vec, dist.ReduceOp.MAX),
+        (min_vec, dist.ReduceOp.MIN),
+    ):
+        if not vec:
+            reduced.append([])
+            continue
+        tensor = paddle.to_tensor(vec, dtype="float64")
+        dist.all_reduce(tensor, op=op)
+        reduced.append(tensor.tolist())
+    return tuple(reduced)
+
+
+def _paddle_schema_gather(local_keys: list) -> list:
+    """All_gather the key lists over the pipeline group.
+
+    Ranks sharing a pipeline stage own the same layers and declare the same keys,
+    so the pipeline group's union is already the world union — and the group is
+    ``pp_size`` wide, which keeps this one-off pickle cheap. A mismatch is not
+    assumed away: training_logs cross-checks a schema checksum on every reduce
+    and falls back to ``_paddle_gather`` if the ranks disagree.
+    """
+    import paddle.distributed as dist
+
+    if not dist.is_initialized():
+        return None
+
+    group = None
+    try:
+        from paddlefleet.parallel_state import get_pipeline_model_parallel_group
+
+        group = get_pipeline_model_parallel_group()
+    except Exception:
+        logger.warning(
+            "[InternalMedicine/paddlefleet] pipeline group unavailable; "
+            "syncing the metric schema over the full world instead (one-off, but large at scale)"
+        )
+
+    # A single-stage group has nothing to union, and paddle rejects all_gather on
+    # a one-rank group outright. With PP=1 every rank already holds every layer,
+    # so the local key set *is* the global schema.
+    if group is not None and getattr(group, "nranks", 0) <= 1:
+        return [list(local_keys)]
+
+    gathered = []
+    try:
+        dist.all_gather_object(gathered, list(local_keys), group=group)
+    except Exception as exc:
+        # Degrade to a local-only schema: the fixed-size probe in training_logs
+        # will notice if that disagrees across ranks and fall back to the legacy
+        # path, so this cannot turn into a hang or a wrong number.
+        logger.warning(f"[InternalMedicine/paddlefleet] metric schema sync failed ({exc}); using local keys only")
+        return [list(local_keys)]
+    return gathered
+
+
 def install_gather_fn():
-    """Install the paddle-based gather function into the global training_logs."""
+    """Install the paddle-based aggregation primitives into the global training_logs."""
     from ...core.training_logs import training_logs
 
     try:
@@ -25,5 +101,7 @@ def install_gather_fn():
 
         if dist.is_initialized():
             training_logs.set_gather_fn(_paddle_gather)
+            training_logs.set_schema_sync_fn(_paddle_schema_gather)
+            training_logs.set_reduce_fn(_paddle_reduce)
     except ImportError:
         pass

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -401,18 +401,10 @@ class PaddleMoEMonitor(PaddleProbe):
         "router_margin_min",
     }
 
-    def __init__(
-        self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False, log_per_expert_share=False
-    ):
+    def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
         super().__init__(
             log_per_layer=log_per_layer, log_global=log_global, monitor_interval=monitor_interval, verbose=verbose
         )
-        # Per-expert share curves emit one key per expert per layer, so they dominate
-        # the payload gather_and_aggregate pickles across the whole world (E=512 x 2
-        # metrics = 1024 keys/layer against ~56 scalars). Off by default: the scalar
-        # assignment_load_* / gate_mass_* family already answers "how imbalanced",
-        # and these answer "which expert" — only needed when drilling into a hotspot.
-        self.log_per_expert_share = log_per_expert_share
         self._patched_gates = []
         self._patched_moe_layers = []
         self._expert_norm_layers = []
@@ -504,7 +496,7 @@ class PaddleMoEMonitor(PaddleProbe):
             # num_experts must come from static config here — a hook-time
             # reduction would need a D2H sync to size the schema.
             num_experts = int(getattr(getattr(moe_layer, "gate", None), "num_experts", 0) or 0)
-            if self.log_per_expert_share and num_experts > 0:
+            if num_experts > 0:
                 for m in ("expert_token_share", "expert_weight_share"):
                     self.declare_layer_vector(layer_idx, m, num_experts)
 
@@ -933,13 +925,7 @@ class PaddleMoEMonitor(PaddleProbe):
         leaves the GPU and neither needs a hook-time collective: the cross-rank
         mean over DP ranks equals the global share, because every rank routes the
         same number of tokens.
-
-        No-op unless ``log_per_expert_share`` is set: the keys are not declared in
-        that case, so recording would be dropped anyway — returning here also skips
-        the normalisation kernels.
         """
-        if not self.log_per_expert_share:
-            return
         self.record_layer_vector(layer_idx, "expert_token_share", assignment / assignment.sum().clip(min=1e-12) * 100.0)
         probs = outputs[3] if isinstance(outputs, tuple | list) and len(outputs) > 3 else None
         if isinstance(probs, paddle.Tensor):
@@ -1047,14 +1033,12 @@ def setup_moe_monitor(
     monitor_interval=1,
     verbose=False,
     monitor_dict=None,
-    log_per_expert_share=False,
 ):
     monitor = PaddleMoEMonitor(
         log_per_layer=log_per_layer,
         log_global=log_global,
         monitor_interval=monitor_interval,
         verbose=verbose,
-        log_per_expert_share=log_per_expert_share,
     )
     monitor.register_hooks(model)
     logger.info(f"[PaddleMoEMonitor] Setup complete. Monitoring {len(monitor.hooks)} hooks.")

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -401,10 +401,18 @@ class PaddleMoEMonitor(PaddleProbe):
         "router_margin_min",
     }
 
-    def __init__(self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False):
+    def __init__(
+        self, log_per_layer=True, log_global=True, monitor_interval=1, verbose=False, log_per_expert_share=False
+    ):
         super().__init__(
             log_per_layer=log_per_layer, log_global=log_global, monitor_interval=monitor_interval, verbose=verbose
         )
+        # Per-expert share curves emit one key per expert per layer, so they dominate
+        # the payload gather_and_aggregate pickles across the whole world (E=512 x 2
+        # metrics = 1024 keys/layer against ~56 scalars). Off by default: the scalar
+        # assignment_load_* / gate_mass_* family already answers "how imbalanced",
+        # and these answer "which expert" — only needed when drilling into a hotspot.
+        self.log_per_expert_share = log_per_expert_share
         self._patched_gates = []
         self._patched_moe_layers = []
         self._expert_norm_layers = []
@@ -496,7 +504,7 @@ class PaddleMoEMonitor(PaddleProbe):
             # num_experts must come from static config here — a hook-time
             # reduction would need a D2H sync to size the schema.
             num_experts = int(getattr(getattr(moe_layer, "gate", None), "num_experts", 0) or 0)
-            if num_experts > 0:
+            if self.log_per_expert_share and num_experts > 0:
                 for m in ("expert_token_share", "expert_weight_share"):
                     self.declare_layer_vector(layer_idx, m, num_experts)
 
@@ -925,7 +933,13 @@ class PaddleMoEMonitor(PaddleProbe):
         leaves the GPU and neither needs a hook-time collective: the cross-rank
         mean over DP ranks equals the global share, because every rank routes the
         same number of tokens.
+
+        No-op unless ``log_per_expert_share`` is set: the keys are not declared in
+        that case, so recording would be dropped anyway — returning here also skips
+        the normalisation kernels.
         """
+        if not self.log_per_expert_share:
+            return
         self.record_layer_vector(layer_idx, "expert_token_share", assignment / assignment.sum().clip(min=1e-12) * 100.0)
         probs = outputs[3] if isinstance(outputs, tuple | list) and len(outputs) > 3 else None
         if isinstance(probs, paddle.Tensor):
@@ -1033,12 +1047,14 @@ def setup_moe_monitor(
     monitor_interval=1,
     verbose=False,
     monitor_dict=None,
+    log_per_expert_share=False,
 ):
     monitor = PaddleMoEMonitor(
         log_per_layer=log_per_layer,
         log_global=log_global,
         monitor_interval=monitor_interval,
         verbose=verbose,
+        log_per_expert_share=log_per_expert_share,
     )
     monitor.register_hooks(model)
     logger.info(f"[PaddleMoEMonitor] Setup complete. Monitoring {len(monitor.hooks)} hooks.")

--- a/src/internal_medicine/core/training_logs.py
+++ b/src/internal_medicine/core/training_logs.py
@@ -3,9 +3,20 @@ Framework-agnostic training metrics store.
 
 All values stored as Python floats. Framework-specific tensor conversion
 is the caller's responsibility.
+
+Cross-rank aggregation has two implementations:
+
+1. Preferred — ``_reduce_fn``: a fixed-schema tensor all_reduce. Payload is
+   ``O(number of distinct keys)`` and independent of world size.
+2. Fallback — ``_gather_fn``: ``all_gather_object``. Payload is
+   ``O(keys x world_size)`` pickled dicts, which at a few thousand ranks costs
+   tens of seconds of pure CPU per flush and gigabytes of resident memory.
+   Kept for single-card runs and as the escape hatch when the schema cannot be
+   made world-consistent.
 """
 
 import logging
+import zlib
 from collections import defaultdict
 from collections.abc import Callable
 
@@ -89,12 +100,57 @@ class TrainingLogs:
     def __init__(self, gather_fn: Callable | None = None):
         if not hasattr(self, "meters"):
             self.meters = {}
+        if not hasattr(self, "_pre_aggregated_keys"):
+            self._pre_aggregated_keys: set[str] = set()
+        if not hasattr(self, "_schema"):
+            self._reset_schema()
         if gather_fn is not None:
             self._gather_fn = gather_fn
+
+    def _reset_schema(self) -> None:
+        self._schema: list[str] | None = None
+        self._schema_set: set[str] = set()
+        self._schema_mean: list[str] = []
+        self._schema_max: list[str] = []
+        self._schema_min: list[str] = []
+        self._schema_checksum: float = 0.0
+        self._tensor_path_disabled = False
 
     def set_gather_fn(self, fn: Callable):
         """Set the distributed gather function (backend provides this)."""
         self._gather_fn = fn
+
+    def set_reduce_fn(self, fn: Callable | None):
+        """Install the backend's fixed-schema tensor all_reduce.
+
+        ``fn(sum_vec, max_vec, min_vec)`` returns the three lists reduced with
+        SUM / MAX / MIN across the whole world, or ``None`` when unavailable.
+        Preferred over ``_gather_fn``: payload no longer scales with world size.
+        """
+        self._reduce_fn = fn
+        self._reset_schema()
+
+    def set_schema_sync_fn(self, fn: Callable | None):
+        """Install the backend's key-list all_gather, used to build the schema.
+
+        ``fn(local_keys)`` returns one key list per rank of the *pipeline* group.
+        Ranks that share a pipeline stage hold the same layers and therefore
+        declare the same keys, so the pipeline group's union already covers the
+        world — gathering key names over the full world would itself cost
+        hundreds of MB at a few thousand ranks.
+        """
+        self._schema_sync_fn = fn
+        self._reset_schema()
+
+    def mark_pre_aggregated(self, keys):
+        """Declare keys whose cross-rank reduction already happened on device.
+
+        They are then excluded from both aggregation paths. Used by vector
+        metrics, which emit one key per element: at 512 experts x 43 layers they
+        would dominate the payload while carrying a value every rank agrees on.
+        Schema-level, so ``reset()`` deliberately does not clear it.
+        """
+        self._pre_aggregated_keys.update(keys)
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -164,15 +220,143 @@ class TrainingLogs:
     def reset(self):
         self.meters.clear()
 
+    def _build_schema(self, local_keys) -> None:
+        """Freeze the global key order. Identical on every rank by construction."""
+        sync_fn = getattr(self, "_schema_sync_fn", None)
+        keys = set(local_keys)
+        if sync_fn is not None:
+            key_lists = sync_fn(sorted(keys))
+            for other in key_lists or ():
+                keys.update(other)
+        self._schema = sorted(keys)
+        self._schema_set = set(self._schema)
+        # Same max-then-min-then-mean order as __setitem__, so a key's reduction
+        # op matches the SmoothedValue mode it was stored under.
+        self._schema_max = [k for k in self._schema if self._is_max_metric(k)]
+        self._schema_min = [k for k in self._schema if not self._is_max_metric(k) and self._is_min_metric(k)]
+        extrema = set(self._schema_max) | set(self._schema_min)
+        self._schema_mean = [k for k in self._schema if k not in extrema]
+        self._schema_checksum = float(zlib.crc32("\n".join(self._schema).encode()))
+
+    def _schema_agreed(self, reduce_fn):
+        """Fixed-size probe of ``(schema length, checksum)``. ``None`` if unavailable.
+
+        This has to run *before* the payload reduce: if two ranks froze different
+        schemas their payload vectors have different lengths, and a mismatched
+        all_reduce hangs rather than raising. Two elements, so the probe itself can
+        never be the thing that hangs.
+        """
+        probe = [float(len(self._schema)), self._schema_checksum]
+        reduced = reduce_fn([], list(probe), list(probe))
+        if reduced is None:
+            return None
+        _, r_max, r_min = reduced
+        return r_max[0] == r_min[0] and r_max[1] == r_min[1]
+
+    def _tensor_aggregate(self, metrics: "dict") -> "dict | None":
+        """Aggregate over a fixed schema with a handful of all_reduce calls.
+
+        Layout, all float64 (exact for the crc32 checksum and for the counts):
+
+        - SUM: ``[mean values (M)] + [presence mask (M)]``
+        - MAX: ``[resync flag] + [max values (X)]``
+        - MIN: ``[min values (I)]``
+
+        Missing keys contribute 0 / ``-inf`` / ``+inf`` and a 0 mask, so a key no
+        rank reported stays absent from the output — matching the legacy path.
+        Dividing by the reduced mask reproduces the legacy mean exactly: an
+        unweighted mean over the ranks that hold the key, *not* count-weighted.
+
+        Every branch below is taken on the value of a *reduced* quantity, so all
+        ranks make the same decision and issue the same sequence of collectives.
+
+        Returns ``None`` to hand the round back to the legacy gather path.
+        """
+        reduce_fn = self._reduce_fn
+        local_keys = set(metrics)
+        if self._schema is None:
+            self._build_schema(local_keys)
+
+        for attempt in (0, 1):
+            agreed = self._schema_agreed(reduce_fn)
+            if agreed is None:
+                return None
+            if not agreed:
+                # Ranks sharing a pipeline stage declared different keys, so the
+                # pipeline-group union is not the world union. Widening the sync
+                # group is the real fix; until then stay correct via the old path.
+                logger.warning(
+                    "[training_logs] metric schema differs across ranks; "
+                    "falling back to all_gather_object aggregation for the rest of the run"
+                )
+                self._tensor_path_disabled = True
+                return None
+
+            unknown = local_keys - self._schema_set
+            mean_keys, max_keys, min_keys = self._schema_mean, self._schema_max, self._schema_min
+            sum_vec = [metrics.get(k, 0.0) for k in mean_keys]
+            sum_vec += [1.0 if k in metrics else 0.0 for k in mean_keys]
+            max_vec = [1.0 if unknown else 0.0]
+            max_vec += [metrics[k] if k in metrics else float("-inf") for k in max_keys]
+            min_vec = [metrics[k] if k in metrics else float("inf") for k in min_keys]
+
+            reduced = reduce_fn(sum_vec, max_vec, min_vec)
+            if reduced is None:
+                return None
+            r_sum, r_max, r_min = reduced
+
+            if r_max[0] > 0:
+                # Some rank holds a key outside the frozen schema. Every rank sees
+                # this same flag, so rebuilding is a collectively consistent
+                # decision — retry once with the widened schema.
+                if attempt == 0:
+                    self._build_schema(local_keys)
+                    continue
+                logger.warning(
+                    "[training_logs] schema still incomplete after a rebuild; "
+                    "falling back to all_gather_object aggregation for the rest of the run"
+                )
+                self._tensor_path_disabled = True
+                return None
+            break
+
+        aggregated: dict[str, float] = {}
+        offset = len(mean_keys)
+        for i, k in enumerate(mean_keys):
+            present = r_sum[offset + i]
+            if present > 0:
+                aggregated[k] = r_sum[i] / present
+        for i, k in enumerate(max_keys):
+            value = r_max[1 + i]
+            if value != float("-inf"):
+                aggregated[k] = value
+        for i, k in enumerate(min_keys):
+            value = r_min[i]
+            if value != float("inf"):
+                aggregated[k] = value
+        return aggregated
+
     def gather_and_aggregate(self):
         """Gather metrics from all ranks and aggregate by naming convention."""
         all_metrics = self.get_latest()
+
+        # Keys already reduced on device are excluded from the payload; every rank
+        # holds the same value, so shipping one copy per rank buys nothing.
+        pre_aggregated = {k: v for k, v in all_metrics.items() if k in self._pre_aggregated_keys}
+        to_reduce = {k: v for k, v in all_metrics.items() if k not in pre_aggregated} if pre_aggregated else all_metrics
+
+        reduce_fn = getattr(self, "_reduce_fn", None)
+        if reduce_fn is not None and not self._tensor_path_disabled:
+            aggregated = self._tensor_aggregate(to_reduce)
+            if aggregated is not None:
+                aggregated.update(pre_aggregated)
+                return aggregated
 
         gather_fn = getattr(self, "_gather_fn", None)
         if gather_fn is None:
             return all_metrics
 
-        info_list = gather_fn(all_metrics)
+        info_list = gather_fn(to_reduce)
         if info_list is None:
             return all_metrics
 
@@ -188,6 +372,7 @@ class TrainingLogs:
                 aggregated[k] = min(values)
             else:
                 aggregated[k] = sum(values) / len(values)
+        aggregated.update(pre_aggregated)
         return aggregated
 
 

--- a/tests/manual_verify_tensor_aggregate.py
+++ b/tests/manual_verify_tensor_aggregate.py
@@ -139,7 +139,12 @@ def main():
         tensor[f"probe/layer_{owned_layer}/metric_0"],
         owned_layer * 100.0 + 0.01 * mean_of_ranks,
     )
-    check(results, "peak_max is the stage maximum", tensor[f"probe/layer_{owned_layer}/peak_max"], 1000.0 - stage * dp_size)
+    check(
+        results,
+        "peak_max is the stage maximum",
+        tensor[f"probe/layer_{owned_layer}/peak_max"],
+        1000.0 - stage * dp_size,
+    )
     check(
         results,
         "floor_min is the stage minimum",
@@ -176,7 +181,12 @@ def main():
     else:
         results.append(("world-wide schema absorbed the key", not training_logs._tensor_path_disabled, 1, 1))
     check(results, "rank-unique key value is right either way", fallback.get("probe/rank0_only", float("nan")), 42.0)
-    check(results, "shared keys still correct after the mismatch", fallback["probe/global_metric_0"], 7.0 + (world - 1) / 2)
+    check(
+        results,
+        "shared keys still correct after the mismatch",
+        fallback["probe/global_metric_0"],
+        7.0 + (world - 1) / 2,
+    )
 
     failures = [r for r in results if not r[1]]
     print(

--- a/tests/manual_verify_tensor_aggregate.py
+++ b/tests/manual_verify_tensor_aggregate.py
@@ -1,0 +1,197 @@
+"""Multi-process check for the fixed-schema tensor aggregation (paddlefleet).
+
+Deliberately not named ``test_*``: the unit suite runs single-process, and the
+only thing that can validate the collective layout is real ranks.
+
+    PP_SIZE=2 python -m paddle.distributed.launch --gpus 0,1,2,3,4,5,6,7 \
+        tests/manual_verify_tensor_aggregate.py
+
+What it pins down:
+
+1. The tensor path and the legacy ``all_gather_object`` path return the same keys
+   and the same values. This change is meant to be purely about cost.
+2. Per-layer keys owned by a single pipeline stage survive the union schema
+   (the shape-consistency assumption that a wrong guess turns into a hang).
+3. ``max`` / ``min`` keys reduce to the global extremum over the ranks that hold
+   them, not to the ``+-inf`` padding.
+4. A key written after the schema froze triggers exactly one collective rebuild
+   instead of hanging or being dropped.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import paddle.distributed as dist
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from internal_medicine.backends.paddlefleet.gather import _paddle_gather, _paddle_reduce  # noqa: E402
+from internal_medicine.core.training_logs import training_logs  # noqa: E402
+
+LAYERS = 8
+METRICS_PER_LAYER = 8
+
+
+def build_local_metrics(stage, pp_size, rank):
+    """Per-layer keys for this stage's layers only, with rank-dependent values.
+
+    Every key here is *stage*-uniform: two ranks of the same pipeline stage hold
+    the same key set. That is the invariant the pipeline-group schema sync relies
+    on, so the happy path must not violate it.
+    """
+    layers_per_stage = LAYERS // pp_size
+    metrics = {}
+    for layer in range(stage * layers_per_stage, (stage + 1) * layers_per_stage):
+        for i in range(METRICS_PER_LAYER):
+            metrics[f"probe/layer_{layer}/metric_{i}"] = layer * 100.0 + i + rank * 0.01
+        metrics[f"probe/layer_{layer}/peak_max"] = 1000.0 - rank
+        metrics[f"probe/layer_{layer}/floor_min"] = 1000.0 + rank
+    metrics["probe/global_metric_0"] = 7.0 + rank
+    metrics[f"probe/stage_{stage}_only"] = 5.0 + rank
+    return metrics
+
+
+def make_pipeline_group(rank, pp_size, dp_size):
+    """One rank per stage, mirroring get_pipeline_model_parallel_group().
+
+    Every rank must create every group, in the same order, or new_group deadlocks.
+    ``None`` for PP=1: a one-rank group has nothing to union and paddle rejects
+    all_gather on it, which is exactly what the backend helper handles too.
+    """
+    if pp_size == 1:
+        return None
+    own = None
+    for dp_index in range(dp_size):
+        members = [stage * dp_size + dp_index for stage in range(pp_size)]
+        group = dist.new_group(members)
+        if rank in members:
+            own = group
+    return own
+
+
+def check(results, label, got, expected, tol=1e-9):
+    ok = abs(got - expected) <= tol
+    results.append((label, ok, got, expected))
+    return ok
+
+
+def step(rank, msg):
+    """Progress markers, flushed: a hang has to be locatable from the worker log."""
+    print(f"[rank {rank}] {msg}", flush=True)
+
+
+def main():
+    dist.init_parallel_env()
+    rank, world = dist.get_rank(), dist.get_world_size()
+    pp_size = int(os.environ.get("PP_SIZE", "2"))
+    if world % pp_size:
+        raise SystemExit(f"world size {world} is not divisible by PP_SIZE={pp_size}")
+    dp_size = world // pp_size
+    stage = rank // dp_size
+    step(rank, f"init ok, world={world} pp={pp_size} dp={dp_size} stage={stage}")
+    pp_group = make_pipeline_group(rank, pp_size, dp_size)
+    step(rank, "pipeline group ready")
+
+    def schema_sync_fn(local_keys):
+        if pp_group is None:
+            return [list(local_keys)]
+        gathered = []
+        dist.all_gather_object(gathered, list(local_keys), group=pp_group)
+        return gathered
+
+    local = build_local_metrics(stage, pp_size, rank)
+
+    # Legacy path first, as the reference.
+    training_logs.reset()
+    training_logs.update(**local)
+    training_logs.set_reduce_fn(None)
+    training_logs.set_gather_fn(_paddle_gather)
+    legacy = training_logs.gather_and_aggregate()
+    step(rank, f"legacy path ok, {len(legacy)} keys")
+
+    # Same inputs through the fixed-schema tensor path.
+    training_logs.reset()
+    training_logs.update(**local)
+    training_logs.set_schema_sync_fn(schema_sync_fn)
+    training_logs.set_reduce_fn(_paddle_reduce)
+    tensor = training_logs.gather_and_aggregate()
+    step(rank, f"tensor path ok, {len(tensor)} keys")
+
+    results = []
+    key_diff = set(legacy) ^ set(tensor)
+    results.append(("same key set", not key_diff, len(legacy), len(tensor)))
+    worst, worst_key = 0.0, None
+    for k in legacy.keys() & tensor.keys():
+        delta = abs(legacy[k] - tensor[k])
+        if delta > worst:
+            worst, worst_key = delta, k
+    results.append((f"max |tensor-legacy| ({worst_key})", worst <= 1e-9, worst, 0.0))
+
+    # The reduction domain for a per-layer key is exactly the DP ranks of the
+    # stage that owns the layer — that is what makes the union schema safe.
+    owned_layer = stage * (LAYERS // pp_size)
+    stage_ranks = range(stage * dp_size, (stage + 1) * dp_size)
+    mean_of_ranks = sum(stage_ranks) / dp_size
+    check(
+        results,
+        f"layer_{owned_layer}/metric_0 mean over its stage",
+        tensor[f"probe/layer_{owned_layer}/metric_0"],
+        owned_layer * 100.0 + 0.01 * mean_of_ranks,
+    )
+    check(results, "peak_max is the stage maximum", tensor[f"probe/layer_{owned_layer}/peak_max"], 1000.0 - stage * dp_size)
+    check(
+        results,
+        "floor_min is the stage minimum",
+        tensor[f"probe/layer_{owned_layer}/floor_min"],
+        1000.0 + stage * dp_size,
+    )
+    check(results, "global key means over all ranks", tensor["probe/global_metric_0"], 7.0 + (world - 1) / 2)
+    check(
+        results,
+        "stage-unique key means over its stage",
+        tensor[f"probe/stage_{stage}_only"],
+        5.0 + mean_of_ranks,
+    )
+
+    # A key written after the schema froze: the resync flag must widen the schema
+    # rather than drop the key or hang.
+    training_logs.update(**{"optim/update_rms": 3.0 + rank})
+    late = training_logs.gather_and_aggregate()
+    step(rank, "late-key rebuild ok")
+    check(results, "late key after one rebuild", late.get("optim/update_rms", float("nan")), 3.0 + (world - 1) / 2)
+    results.append(("tensor path still enabled", not training_logs._tensor_path_disabled, 0, 0))
+
+    # A rank-*unique* key breaks the stage-uniformity the pipeline-group sync
+    # assumes, so the payload vectors would have different lengths on different
+    # ranks. The fixed-size probe must catch that and fall back instead of hanging.
+    # With dp_size == 1 the pipeline group *is* the world, so there is nothing to
+    # disagree about and the key is simply absorbed by a schema rebuild.
+    if rank == 0:
+        training_logs.update(**{"probe/rank0_only": 42.0})
+    fallback = training_logs.gather_and_aggregate()
+    step(rank, "rank-unique key handled without a hang")
+    if dp_size > 1:
+        results.append(("mismatch latched the tensor path off", training_logs._tensor_path_disabled, 1, 1))
+    else:
+        results.append(("world-wide schema absorbed the key", not training_logs._tensor_path_disabled, 1, 1))
+    check(results, "rank-unique key value is right either way", fallback.get("probe/rank0_only", float("nan")), 42.0)
+    check(results, "shared keys still correct after the mismatch", fallback["probe/global_metric_0"], 7.0 + (world - 1) / 2)
+
+    failures = [r for r in results if not r[1]]
+    print(
+        f"[rank {rank}/{world} stage {stage}] {len(results) - len(failures)}/{len(results)} checks passed"
+        f" | schema {len(training_logs._schema)} keys, local {len(local)}"
+    )
+    for label, ok, got, expected in results:
+        if not ok:
+            print(f"[rank {rank}] FAIL {label}: got {got!r} expected {expected!r}")
+    dist.barrier()
+    if failures:
+        raise SystemExit(1)
+    if rank == 0:
+        print("ALL RANKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -82,6 +82,150 @@ class CoreMonitoringTest(unittest.TestCase):
         self.assertEqual(calls, [{}], "gather_fn must be called even with no local metrics")
         self.assertEqual(aggregated, {"dummy/layer_0/mean": 4.0})
 
+    def test_pre_aggregated_keys_skip_the_gather_payload(self):
+        """Device-reduced keys must not be pickled per rank, but must still be returned.
+
+        Vector metrics emit one key per element (512 experts x 43 layers), so leaving
+        them in the ``all_gather_object`` dict dominates the payload while every rank
+        already agrees on the value.
+        """
+        calls = []
+
+        def fake_gather(local_metrics):
+            calls.append(dict(local_metrics))
+            return [local_metrics, {"dummy/layer_0/mean": 4.0}]
+
+        training_logs.update(**{"dummy/layer_0/mean": 2.0, "dummy/layer_0/share_e0": 7.0})
+        training_logs.mark_pre_aggregated(["dummy/layer_0/share_e0"])
+        training_logs.set_gather_fn(fake_gather)
+        try:
+            aggregated = training_logs.gather_and_aggregate()
+        finally:
+            training_logs.set_gather_fn(None)
+            training_logs._pre_aggregated_keys.clear()
+
+        self.assertEqual(calls, [{"dummy/layer_0/mean": 2.0}], "pre-aggregated key must be excluded")
+        self.assertEqual(aggregated["dummy/layer_0/mean"], 3.0)
+        self.assertEqual(aggregated["dummy/layer_0/share_e0"], 7.0, "value must survive as-is")
+
+    def _install_two_rank_reduce(self, other_metrics):
+        """Fake the fixed-schema reduce against one more rank holding ``other_metrics``.
+
+        Decodes the vectors with the schema training_logs just froze, so the test
+        also pins the layout (offsets of the resync flag and the two checksums).
+        """
+
+        def schema_sync_fn(local_keys):
+            return [list(local_keys), sorted(other_metrics)]
+
+        def reduce_fn(sum_vec, max_vec, min_vec):
+            # The fixed-size (length, checksum) probe: both ranks agree, so MAX
+            # and MIN of it come back identical.
+            if not sum_vec:
+                return [], list(max_vec), list(min_vec)
+            mean_keys = training_logs._schema_mean
+            width = len(mean_keys)
+            sums = list(sum_vec[:width])
+            mask = list(sum_vec[width:])
+            for i, k in enumerate(mean_keys):
+                if k in other_metrics:
+                    sums[i] += other_metrics[k]
+                    mask[i] += 1.0
+            maxes = list(max_vec)
+            for i, k in enumerate(training_logs._schema_max):
+                if k in other_metrics:
+                    maxes[1 + i] = max(maxes[1 + i], other_metrics[k])
+            mins = list(min_vec)
+            for i, k in enumerate(training_logs._schema_min):
+                if k in other_metrics:
+                    mins[i] = min(mins[i], other_metrics[k])
+            return sums + mask, maxes, mins
+
+        training_logs.set_schema_sync_fn(schema_sync_fn)
+        training_logs.set_reduce_fn(reduce_fn)
+
+    def _clear_aggregation_fns(self):
+        training_logs.set_reduce_fn(None)
+        training_logs.set_schema_sync_fn(None)
+        training_logs.set_gather_fn(None)
+
+    def test_tensor_path_matches_the_legacy_gather_path(self):
+        """The fixed-schema reduce must reproduce all_gather_object numerically.
+
+        mean stays an unweighted mean over the ranks holding the key (the presence
+        mask, not an observation count), and max/min keys present on only one rank
+        must survive instead of collapsing to +-inf.
+        """
+        local = {"dummy/layer_0/mean": 2.0, "dummy/layer_0/peak_max": 5.0, "dummy/layer_0/floor_min": 3.0}
+        other = {"dummy/layer_0/mean": 4.0, "dummy/layer_0/peak_max": 1.0, "dummy/layer_1/mean": 9.0}
+
+        training_logs.update(**local)
+        try:
+            training_logs.set_gather_fn(lambda m: [dict(m), dict(other)])
+            legacy = training_logs.gather_and_aggregate()
+
+            self._install_two_rank_reduce(other)
+            tensor = training_logs.gather_and_aggregate()
+        finally:
+            self._clear_aggregation_fns()
+
+        self.assertEqual(set(tensor), set(legacy))
+        for k in legacy:
+            self.assertAlmostEqual(tensor[k], legacy[k], places=12, msg=k)
+        self.assertAlmostEqual(tensor["dummy/layer_0/mean"], 3.0, places=12)
+        self.assertAlmostEqual(tensor["dummy/layer_1/mean"], 9.0, places=12, msg="single-rank key keeps its value")
+        self.assertAlmostEqual(tensor["dummy/layer_0/peak_max"], 5.0, places=12)
+        self.assertAlmostEqual(tensor["dummy/layer_0/floor_min"], 3.0, places=12)
+
+    def test_tensor_path_rebuilds_the_schema_for_a_late_key(self):
+        """A key appearing after the schema froze triggers one collective rebuild."""
+        training_logs.update(**{"dummy/layer_0/mean": 2.0})
+        rebuilds = []
+        try:
+            self._install_two_rank_reduce({"dummy/layer_0/mean": 4.0})
+            inner = training_logs._schema_sync_fn
+
+            def counting_sync(local_keys):
+                rebuilds.append(sorted(local_keys))
+                return inner(local_keys)
+
+            training_logs._schema_sync_fn = counting_sync
+            training_logs.gather_and_aggregate()
+            self.assertEqual(len(rebuilds), 1)
+
+            # optim-style key written after the first aggregation.
+            training_logs.update(**{"optim/update_rms": 8.0})
+            aggregated = training_logs.gather_and_aggregate()
+            disabled = training_logs._tensor_path_disabled
+        finally:
+            self._clear_aggregation_fns()
+
+        self.assertEqual(len(rebuilds), 2, "the resync flag must trigger exactly one rebuild")
+        self.assertAlmostEqual(aggregated["optim/update_rms"], 8.0, places=12)
+        self.assertFalse(disabled)
+
+    def test_tensor_path_falls_back_when_schemas_disagree(self):
+        """A schema mismatch must be caught by the fixed-size probe, not by hanging.
+
+        Two ranks with different schemas build payload vectors of different lengths;
+        a mismatched all_reduce hangs, so the probe has to catch it first.
+        """
+        training_logs.update(**{"dummy/layer_0/mean": 2.0})
+        try:
+            training_logs.set_gather_fn(lambda m: [dict(m), {"dummy/layer_9/mean": 6.0}])
+            training_logs.set_schema_sync_fn(lambda keys: [list(keys)])
+            # Only the probe is answered, and with a checksum the other rank does
+            # not share: MAX and MIN of it diverge.
+            training_logs.set_reduce_fn(lambda s, mx, mn: ([], [mx[0], mx[1] + 1.0], list(mn)))
+            aggregated = training_logs.gather_and_aggregate()
+            disabled = training_logs._tensor_path_disabled
+        finally:
+            self._clear_aggregation_fns()
+
+        self.assertTrue(disabled, "must latch off after a mismatch")
+        self.assertAlmostEqual(aggregated["dummy/layer_0/mean"], 2.0, places=12)
+        self.assertAlmostEqual(aggregated["dummy/layer_9/mean"], 6.0, places=12, msg="legacy path took over")
+
     def test_log_flags_are_respected(self):
         probe = DummyProbe(log_per_layer=False, log_global=True)
         probe._record_metrics(0, {"mean": 2.0})

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -509,7 +509,7 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
     def test_expert_shares_come_from_assignment_and_probs(self):
         """assignment -> token share, probs -> combine-weight share, both in percent."""
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
         monitor.declare_layer_vector(0, "expert_token_share", 3)
         monitor.declare_layer_vector(0, "expert_weight_share", 3)
         monitor.allocate_buffers()
@@ -534,7 +534,7 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
     def test_expert_token_share_survives_missing_probs(self):
         """A gate that returns no combine weights still yields the token share."""
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
         monitor.declare_layer_vector(0, "expert_token_share", 2)
         monitor.declare_layer_vector(0, "expert_weight_share", 2)
         monitor.allocate_buffers()
@@ -546,6 +546,86 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e0"], 75.0, places=4)
         self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e1"], 25.0, places=4)
         self.assertNotIn("moe_health/layer_0/expert_weight_share_e0", latest)
+
+    def test_per_expert_share_recording_is_off_by_default(self):
+        """The curves are opt-in: 2 x num_experts keys/layer dominate the gather payload."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        self.assertFalse(monitor.log_per_expert_share)
+        monitor.declare_layer_vector(0, "expert_token_share", 2)
+        monitor.allocate_buffers()
+
+        monitor._record_expert_shares(0, paddle.to_tensor([3.0, 1.0]), (None, None, None))
+        monitor.step()
+
+        self.assertEqual(training_logs.get_latest(prefix="moe_health"), {})
+
+    def test_per_expert_share_declaration_follows_the_flag(self):
+        """register_hooks declares the vectors only when the flag is on."""
+
+        class Gate(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.num_experts = 4
+
+        class TransformerLayer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layer_idx = 0
+                self.mlp = nn.Layer()
+                self.mlp.gate = Gate()
+
+        class Model(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.LayerList([TransformerLayer()])
+
+        off = PaddleMoEMonitor(log_per_layer=True, log_global=False)
+        off.register_hooks(Model())
+        self.assertEqual(off._vector_keys, {})
+
+        on = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        on.register_hooks(Model())
+        self.assertEqual(
+            set(on._vector_keys),
+            {"moe_health/layer_0/expert_token_share", "moe_health/layer_0/expert_weight_share"},
+        )
+        self.assertEqual(on._vector_keys["moe_health/layer_0/expert_token_share"], 4)
+
+    def test_vector_elem_keys_are_marked_pre_aggregated(self):
+        """allocate_buffers keeps the per-element keys out of the gather payload.
+
+        Their cross-rank reduction happens on device in _flush_gpu_buffer, so pickling
+        one copy per rank through all_gather_object would be pure overhead.
+        """
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        monitor.declare_layer_vector(0, "expert_token_share", 3)
+        monitor.declare_layer_metric(0, "router_entropy")
+        try:
+            monitor.allocate_buffers()
+
+            for i in range(3):
+                self.assertIn(f"moe_health/layer_0/expert_token_share_e{i}", training_logs._pre_aggregated_keys)
+            self.assertNotIn("moe_health/layer_0/router_entropy", training_logs._pre_aggregated_keys)
+        finally:
+            training_logs._pre_aggregated_keys.clear()
+
+    def test_vector_reduction_is_a_noop_without_a_process_group(self):
+        """Single-card / no DP group: fall back to the rank-local vector mean."""
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        monitor.declare_layer_vector(0, "expert_token_share", 2)
+        try:
+            monitor.allocate_buffers()
+            self.assertIsNone(monitor._vector_reduce_group())
+
+            monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([20.0, 80.0]))
+            monitor.record_layer_vector(0, "expert_token_share", paddle.to_tensor([40.0, 60.0]))
+            monitor.step()
+
+            latest = training_logs.get_latest(prefix="moe_health")
+            self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e0"], 30.0, places=4)
+            self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e1"], 70.0, places=4)
+        finally:
+            training_logs._pre_aggregated_keys.clear()
 
     def test_gpu_buffer_multi_layer_global_aggregation(self):
         """Global metrics are derived from layer accumulators at flush time."""

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -509,7 +509,7 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
     def test_expert_shares_come_from_assignment_and_probs(self):
         """assignment -> token share, probs -> combine-weight share, both in percent."""
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
         monitor.declare_layer_vector(0, "expert_token_share", 3)
         monitor.declare_layer_vector(0, "expert_weight_share", 3)
         monitor.allocate_buffers()
@@ -534,7 +534,7 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
     def test_expert_token_share_survives_missing_probs(self):
         """A gate that returns no combine weights still yields the token share."""
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
         monitor.declare_layer_vector(0, "expert_token_share", 2)
         monitor.declare_layer_vector(0, "expert_weight_share", 2)
         monitor.allocate_buffers()
@@ -547,57 +547,13 @@ class PaddleMoEMonitorTest(unittest.TestCase):
         self.assertAlmostEqual(latest["moe_health/layer_0/expert_token_share_e1"], 25.0, places=4)
         self.assertNotIn("moe_health/layer_0/expert_weight_share_e0", latest)
 
-    def test_per_expert_share_recording_is_off_by_default(self):
-        """The curves are opt-in: 2 x num_experts keys/layer dominate the gather payload."""
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
-        self.assertFalse(monitor.log_per_expert_share)
-        monitor.declare_layer_vector(0, "expert_token_share", 2)
-        monitor.allocate_buffers()
-
-        monitor._record_expert_shares(0, paddle.to_tensor([3.0, 1.0]), (None, None, None))
-        monitor.step()
-
-        self.assertEqual(training_logs.get_latest(prefix="moe_health"), {})
-
-    def test_per_expert_share_declaration_follows_the_flag(self):
-        """register_hooks declares the vectors only when the flag is on."""
-
-        class Gate(nn.Layer):
-            def __init__(self):
-                super().__init__()
-                self.num_experts = 4
-
-        class TransformerLayer(nn.Layer):
-            def __init__(self):
-                super().__init__()
-                self.layer_idx = 0
-                self.mlp = nn.Layer()
-                self.mlp.gate = Gate()
-
-        class Model(nn.Layer):
-            def __init__(self):
-                super().__init__()
-                self.layers = nn.LayerList([TransformerLayer()])
-
-        off = PaddleMoEMonitor(log_per_layer=True, log_global=False)
-        off.register_hooks(Model())
-        self.assertEqual(off._vector_keys, {})
-
-        on = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
-        on.register_hooks(Model())
-        self.assertEqual(
-            set(on._vector_keys),
-            {"moe_health/layer_0/expert_token_share", "moe_health/layer_0/expert_weight_share"},
-        )
-        self.assertEqual(on._vector_keys["moe_health/layer_0/expert_token_share"], 4)
-
     def test_vector_elem_keys_are_marked_pre_aggregated(self):
         """allocate_buffers keeps the per-element keys out of the gather payload.
 
         Their cross-rank reduction happens on device in _flush_gpu_buffer, so pickling
         one copy per rank through all_gather_object would be pure overhead.
         """
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
         monitor.declare_layer_vector(0, "expert_token_share", 3)
         monitor.declare_layer_metric(0, "router_entropy")
         try:
@@ -611,7 +567,7 @@ class PaddleMoEMonitorTest(unittest.TestCase):
 
     def test_vector_reduction_is_a_noop_without_a_process_group(self):
         """Single-card / no DP group: fall back to the rank-local vector mean."""
-        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False, log_per_expert_share=True)
+        monitor = PaddleMoEMonitor(log_per_layer=True, log_global=False)
         monitor.declare_layer_vector(0, "expert_token_share", 2)
         try:
             monitor.allocate_buffers()


### PR DESCRIPTION
## 问题

`training_logs.gather_and_aggregate` 走 `all_gather_object`：每个 rank 把自己的 K 个 key 全量 pickle 出去，rank0 再按 key 遍历 N 份 payload：

```python
for k in all_keys:
    values = [v[k] for v in info_list if k in v]
```

payload 和聚合耗时都是 O(K×N)。paddlefleet 下每层 1251 个 key（其中 84% 是向量展开出来的），单进程精确复现（pickle + 聚合是纯本地 CPU）：

- 512 rank：4.1s
- 4096 rank：2.9GB 常驻 / 43.7s CPU

## 改动

1. **`moe_monitor`** — per-expert 的 token / combine 占比曲线默认关闭，由 `log_per_expert_share=True` 打开。这两组是 `2 × num_experts` 个向量元素/层，占 payload 大头，日常巡检只看聚合量。没有 revert #55，因为 #58 依赖它。
2. **`paddlefleet/base`** — 向量指标在 GPU 上按 DP(+CP) 组以 float64 `all_reduce` 求均值，单独一次 D2H，并 `mark_pre_aggregated` 从 payload 摘掉。
3. **`core/training_logs`** — 标量走固定 schema 的 tensor `all_reduce`。schema 在 PP 组内取并集后排序，按 max / min / mean 切段，SUM 段同时带 presence mask，所以均值语义与旧路径**逐位一致**（不是 count-weighted）。schema 不一致时 latch off 回退旧路径。

## 三个坑（都是 8 卡实测暴露的）

- **校验值不能放在 payload 里。** 第一版把 crc32 塞进 payload 一起 reduce，结果某个 rank-unique key 让 PP 组并集长度不一致 → `all_reduce` 形状不匹配是**挂死**而不是报错，校验值永远等不到被比较。改成 payload 之前先发一次**定长 2 元素探针**（schema 长度 + crc32，MAX/MIN 各一次）。
- **PP=1 时单 rank 组会被 paddle 拒绝**，两个 backend 都加了 `nranks <= 1` 短路 + try/except 降级。
- **向量归约必须 float64。** 第一版 float32 下 5734 个 mhc 向量指标偏差到 1.9e-7（≈float32 eps），且按 sqrt(N)·eps 增长，4096 卡下到 1e-6。不能复用标量那次 float32 concat，否则又被截断。

## 收益（4096 rank）

- payload 2.9GB → 132KB
- 聚合 43.7s → 1.4ms
- 且与卡数无关

## 验证

- 352 个单测通过（`PYTHONPATH=<Megatron-LM> pytest tests/ -q`）
- `tests/manual_verify_tensor_aggregate.py`：单机 8 卡，PP=1/2/4/8 各 12/12
- 真实训练 10 step A/B（`FLAGS_embedding_deterministic=1` + `FLAGS_cudnn_deterministic=1`）：**loss 10 步全部逐位一致**；内科指标 30408/30410 逐位一致，余 2 个是 `gate_mass_max_min_ratio` 的 1 ULP（1.7e-16）；768 个 per-expert key 按预期消失；零回退告警

## 顺带说明

`all_gather_object` 的聚合循环本身**没有**可优化空间——实测两种改写都更慢（原版 1347ms，dict-of-lists 2458ms，defaultdict 累积 2161ms），所以只能从降 K 和换通信原语两侧入手。