### PR TITLE
feat(core): support skipping resumed training steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,13 @@ if any(m.sampled_this_step for m in monitor_dict.values()):
 一致**，`sampled_this_step` 只依赖各 rank 同步推进的 `step_count`，本地指标是否
 为空则不满足这个要求（历史上据此早返回导致过 PP 死锁）。
 
+从 checkpoint 续训时，如果要避免新进程 `step_count == 0` 导致恢复后的第一步
+必然采样，应在首个 forward 前对所有 monitor 调用 `skip_next_steps(1)`。该门控
+在 hook 做指标计算之前生效；被跳过的 step 仍推进本地 `step_count`，但不会 flush
+指标 buffer，`sampled_this_step` 也保持为 `False`，调用方因而可同时跳过跨卡聚合
+与日志输出。是否属于续训应由调用方使用已恢复的 Trainer state 判断，不应依赖
+历史指标文件是否存在。
+
 注意: QK Stats Monitor 不在 hook 内做 TP `all_reduce`/`all_gather`，避免在 attention 热路径插入通信；跨 rank 聚合统一交给 `gather_and_aggregate()`。MassiveAct 会先对 TP 内 per-channel maxima 做 `MAX all_reduce`（通道维被 TP 切分时这是正确性所需），再依赖 `gather_and_aggregate()` 做跨 rank 聚合；MoE/PLE 同样依赖 `gather_and_aggregate()` 统一处理。
 
 ### 通用配置参数

--- a/src/internal_medicine/core/base_monitor.py
+++ b/src/internal_medicine/core/base_monitor.py
@@ -52,6 +52,7 @@ class Probe(ABC):
         self.hooks = []
         self.step_count = 0
         self.sampled_this_step = False
+        self._skip_steps_remaining = 0
         self.pp_rank = 0
         self._global_accum: dict[str, float] = {}
         self._global_metric_counts: dict[str, int] = {}
@@ -102,11 +103,15 @@ class Probe(ABC):
         # resumes from a checkpoint while ``step_count`` restarts at 0, and the
         # two drift apart whenever the resume step is not a multiple of
         # ``monitor_interval``.
+        skip_step = self._skip_steps_remaining > 0
         self.sampled_this_step = self._interval_reached()
+        if skip_step:
+            self._skip_steps_remaining -= 1
         self.step_count += 1
-        self._flush_buffers()
-        if self.log_global and self._global_accum:
-            self._flush_global_metrics()
+        if not skip_step:
+            self._flush_buffers()
+            if self.log_global and self._global_accum:
+                self._flush_global_metrics()
 
     def _flush_buffers(self) -> None:
         """Hook for backend-specific batched flush. Default: no-op.
@@ -122,12 +127,21 @@ class Probe(ABC):
         backend-specific conditions on top; ``step`` latches this one alone so
         the flag stays a pure function of the step counter.
         """
-        if not self.monitor_interval:
+        if self._skip_steps_remaining > 0 or not self.monitor_interval:
             return False
         return self.step_count % self.monitor_interval == 0
 
     def _should_monitor(self) -> bool:
         return self._interval_reached()
+
+    def skip_next_steps(self, count: int = 1) -> None:
+        """Suppress metric collection for the next ``count`` training steps.
+
+        The gate lives on the probe so forward/backward hooks see it before doing
+        metric work. ``step()`` still advances the local interval counter while
+        consuming the suppression, preserving the existing process-local phase.
+        """
+        self._skip_steps_remaining = max(self._skip_steps_remaining, max(0, int(count)))
 
     # ------------------------------------------------------------------
     # Legacy CPU-float API

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -199,6 +200,46 @@ class CoreMonitoringTest(unittest.TestCase):
         probe = DummyProbe(monitor_interval=0)
         probe.step()
         self.assertFalse(probe.sampled_this_step)
+
+    def test_skip_next_step_suppresses_hooks_and_sampled_flag_once(self):
+        probe = DummyProbe(monitor_interval=1)
+        probe._flush_buffers = Mock()
+        probe.skip_next_steps()
+
+        self.assertFalse(probe._should_monitor())
+        probe.step()
+        self.assertFalse(probe.sampled_this_step)
+        self.assertEqual(probe.step_count, 1)
+        probe._flush_buffers.assert_not_called()
+
+        self.assertTrue(probe._should_monitor())
+        probe.step()
+        self.assertTrue(probe.sampled_this_step)
+        probe._flush_buffers.assert_called_once_with()
+
+    def test_skip_next_step_preserves_process_local_interval_phase(self):
+        probe = DummyProbe(monitor_interval=5)
+        probe.skip_next_steps()
+        sampled_steps = []
+
+        for resumed_step in range(1, 8):
+            if probe._should_monitor():
+                sampled_steps.append(resumed_step)
+            probe.step()
+
+        self.assertEqual(sampled_steps, [6])
+
+    def test_skip_next_steps_consumes_exactly_requested_count(self):
+        probe = DummyProbe(monitor_interval=1)
+        probe.skip_next_steps(2)
+        sampled = []
+
+        for step in range(1, 5):
+            if probe._should_monitor():
+                sampled.append(step)
+            probe.step()
+
+        self.assertEqual(sampled, [3, 4])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR types

 Performance optimization


### PR changes

Docs
Others

### Description

When resuming training from a checkpoint, each internal medicine monitor's local `step_count` restarts from 0, while `TrainerState.global_step` is restored. As a result, the first resumed training step is incorrectly sampled because `0 % monitor_interval == 0`.

This change adds a one-shot `skip_next_steps()` gate to the monitor base class. The gate is applied before forward and backward hooks perform metric calculation. When resuming from a checkpoint, the first resumed step is skipped based on `global_step > 0`.

The skipped step:

- does not collect internal medicine metrics;
- does not flush metric buffers;
- sets `sampled_this_step` to `False`;
- does not trigger cross-rank metric gathering;
- does not write to `internal_medicine.jsonl`.

The monitor's local `step_count` still advances normally, so the existing process-local sampling phase is preserved. Cold-start behavior is unchanged.

### Validation

- End-to-end single-node 8-GPU cold-start and checkpoint-resume validation passed.
- Cold-start internal medicine sampling occurred at global steps 1, 6, and 11.
- Resumed from global step 15 and continued to global step 21.
- No internal medicine record was generated for resumed global step 16.
- Internal medicine sampling resumed normally at global step 21.
- Internal medicine tests: 301 passed, with 5 subtests passed.
- Monitor regression tests: 15 passed.
- PaddleFormers callback regression tests: 2 passed.
- Ruff checks and `git diff --check` passed.