### PR TITLE
perf(core): reduce metrics across ranks instead of gathering objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ from internal_medicine import training_logs
 
 ### 跨卡聚合
 
-`training_logs.gather_and_aggregate()` 通过 `dist.all_gather_object` 收集所有 rank 的指标，然后按键名规则聚合：
+`training_logs.gather_and_aggregate()` 收集所有 rank 的指标，然后按键名规则聚合：
 
 | 键名模式 | 聚合方式 |
 |----------|----------|
@@ -758,6 +758,10 @@ from internal_medicine import training_logs
 | `massive_act_channel_count` 或 `channel_count_gt_*` | `np.max(all_ranks)` |
 | 包含 `_min` 或以 `/min` 结尾 | `np.min(all_ranks)` |
 | 其他 | `np.mean(all_ranks)` |
+
+PaddleFleet 后端默认走**数值 all_reduce**：首次采样只 `all_gather_object` 各 rank 的 key 名
+以对齐 layout，之后每次采样只交换一个 float64 向量（3 次 all_reduce：SUM 值与 count、MAX、MIN），
+载荷不随 world size 增长。`all_gather_object` 保留为回退路径，`IM_DISABLE_REDUCE=1` 可切回。
 
 **`monitor_interval > 1` 时不要每步都调用**：`gather_and_aggregate()` 是全 world 的
 集合通信，只有采样步才可能产出指标，其余步跑的是一次空的 `all_gather_object`

--- a/src/internal_medicine/backends/paddlefleet/gather.py
+++ b/src/internal_medicine/backends/paddlefleet/gather.py
@@ -1,4 +1,10 @@
-"""PaddleFleet distributed gather function for training_logs."""
+"""PaddleFleet cross-rank aggregation for training_logs.
+
+Two paths live here. ``_paddle_gather`` is the original object gather, kept as a
+fallback. ``_PaddleReducer`` is the numeric path: it exchanges a float64 vector
+whose length is the number of metric keys, so the payload no longer scales with
+world size and no rank has to unpickle world_size dicts.
+"""
 
 import logging
 
@@ -16,8 +22,139 @@ def _paddle_gather(local_metrics: dict) -> list:
     return info_list
 
 
+class _PaddleReducer:
+    """Reduce metrics across ranks with a layout agreed once, then reused.
+
+    ``all_reduce`` needs every rank to pass the same shape, so the key layout has
+    to be global. Deriving it is a collective operation, which means the
+    *decision* to re-derive it must be collective too — a rank that re-aligns
+    alone would hang the job. Hence every call first agrees, in two tiny
+    reductions, on whether the cached layout still holds.
+    """
+
+    def __init__(self):
+        self._layout: tuple[str, ...] = ()
+        self._modes: tuple[int, ...] = ()  # 0=mean, 1=max, 2=min, parallel to _layout
+        self._fingerprint: int | None = None
+
+    def __call__(self, schema):
+        import paddle
+        import paddle.distributed as dist
+
+        if not dist.is_initialized() or dist.get_world_size() == 1:
+            return None
+
+        if not self._agree_on_layout(schema, paddle, dist):
+            self._align(schema, dist)
+        if not self._layout:
+            return {}
+        return self._reduce(schema, paddle, dist)
+
+    # ------------------------------------------------------------------
+    # Layout agreement
+    # ------------------------------------------------------------------
+
+    def _agree_on_layout(self, schema, paddle, dist) -> bool:
+        """True when every rank still shares the cached layout."""
+        local_fp = schema.fingerprint
+        stale = 1 if (not self._layout or local_fp != self._fingerprint) else 0
+        probe = paddle.to_tensor([local_fp, stale], dtype="int64")
+        dist.all_reduce(probe, op=dist.ReduceOp.MAX)
+        fp_max, any_stale = (int(v) for v in probe.numpy())
+        fp_only = paddle.to_tensor([local_fp], dtype="int64")
+        dist.all_reduce(fp_only, op=dist.ReduceOp.MIN)
+        fp_min = int(fp_only.numpy()[0])
+        return fp_max == fp_min and not any_stale
+
+    def _align(self, schema, dist) -> None:
+        """Derive the global layout from every rank's key names.
+
+        Only the names travel here, and only when the schema actually changed —
+        under a fixed model that is once per process.
+        """
+        payload = {"mean": schema.mean_keys, "max": schema.max_keys, "min": schema.min_keys}
+        gathered: list = []
+        dist.all_gather_object(gathered, payload)
+
+        merged: dict[int, set] = {0: set(), 1: set(), 2: set()}
+        for item in gathered:
+            merged[0].update(item.get("mean", ()))
+            merged[1].update(item.get("max", ()))
+            merged[2].update(item.get("min", ()))
+
+        layout: list[str] = []
+        modes: list[int] = []
+        for mode in (0, 1, 2):
+            for key in sorted(merged[mode]):
+                layout.append(key)
+                modes.append(mode)
+        self._layout = tuple(layout)
+        self._modes = tuple(modes)
+        self._fingerprint = schema.fingerprint
+        logger.info(f"[internal_medicine] reduce layout aligned: {len(self._layout)} keys")
+
+    # ------------------------------------------------------------------
+    # Reduction
+    # ------------------------------------------------------------------
+
+    def _reduce(self, schema, paddle, dist) -> dict:
+        values = schema.values
+        n = len(self._layout)
+        # float64: a float32 sum over thousands of ranks loses digits these
+        # metrics are read at, and doubling a few-KB payload costs nothing.
+        sums = [0.0] * n
+        counts = [0.0] * n
+        maxs = [float("-inf")] * n
+        mins = [float("inf")] * n
+
+        for idx, (key, mode) in enumerate(zip(self._layout, self._modes, strict=True)):
+            if key not in values:
+                continue
+            val = values[key]
+            if mode == 0:
+                sums[idx] = val
+                counts[idx] = 1.0
+            elif mode == 1:
+                maxs[idx] = val
+            else:
+                mins[idx] = val
+
+        # mean needs sum and count together, so pack them into one collective.
+        sum_t = paddle.to_tensor(sums + counts, dtype="float64")
+        max_t = paddle.to_tensor(maxs, dtype="float64")
+        min_t = paddle.to_tensor(mins, dtype="float64")
+        dist.all_reduce(sum_t, op=dist.ReduceOp.SUM)
+        dist.all_reduce(max_t, op=dist.ReduceOp.MAX)
+        dist.all_reduce(min_t, op=dist.ReduceOp.MIN)
+
+        # Single D2H for the whole result, matching the probes' one-sync-per-step rule.
+        flat = paddle.concat([sum_t, max_t, min_t]).numpy().tolist()
+        sum_out, cnt_out = flat[:n], flat[n : 2 * n]
+        max_out, min_out = flat[2 * n : 3 * n], flat[3 * n :]
+
+        out: dict[str, float] = {}
+        for idx, (key, mode) in enumerate(zip(self._layout, self._modes, strict=True)):
+            if mode == 0:
+                count = cnt_out[idx]
+                if count > 0:
+                    out[key] = sum_out[idx] / count
+            elif mode == 1:
+                if max_out[idx] != float("-inf"):
+                    out[key] = max_out[idx]
+            elif min_out[idx] != float("inf"):
+                out[key] = min_out[idx]
+        return out
+
+
 def install_gather_fn():
-    """Install the paddle-based gather function into the global training_logs."""
+    """Install the paddle-based aggregation into the global training_logs.
+
+    ``IM_DISABLE_REDUCE=1`` keeps the object-gather path. It exists so the
+    reduction can be switched off in a running job — and so an A/B can hold
+    everything else fixed — without shipping a different build.
+    """
+    import os
+
     from ...core.training_logs import training_logs
 
     try:
@@ -25,5 +162,9 @@ def install_gather_fn():
 
         if dist.is_initialized():
             training_logs.set_gather_fn(_paddle_gather)
+            if os.environ.get("IM_DISABLE_REDUCE", "") == "1":
+                logger.info("[internal_medicine] IM_DISABLE_REDUCE=1: using all_gather_object")
+            else:
+                training_logs.set_reduce_fn(_PaddleReducer())
     except ImportError:
         pass

--- a/src/internal_medicine/core/training_logs.py
+++ b/src/internal_medicine/core/training_logs.py
@@ -6,12 +6,44 @@ is the caller's responsibility.
 """
 
 import logging
+import zlib
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
-__all__ = ("SmoothedValue", "TrainingLogs", "training_logs")
+__all__ = ("ReduceSchema", "SmoothedValue", "TrainingLogs", "training_logs")
+
+
+@dataclass(frozen=True)
+class ReduceSchema:
+    """One rank's metrics, split by how they reduce across ranks.
+
+    ``mean_keys`` / ``max_keys`` / ``min_keys`` are sorted so that two ranks
+    holding the same key set produce byte-identical layouts, which is what makes
+    the fingerprint below a usable agreement check.
+    """
+
+    values: dict
+    mean_keys: tuple[str, ...] = ()
+    max_keys: tuple[str, ...] = ()
+    min_keys: tuple[str, ...] = ()
+
+    @property
+    def fingerprint(self) -> int:
+        """Stable hash of the local key layout.
+
+        ``hash()`` is salted per process (PYTHONHASHSEED), so it would disagree
+        between ranks that hold identical keys and trigger a re-alignment every
+        step. CRC32 is stable across processes and interpreter runs.
+        """
+        blob = "\u0000".join(("M", *self.mean_keys, "X", *self.max_keys, "N", *self.min_keys))
+        return zlib.crc32(blob.encode()) & 0x7FFFFFFF
+
+    def all_keys(self) -> tuple[str, ...]:
+        return self.mean_keys + self.max_keys + self.min_keys
+
 
 MAX_AGGREGATED_SUFFIXES = (
     "topk_channel_norm",
@@ -96,6 +128,23 @@ class TrainingLogs:
         """Set the distributed gather function (backend provides this)."""
         self._gather_fn = fn
 
+    def set_reduce_fn(self, fn: Callable):
+        """Install a numeric cross-rank reducer, preferred over ``gather_fn``.
+
+        ``all_gather_object`` pickles the whole ``{key: value}`` dict, so its
+        payload — and the receive buffer, and the number of unpickle calls on
+        every rank — grows with world size: at 6144 ranks a 155 KB dict means
+        ~930 MB of traffic per rank and 6144 deserialisations, none of which the
+        GPU can overlap. The aggregation only ever needs mean/max/min, which a
+        reduction can do in one pass with a payload that does not depend on world
+        size at all. Backends that cannot reduce (or want the old semantics) just
+        leave this unset and keep using ``gather_fn``.
+
+        ``fn(schema) -> dict[str, float] | None`` receives a ``ReduceSchema`` and
+        returns the aggregated metrics, or None to fall back to the gather path.
+        """
+        self._reduce_fn = fn
+
     def update(self, **kwargs):
         for k, v in kwargs.items():
             self[k] = v
@@ -165,8 +214,14 @@ class TrainingLogs:
         self.meters.clear()
 
     def gather_and_aggregate(self):
-        """Gather metrics from all ranks and aggregate by naming convention."""
+        """Aggregate metrics across ranks, by reduction when the backend can."""
         all_metrics = self.get_latest()
+
+        reduce_fn = getattr(self, "_reduce_fn", None)
+        if reduce_fn is not None:
+            reduced = reduce_fn(self.build_reduce_schema(all_metrics))
+            if reduced is not None:
+                return reduced
 
         gather_fn = getattr(self, "_gather_fn", None)
         if gather_fn is None:
@@ -189,6 +244,28 @@ class TrainingLogs:
             else:
                 aggregated[k] = sum(values) / len(values)
         return aggregated
+
+    def build_reduce_schema(self, metrics: dict) -> ReduceSchema:
+        """Describe this rank's metrics for a numeric cross-rank reduction.
+
+        The mode split has to happen here, not in the backend: ``_is_max_metric``
+        and ``_is_min_metric`` are the single source of truth for how a key
+        reduces, and the gather path already agrees with them.
+        """
+        mean_keys, max_keys, min_keys = [], [], []
+        for key in metrics:
+            if self._is_max_metric(key):
+                max_keys.append(key)
+            elif self._is_min_metric(key):
+                min_keys.append(key)
+            else:
+                mean_keys.append(key)
+        return ReduceSchema(
+            values=metrics,
+            mean_keys=tuple(sorted(mean_keys)),
+            max_keys=tuple(sorted(max_keys)),
+            min_keys=tuple(sorted(min_keys)),
+        )
 
 
 training_logs = TrainingLogs()

--- a/tests/test_core_monitoring.py
+++ b/tests/test_core_monitoring.py
@@ -82,6 +82,61 @@ class CoreMonitoringTest(unittest.TestCase):
         self.assertEqual(calls, [{}], "gather_fn must be called even with no local metrics")
         self.assertEqual(aggregated, {"dummy/layer_0/mean": 4.0})
 
+    def test_reduce_path_is_preferred_and_matches_gather_semantics(self):
+        """The numeric reducer must agree with the object-gather it replaces."""
+        training_logs.update(**{"dummy/a_mean": 2.0, "dummy/b_max": 5.0, "dummy/c_min": 1.0})
+        captured = {}
+
+        def fake_reduce(schema):
+            captured["schema"] = schema
+            # Emulate a second rank: mean averages, max/min extend.
+            return {"dummy/a_mean": 3.0, "dummy/b_max": 9.0, "dummy/c_min": 0.5}
+
+        def fake_gather(_local):
+            raise AssertionError("gather_fn must not run when a reducer is installed")
+
+        training_logs.set_gather_fn(fake_gather)
+        training_logs.set_reduce_fn(fake_reduce)
+        try:
+            aggregated = training_logs.gather_and_aggregate()
+        finally:
+            training_logs.set_reduce_fn(None)
+            training_logs.set_gather_fn(None)
+
+        self.assertEqual(aggregated["dummy/a_mean"], 3.0)
+        self.assertEqual(aggregated["dummy/b_max"], 9.0)
+        self.assertEqual(aggregated["dummy/c_min"], 0.5)
+
+        schema = captured["schema"]
+        self.assertEqual(schema.max_keys, ("dummy/b_max",))
+        self.assertEqual(schema.min_keys, ("dummy/c_min",))
+        self.assertEqual(schema.mean_keys, ("dummy/a_mean",))
+        training_logs.reset()
+
+    def test_reduce_falls_back_to_gather_when_reducer_declines(self):
+        """A single-rank job (or an unsupported backend) keeps the old path."""
+        training_logs.update(**{"dummy/a_mean": 2.0})
+        training_logs.set_reduce_fn(lambda schema: None)
+        training_logs.set_gather_fn(lambda local: [local, {"dummy/a_mean": 4.0}])
+        try:
+            aggregated = training_logs.gather_and_aggregate()
+        finally:
+            training_logs.set_reduce_fn(None)
+            training_logs.set_gather_fn(None)
+
+        self.assertEqual(aggregated, {"dummy/a_mean": 3.0})
+        training_logs.reset()
+
+    def test_reduce_fingerprint_is_stable_across_processes(self):
+        """PYTHONHASHSEED-salted hash() would re-align the layout every step."""
+        schema = training_logs.build_reduce_schema({"dummy/a_mean": 1.0, "dummy/b_max": 2.0})
+        # Recomputed from the same key layout, as another rank would.
+        twin = training_logs.build_reduce_schema({"dummy/b_max": 9.0, "dummy/a_mean": 9.0})
+        self.assertEqual(schema.fingerprint, twin.fingerprint)
+        different = training_logs.build_reduce_schema({"dummy/a_mean": 1.0})
+        self.assertNotEqual(schema.fingerprint, different.fingerprint)
+        training_logs.reset()
+
     def test_log_flags_are_respected(self):
         probe = DummyProbe(log_per_layer=False, log_global=True)
         probe._record_metrics(0, {"mean": 2.0})


### PR DESCRIPTION
## 背景

跨 rank 聚合走 `dist.all_gather_object`，代价随 world size 线性增长：

- payload 里 ~92% 是 key 字符串，每个采样步重传一遍。3000 个指标 pickle 后 155 KB，其中数值本身只有 11.7 KB。
- 接收缓冲是 `world_size × max_len`，unpickle 要跑 `world_size` 次。
- 本机实测 `loads()` 0.444 ms / 155 KB。外推到 6144 卡：每 rank ~2.7 s 反序列化 + ~930 MB 过网 + 930 MB 接收缓冲，且这段 CPU 时间 GPU 无法 overlap。
- 打开 per-expert 指标族（47000 keys）时是 ~65 s / 14.9 GB。

## 改动

聚合只需要 mean/max/min，这三个都是 reduce 语义，payload 与 world size 无关。改为交换一个 float64 向量：

- 一次 `SUM`（values 与 counts 拼接，mean 除以真正持有该 key 的 rank 数）
- 一次 `MAX`、一次 `MIN`
- 结果只做一次 D2H

用 float64 而非 float32：上千 rank 求和会吃掉这些指标实际读数的有效位，而 23 KB 的额外体积可以忽略。

### layout 对齐

`all_reduce` 要求各 rank 形状一致，所以 key layout 是全局量；推导 layout 本身是集合操作，于是"是否要重新推导"也必须是集合决策 —— 单个 rank 独自重新对齐会挂住整个任务。每次调用先用两次 ≤24 B 的 reduce 就"缓存的 layout 是否仍然有效"达成一致，`stale` 用 `MAX` 传播，任一 rank 发现漂移就带所有 rank 一起重新对齐。

fingerprint 用 `zlib.crc32` 而不是内置 `hash()`：后者受 `PYTHONHASHSEED` 加盐，会导致每步都误判漂移。

### PP 下的异构 key

PP rank 持有的 key 集合本就不同，这由 count 向量承载，语义与 gather 路径上的 `if k in v` 完全一致。缺失项在 MAX/MIN 中填 ±inf，聚合后按 count 过滤，因此全体缺失的 key 不会漏出 inf。

## 验证

8 卡、其余变量全部固定，与 gather 路径对照：

- step 1 全部 1829 个指标相对偏差 `0.000e+00`，key 集合完全一致
- `reduce layout aligned` 只出现一次（2417 keys），采样步相位一致
- 后续步偏差从 1e-6 涨到 1e-5 且随步数增长 —— 这是两条独立训练轨迹本身的发散，不是聚合误差
- 单测覆盖：reducer 优先级、reducer 拒绝时回落 gather、fingerprint 跨进程稳定

## 回退与影响面

- `IM_DISABLE_REDUCE=1` 保留原 object gather 路径，线上任务可不换镜像直接回退
- Megatron backend 与单 rank 任务不受影响