### PR TITLE
feat(core): 用 sampled_this_step 暴露采样相位，供调用方门控跨 rank 聚合

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,23 @@ from internal_medicine import training_logs
 | 包含 `_min` 或以 `/min` 结尾 | `np.min(all_ranks)` |
 | 其他 | `np.mean(all_ranks)` |
 
+**`monitor_interval > 1` 时不要每步都调用**：`gather_and_aggregate()` 是全 world 的
+集合通信，只有采样步才可能产出指标，其余步跑的是一次空的 `all_gather_object`
+（6144 卡实测 872 ms/步）。调用方应当先问 `monitor.sampled_this_step`——它由
+`step()` 在自增前锁存，是"刚结束这一步的 hook 有没有采样"的唯一权威答案：
+
+```python
+if any(m.sampled_this_step for m in monitor_dict.values()):
+    aggregated = training_logs.gather_and_aggregate()
+```
+
+**不要**用调用方自己的步数取模去推这个相位（`global_step % interval == 1`）。
+`step_count` 是进程内变量、续训从 0 重开，而 `global_step` 从 checkpoint 恢复；
+两者相位一旦错开（resume 步不是 `monitor_interval` 整数倍时必然错开），门控会
+静默挡掉全部采样步。同时注意：这个判断决定要不要进集合通信，**条件必须全 rank
+一致**，`sampled_this_step` 只依赖各 rank 同步推进的 `step_count`，本地指标是否
+为空则不满足这个要求（历史上据此早返回导致过 PP 死锁）。
+
 注意: QK Stats Monitor 不在 hook 内做 TP `all_reduce`/`all_gather`，避免在 attention 热路径插入通信；跨 rank 聚合统一交给 `gather_and_aggregate()`。MassiveAct 会先对 TP 内 per-channel maxima 做 `MAX all_reduce`（通道维被 TP 切分时这是正确性所需），再依赖 `gather_and_aggregate()` 做跨 rank 聚合；MoE/PLE 同样依赖 `gather_and_aggregate()` 统一处理。
 
 ### 通用配置参数

--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -36,6 +36,7 @@ class Probe(ABC):
         self.verbose = verbose
         self.hooks = []
         self.step_count = 0
+        self.sampled_this_step = False
         self.pp_rank = 0
         self._global_accum: dict[str, float] = {}
         self._global_metric_counts: dict[str, int] = {}
@@ -50,6 +51,15 @@ class Probe(ABC):
         self.hooks = []
 
     def step(self):
+        # Latch *before* the increment: the hooks that ran during this step's
+        # forward saw the pre-increment ``step_count``, so this is the answer to
+        # "did this step sample anything?". A trainer callback that wants to skip
+        # the cross-rank gather on non-sampling steps must read this instead of
+        # re-deriving the phase from its own global step counter — that counter
+        # resumes from a checkpoint while ``step_count`` restarts at 0, and the
+        # two drift apart whenever the resume step is not a multiple of
+        # ``monitor_interval``.
+        self.sampled_this_step = self._interval_reached()
         self.step_count += 1
         self._flush_buffers()
         if self.log_global and self._global_accum:
@@ -62,10 +72,19 @@ class Probe(ABC):
         """
         return None
 
-    def _should_monitor(self) -> bool:
+    def _interval_reached(self) -> bool:
+        """Whether ``step_count`` puts this step on the sampling interval.
+
+        The single owner of the sampling phase. ``_should_monitor`` adds
+        backend-specific conditions on top; ``step`` latches this one alone so
+        the flag stays a pure function of the step counter.
+        """
         if not self.monitor_interval:
             return False
         return self.step_count % self.monitor_interval == 0
+
+    def _should_monitor(self) -> bool:
+        return self._interval_reached()
 
     # ------------------------------------------------------------------
     # Legacy CPU-float API

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -153,6 +153,53 @@ class CoreMonitoringTest(unittest.TestCase):
     def test_paddlefleet_registry_lists_massive_activation_monitor(self):
         self.assertIn("massive_act", AVAILABLE_MONITORS["paddlefleet"])
 
+    def test_sampled_this_step_marks_exactly_the_steps_the_hooks_recorded(self):
+        """The flag is what a trainer callback gates its cross-rank gather on.
+
+        It has to agree with `_should_monitor()` as seen *inside* the hooks —
+        i.e. the pre-increment `step_count` — or the callback either drops
+        metrics or pays for an empty collective.
+        """
+        for interval in (1, 2, 3, 5, 200):
+            probe = DummyProbe(monitor_interval=interval)
+            recorded, flagged = [], []
+            for global_step in range(1, 4 * interval + 2):
+                if probe._should_monitor():  # forward: hooks see step_count pre-increment
+                    recorded.append(global_step)
+                probe.step()  # on_step_end
+                if probe.sampled_this_step:  # on_log
+                    flagged.append(global_step)
+            self.assertEqual(recorded, flagged, f"interval={interval}")
+            self.assertEqual(recorded[0], 1, f"interval={interval}")
+
+    def test_sampled_this_step_survives_a_resume_at_an_unaligned_step(self):
+        """`step_count` restarts at 0 on resume while `global_step` does not.
+
+        Deriving the phase from `global_step % interval` drifts (and silently
+        drops every sampled step); the flag cannot, because it only ever reads
+        `step_count`.
+        """
+        interval = 200
+        for resume_at in (0, 300, 5050, 999):
+            probe = DummyProbe(monitor_interval=interval)
+            recorded, flagged, by_global_step = [], [], []
+            for global_step in range(resume_at + 1, resume_at + 1 + 3 * interval):
+                if probe._should_monitor():
+                    recorded.append(global_step)
+                probe.step()
+                if probe.sampled_this_step:
+                    flagged.append(global_step)
+                if global_step % interval == 1:
+                    by_global_step.append(global_step)
+            self.assertEqual(recorded, flagged, f"resume_at={resume_at}")
+            if resume_at % interval:
+                self.assertNotEqual(recorded, by_global_step, f"resume_at={resume_at}")
+
+    def test_sampled_this_step_is_false_when_monitoring_is_disabled(self):
+        probe = DummyProbe(monitor_interval=0)
+        probe.step()
+        self.assertFalse(probe.sampled_this_step)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 问题

`monitor_interval > 1` 时，`gather_and_aggregate()` 在 199/200 步上跑的是一次**空的**全 world 集合通信——6144 卡实测 **872 ms/步**，摊薄 **868 ms/步**（`all_gather_object` 栈占 py-spy 采样的 12.8%，与普通步 POSTOPT 1068 ms vs 老版 196 ms 的差完全吻合）。

调用方（`InternalMedicineCallback.on_log`，`logging_steps=1` 时每步触发）需要知道"这一步有没有采样"才能跳过它。但这个判定有两条硬约束：

1. **必须全 rank 一致。** 用本地 metrics 是否为空来判，在 PP stage 之间不对称——没有被监控层的 stage 恒为空，它跳过集合通信，其余 rank 就永远等在里面。#45 正是为此把 `if not all_metrics: return {}` 删掉的（PP=4 死锁）。
2. **不能由调用方自己的步数取模推出。** `step_count` 是进程内变量、续训从 0 重开，`global_step` 从 checkpoint 恢复。resume 步不是 `monitor_interval` 整数倍时两者相位必然错开——线上 jsonl 里已经观察到：

   ```
   steps = [1, 201, 401, 551, 751, 951, 1151, ...]
   → mod 200 有两个值 {1, 151}
   ```

   写死 `global_step % interval == 1` 在重启后会**静默挡掉全部采样步**，而且 `reset()` 也永不执行，meter 一直累积。

## 改动

`step()` 是唯一同时知道"hook 看到的 `step_count`"和"自增时机"的地方，由它在**自增前**锁存：

```python
def step(self):
    self.sampled_this_step = self._interval_reached()
    self.step_count += 1
    ...

def _interval_reached(self) -> bool:
    """采样相位的唯一归属地。"""
    if not self.monitor_interval:
        return False
    return self.step_count % self.monitor_interval == 0

def _should_monitor(self) -> bool:
    return self._interval_reached()
```

相位规则收敛到 `_interval_reached()` 一处。标志刻意只读 `_interval_reached()` 而非 `_should_monitor()`——后者在 paddlefleet 里叠了 `paddle.is_grad_enabled()`，而 `step()` 在 `on_step_end` 调用、不在 forward 的梯度上下文里，用它会引入一个与采样时刻不同源的条件。标志保持为步数的纯函数。

`step_count` 在各 rank 上同步推进，因此天然满足约束 1。

## 调用方用法

```python
if any(m.sampled_this_step for m in monitor_dict.values()):
    aggregated = training_logs.gather_and_aggregate()
```

建议用 `getattr(m, "sampled_this_step", True)` 读，这样配旧版库时退化成"照旧 gather"——丢的是优化而不是指标。README 的跨卡聚合章节已补上这段，并写明为什么不能用取模。

## 测试

新增 3 个，全量 **347 passed**：

- `test_sampled_this_step_marks_exactly_the_steps_the_hooks_recorded`：interval = 1/2/3/5/200，hook 实际采样的步集合与标志放行的步集合逐一相等
- `test_sampled_this_step_survives_a_resume_at_an_unaligned_step`：resume_at = 0/300/5050/999 下仍对齐，**同时断言取模方案在此确实会错**——把旧方案的失效固化成回归，防止有人改回取模
- `test_sampled_this_step_is_false_when_monitoring_is_disabled`：`monitor_interval=0`

## 说明

这个 commit 原本在 #62 上，拆出来单独走，因为它能独立合入、且线上收益（摊薄 868 ms/步，占 step 时间约 14.5%）比 #62 更急。#62 处理的是另一笔账：采样步本身的 37.9 s（K 太大，摊薄 190 ms/步）。两者互不依赖。