### PR TITLE
feat(families): 线上默认不采按结构单元展开的指标族

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 
 | Monitor | 族 |
 |---------|-----|
-| `mhc_health` | `gate` 门控强度 / `mix` 混合矩阵 / `gain` 增益放大 / `param` 可学习参数 / `share` 残差占比 |
+| `mhc_health` | `gate` 门控强度（逐层聚合）/ `stream` 按流门控值 `h_{pre,post}_idx{i}` / `mix` 混合矩阵（逐层聚合）/ `cell` 混合矩阵元素 `h_res_cell{i}` / `gain` 增益放大 / `param` 可学习参数 / `share` 残差占比 |
 | `qk_stats` | `sink` sink head / `logit` logits 量级 / `entropy` 注意力熵 / `qkv` q/k/v 范数 |
 | `massive_act` | `channel` 通道量级分布 / `outlier` 超大通道计数 / `module` 各模块输出量级 / `norm` 归一化后表示 / `overall` 整体激活量级 |
 | `ape_health` | `softmax` 位置 softmax 形状 / `coverage` 位置覆盖 / `scale` 量级与数值健康 |
@@ -816,15 +816,33 @@ setup_monitors(
 )
 ```
 
-PaddleFormers YAML 里用独立的一项（不塞进 `internal_medicine_monitors`）：
+单个 monitor 也可以直接传 `exclude_families=["mix"]`。只提供排除式、不提供白名单：白名单会把分类表的遗漏变成静默漏采（新族不在名单里 → 不采集，且无人察觉），而排除式下同样的遗漏只是「payload 没省下来」。想「只看某几族」就填它的补集。
+
+### 线上默认与 debug 模式 (debug_mode)
+
+训练侧不暴露族名字符串，只有一个布尔开关：**默认（`debug_mode=False`）排除按结构单元膨胀的族**，`debug_mode=True` 才全采。这个集合是代码里的常量 `DEBUG_ONLY_FAMILIES`：
+
+| Monitor | 默认排除的族 | 内容 | 膨胀方式 |
+|---------|------------|------|---------|
+| `moe_health` | `expert` | `expert_{token,weight}_share_e{i}` | 每专家一条 |
+| `mhc_health` | `cell` | `{attn,mlp}_h_res_cell{i}` | 每层每个混合矩阵元素一条 |
+| `mhc_health` | `stream` | `{attn,mlp}_h_{pre,post}_idx{i}` | 每层每个输入流一条 |
+
+在 43 层 mHC + MoE 的配置上，这三族占每步 3732 个 key 里的 1392 个（37.3%）——同比例地占跨 rank 聚合的 payload 和落盘的 jsonl。其余族的 key 数只随层数变化。
+
+关键是这三族**恰好是诊断层不读的部分**：诊断看的是逐层聚合量（`h_res_logits_max`、`h_post_mean`、`h_post_stream_concentration` 等），它们留在 `mix` / `gate` 里照常采集。所以线上默认只省 payload，不损失任何诊断深度——这也正是把 `mix` / `gate` 各拆成「逐层聚合」和「按单元展开」两族的原因。
 
 ```yaml
 internal_medicine_monitors: "qk_stats,moe_health,massive_act,mhc_health,vha_health"
 internal_medicine_monitor_interval: 200
-internal_medicine_exclude_families: "mhc_health:mix, moe_health:expert+act"
+internal_medicine_debug_mode: false   # true = 连按专家/按 cell/按流的族一起采
 ```
 
-单个 monitor 也可以直接传 `exclude_families=["mix"]`。只提供排除式、不提供白名单：白名单会把分类表的遗漏变成静默漏采（新族不在名单里 → 不采集，且无人察觉），而排除式下同样的遗漏只是「payload 没省下来」。想「只看某几族」就填它的补集。
+```python
+from internal_medicine.core.metric_families import exclusions_for
+
+setup_monitors(model, monitors=[...], exclude_families=exclusions_for(debug_mode=False))
+```
 
 ---
 

--- a/src/internal_medicine/core/metric_families.py
+++ b/src/internal_medicine/core/metric_families.py
@@ -27,11 +27,13 @@ import re
 
 __all__ = [
     "METRIC_TAXONOMY",
+    "DEBUG_ONLY_FAMILIES",
     "FAMILY_OTHER",
     "UnknownFamilyError",
     "UnknownMonitorError",
     "classify",
     "components_of",
+    "exclusions_for",
     "families_of",
     "parse_exclude",
     "parse_exclusions",
@@ -54,8 +56,12 @@ _VHA_BRANCH_RE = re.compile(r"^(?:main|sparse)_(?P<base>.+)$")
 METRIC_TAXONOMY: dict[str, dict] = {
     "mhc_health": {
         "components": ("attn", "mlp"),
+        # `stream` and `cell` must precede `gate` / `mix`: they are the per-unit
+        # slices of those same quantities and would otherwise be swallowed.
         "families": (
+            ("stream", "按流门控值 h_pre / h_post_idx", r"^h_(pre|post)_idx\d"),
             ("gate", "门控强度 h_pre / h_post", r"^h_(pre|post)(_|$)"),
+            ("cell", "混合矩阵元素 h_res_cell", r"^h_res_cell\d"),
             ("mix", "混合矩阵 h_res", r"^h_res(_|$)"),
             ("gain", "增益放大 amax / composite", r"amax_gain"),
             ("param", "可学习参数 α / bias", r"^(alpha|bias)_"),
@@ -194,6 +200,40 @@ class FamilySelection:
 
 class UnknownFamilyError(ValueError):
     """A config named a family the monitor does not declare."""
+
+
+# Families kept out of a production run and collected only under debug mode.
+#
+# The criterion is *how a family's key count grows*, not how interesting it is:
+# each family below emits one curve per structural unit — per expert, per
+# hyper-connection cell, per input stream — so its footprint scales with depth x
+# expert count while every other family stays constant. On a 43-layer mHC + MoE
+# run these three are 1392 of 3732 keys per step (37.3%), the same share of the
+# cross-rank payload and of the jsonl on disk.
+#
+# They are also exactly the families the diagnosis layer never reads: it works
+# off the per-layer aggregates (`h_res_logits_max`, `h_post_mean`, ...), which
+# stay on. So this default costs payload and nothing else — the reason `mix` and
+# `gate` are split into an aggregate half and a per-unit half at all.
+#
+# Deliberately a code-side constant rather than a config string: the switch that
+# selects it carries one bit, so there is nothing to get wrong in a yaml file,
+# and changing what "debug" means becomes a reviewable diff.
+DEBUG_ONLY_FAMILIES: dict[str, tuple[str, ...]] = {
+    "moe_health": ("expert",),
+    "mhc_health": ("cell", "stream"),
+}
+
+
+def exclusions_for(debug_mode: bool) -> dict[str, list[str]]:
+    """``{monitor: [family, ...]}`` to switch off for this run.
+
+    ``debug_mode=True`` collects everything; the production default drops
+    ``DEBUG_ONLY_FAMILIES``. Returns a fresh dict so callers may mutate it.
+    """
+    if debug_mode:
+        return {}
+    return {monitor: list(families) for monitor, families in DEBUG_ONLY_FAMILIES.items()}
 
 
 def _split_names(value) -> list[str]:

--- a/tests/test_metric_families.py
+++ b/tests/test_metric_families.py
@@ -113,7 +113,7 @@ class FamilySelectionTest(unittest.TestCase):
                 continue
             (kept if selection.allows(sub) else dropped).add(mf.classify(monitor, sub)[0])
         self.assertEqual(dropped, {"mix"})
-        self.assertEqual(kept, {"gate", "gain", "param", "share"})
+        self.assertEqual(kept, {"gate", "stream", "cell", "gain", "param", "share"})
 
     def test_excluding_several_families_at_once(self):
         selection = mf.parse_exclude("moe_health", "expert+act")
@@ -172,6 +172,74 @@ class FamilySelectionTest(unittest.TestCase):
     def test_a_known_but_unused_monitor_is_accepted(self):
         """One exclusion string may be shared by configs enabling different monitors."""
         mf.validate_exclusions(mf.parse_exclusions("moe_health:expert"), {"moe_health": None, "qk_stats": None})
+
+
+class DebugOnlyFamiliesTest(unittest.TestCase):
+    def test_mhc_per_unit_slices_are_their_own_families(self):
+        """The per-cell / per-stream curves must not fall into their aggregates.
+
+        This split is the whole point of the production default: `h_res_cell{i}`
+        and `h_{pre,post}_idx{i}` are one curve per structural unit, while
+        `h_res_logits_max` / `h_post_mean` are one per layer and are what the
+        diagnosis layer reads.
+        """
+        self.assertEqual(mf.classify("mhc_health", "attn_h_res_cell0"), ("cell", "attn"))
+        self.assertEqual(mf.classify("mhc_health", "attn_h_res_logits_max"), ("mix", "attn"))
+        self.assertEqual(mf.classify("mhc_health", "mlp_h_pre_idx3"), ("stream", "mlp"))
+        self.assertEqual(mf.classify("mhc_health", "mlp_h_post_idx3"), ("stream", "mlp"))
+        self.assertEqual(mf.classify("mhc_health", "mlp_h_post_mean"), ("gate", "mlp"))
+        # `global_` aggregates have no index and so stay with the aggregates.
+        self.assertEqual(mf.classify("mhc_health", "global_attn_h_post_token_std")[0], "gate")
+
+    def test_the_debug_only_set_is_pinned(self):
+        """Changing what a production run stops collecting must be a visible diff."""
+        self.assertEqual(
+            {monitor: set(families) for monitor, families in mf.DEBUG_ONLY_FAMILIES.items()},
+            {"moe_health": {"expert"}, "mhc_health": {"cell", "stream"}},
+        )
+
+    def test_every_debug_only_family_is_a_declared_family(self):
+        """A stale name here would silently switch nothing off in production."""
+        for monitor, families in mf.DEBUG_ONLY_FAMILIES.items():
+            selection = mf.parse_exclude(monitor, list(families))
+            self.assertEqual(selection.excluded, frozenset(families))
+
+    def test_debug_mode_collects_everything(self):
+        self.assertEqual(mf.exclusions_for(True), {})
+
+    def test_production_drops_the_debug_only_families(self):
+        self.assertEqual(
+            mf.exclusions_for(False),
+            {monitor: list(families) for monitor, families in mf.DEBUG_ONLY_FAMILIES.items()},
+        )
+
+    def test_the_returned_mapping_is_the_callers_to_mutate(self):
+        """Backends merge per-monitor options into it; the constant must survive."""
+        excluded = mf.exclusions_for(False)
+        excluded["moe_health"].append("router")
+        excluded["qk_stats"] = ["sink"]
+        self.assertEqual(mf.DEBUG_ONLY_FAMILIES["moe_health"], ("expert",))
+        self.assertNotIn("qk_stats", mf.DEBUG_ONLY_FAMILIES)
+
+    def test_production_exclusions_pass_backend_validation(self):
+        """The default must never be the thing that fails a run at startup."""
+        known = {monitor: None for monitor in mf.METRIC_TAXONOMY}
+        mf.validate_exclusions(mf.exclusions_for(False), known, backend="paddlefleet")
+
+    def test_the_debug_only_families_are_the_ones_that_grow_per_unit(self):
+        """The selection criterion, checked against real keys rather than asserted.
+
+        Indices are normalised out of the corpus, so this counts *distinct key
+        shapes*, not the per-step key count — enough to show these families carry
+        the per-expert / per-cell fan-out.
+        """
+        counts = {}
+        for monitor, sub in corpus_entries():
+            family, _component = mf.classify(monitor, sub)
+            counts[(monitor, family)] = counts.get((monitor, family), 0) + 1
+        for monitor, families in mf.DEBUG_ONLY_FAMILIES.items():
+            for family in families:
+                self.assertGreater(counts.get((monitor, family), 0), 0, f"{monitor}:{family} matches no real key")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 做了什么

把 `mhc_health` 的 `mix` / `gate` 各拆成「逐层聚合」和「按结构单元展开」两族，并把后者连同 `moe_health:expert` 定为线上默认不采：

- `mix` → 拆出 `cell`：`{attn,mlp}_h_res_cell{i}`，每层每个混合矩阵元素一条（416 个）
- `gate` → 拆出 `stream`：`{attn,mlp}_h_{pre,post}_idx{i}`，每层每个输入流一条（208 个）
- `moe_health:expert`：`expert_{token,weight}_share_e{i}`，每专家一条（768 个）

`stream` / `cell` 必须排在 `gate` / `mix` 之前——`^h_(pre|post)(_|$)` 会吞掉 `h_pre_idx3`。族是声明序、首次匹配即中，新增测试钉住这条边界。

## 训练侧的面只有一个 bit

```yaml
internal_medicine_debug_mode: false   # true = 连这三族一起采
```

集合本身是库侧常量 `DEBUG_ONLY_FAMILIES`，由 `exclusions_for(debug_mode)` 转成 backend 已经接受的排除映射。不做成 yaml 里的族名字符串：debug 模式多采哪几族是分类表的性质，放在分类表旁边才能被单测钉住，yaml 里也就没有可写错的东西。

## 收益与代价

- 43 层 mHC + MoE 的真实 jsonl：3732 → 2340 keys/step，**省 1392 个（37.3%）**，同比例省跨 rank 聚合 payload、buffer 和落盘体积
- 拿 `tools/internal_medicine/diagnose.py` 逐名比对：**被排除的指标名它一个都没引用**。诊断读的是逐层聚合量（`h_res_logits_max`、`h_post_mean`、`h_post_stream_concentration` 等），这些留在 `mix` / `gate` 里照常采集。所以这个默认只省 payload，不损失诊断深度——这也正是要做这次拆分的原因
- 已知影响：`compare_server.py` 的 `derive_context` 靠按专家/按 cell 的 key 下标反推 `n_experts` 和 `n_streams`，默认配置下会变成 `None`，跨 run 对比的可比性判级少这部分结构信息。修法是补一行 run-meta（那处注释里已经写了这是正解），而不是为了带两个整数采 1392 条曲线

## 验证

`pre-commit run --all-files` 通过；`pytest tests/ -q` **386 passed**（新增 8 个：钉住 cell/stream 与 mix/gate 的边界、钉住 `DEBUG_ONLY_FAMILIES` 内容、每个名字都是已声明的族、默认集合能过 backend 校验、返回的映射可被调用方安全 mutate）。

配套：PaddlePaddle/PaddleFormers#4940（透传 `internal_medicine_debug_mode`）。

## 勘误(2026-09-02)

本 PR 的默认排除只对 `moe_health:expert` 生效,`mhc_health` 的 `cell` / `stream`实际仍在采集。原因:`declare_layer_vector`(backends/paddlefleet/base.py)按未展开的base name 判族,而 `h_res` / `h_pre` / `h_post` 分别落到 `mix` / `gate`——这两族线上保留,于是向量照样声明。`cell` / `stream` 只在展开后的 `_{elem_tag}{i}` 上才匹配得到。

本 PR 是第一次引入「族名只存在于展开后缀里」的族,而声明路径的既有测试(`test_vector_families_are_filtered_too`,PR #64)只用 `moe_health:expert` 验证,其 base name 自带族名,对这个场景空过,因此没能拦住。

实测(13 层 run):3042 keys/step,其中 cell 416、stream 208 仍在,expert 0。描述里「3732 → 2340,省 37.3%」是推算值,合入时未端到端核对。

修复与回归测试见 #<后续 PR 号>。分类表的声明序(stream/cell 先于 gate/mix)本身是对的,不是排序回归。