### PR TITLE
fix(families): classify vector metrics by expanded key

### DIFF
--- a/src/internal_medicine/backends/paddlefleet/base.py
+++ b/src/internal_medicine/backends/paddlefleet/base.py
@@ -254,7 +254,9 @@ class PaddleProbe(Probe):
         if not self.log_per_layer:
             return
         key = self._layer_key(layer_idx, metric_name)
-        if not self.family_allows(key):
+        # 判族要用展开后的元素名：per-unit 族（cell / stream）只在 ``_{elem_tag}{i}``
+        # 后缀上才匹配得到，base name 会落到聚合族（mix / gate）而误判为保留。
+        if not self.family_allows(f"{key}_{elem_tag}0"):
             # No buffer is allocated, so record_layer_vector already no-ops on it.
             return
         assert key not in self._vector_keys, f"declare_layer_vector({key!r}) declared twice"

--- a/tests/test_mhc_paddlefleet_monitor.py
+++ b/tests/test_mhc_paddlefleet_monitor.py
@@ -861,6 +861,53 @@ class MHCMonitorTest(unittest.TestCase):
         monitor.step()
 
 
+class MHCVectorFamilyExclusionTest(unittest.TestCase):
+    """`cell` / `stream` are per-unit families and must be droppable.
+
+    Regression: `declare_layer_vector` judged the family on the undecorated base
+    name, and `h_res` / `h_pre` / `h_post` classify as the *aggregate* families
+    (`mix` / `gate`) that production keeps. Only the expanded element names carry
+    `cell` / `stream`, so a non-debug run collected all 624 curves anyway.
+    """
+
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def _declare(self, exclude_families):
+        monitor = mhc_monitor.PaddleMHCHealthMonitor(
+            log_per_layer=True, log_global=False, exclude_families=exclude_families
+        )
+        for name, tag, size in mhc_monitor._vector_metric_specs(4):
+            monitor.declare_layer_vector(0, f"attn_{name}", size, elem_tag=tag)
+        return monitor
+
+    def test_cell_and_stream_vectors_are_dropped(self):
+        monitor = self._declare("cell+stream")
+        self.assertEqual(monitor._vector_keys, {})
+
+    def test_dropping_cell_alone_keeps_the_stream_vectors(self):
+        monitor = self._declare("cell")
+        self.assertEqual(
+            sorted(monitor._vector_keys),
+            [
+                "mhc_health/layer_0/attn_h_post",
+                "mhc_health/layer_0/attn_h_pre",
+            ],
+        )
+
+    def test_aggregate_families_do_not_drop_the_per_unit_vectors(self):
+        """`mix` / `gate` must not take `h_res` / `h_pre` down with them."""
+        monitor = self._declare("mix+gate")
+        self.assertEqual(len(monitor._vector_keys), 3)
+
+    def test_default_run_collects_everything(self):
+        monitor = self._declare(None)
+        self.assertEqual(len(monitor._vector_keys), 3)
+
+
 class MHCMonitorNoOpTest(unittest.TestCase):
     def setUp(self):
         training_logs.reset()


### PR DESCRIPTION
## 问题

`declare_layer_vector` 使用未展开的 base key 判断指标族。

对 mHC 向量指标而言：

- `h_res` 会被归入聚合族 `mix`，展开后才是 `h_res_cell{i}` → `cell`
- `h_pre` / `h_post` 会被归入聚合族 `gate`，展开后才是 `h_{pre,post}_idx{i}` → `stream`

因此 `internal_medicine_debug_mode: false` 虽然排除了 `cell` / `stream`，但声明阶段仍把这些向量注册下来，导致线上继续采集全部 per-unit 曲线。反向也存在误判：排除 `mix` / `gate` 会误伤对应的 per-unit 向量。

## 修复

`declare_layer_vector` 改用代表性的展开元素 key 判族：

```python
if not self.family_allows(f"{key}_{elem_tag}0"):
    return
```

这样 cell / stream 按展开后的真实输出名称分类； moe_health:expert 仍正常归入 expert。