### PR TITLE
feat(moe): report dispatched tokens per card and their peak/mean ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,70 @@ PaddleFleet 后端还会直接从每次 router forward 的实际选择结果输�
 | | < 0.3 | INEFFECTIVE | 共享专家作用不大 |
 | | > 3.0 | MONOPOLY | 共享专家主导，MoE 退化为 Dense |
 
+### 按卡负载（`card` 族，仅 paddlefleet）
+
+EP 下"这张卡本 step 收到了多少 token"及其峰均比。前面那些负载指标都是**发送侧**视角
+（router 把本 rank 的 token 分给了哪些专家），这一族是 dispatch **之后**的**接收侧**视角
+——决定 step 时间的是收得最多的那张卡，全组都要等它。
+
+| 指标 | 含义 |
+|------|------|
+| `card_tokens_max` | 收到 token 最多的那张卡 |
+| `card_tokens_mean` | 平均 |
+| `card_tokens_peak_mean_ratio` | 峰均比。1.0 = 完全均衡 |
+
+#### 两种口径，同一组 key
+
+`_reduce_card_tokens_over_ep` 跑完后，**同一 EP 组内每张卡持有的这三个值是相同的**（max 与 mean
+都是组内 `all_reduce` 出来的）。之后跨 rank 归约按 key 名再来一层，于是三条曲线各自代表不同的范围：
+
+- `card_tokens_max` → `all_reduce(MAX)`：max of maxes = **全局最热的那张卡**
+- `card_tokens_mean` → `all_reduce(SUM)/count`：G 个组各 `ep_size` 张卡都上报组均值 `m_g`，
+  `(Σ_g ep_size·m_g) / (G·ep_size) = (Σ_g m_g)/G` = **全局所有卡的均值**（各组等大时）
+- `card_tokens_peak_mean_ratio` → `all_reduce(SUM)/count` = **各 EP 组峰均比的平均**
+
+所以：
+
+| 想问的问题 | 看哪个 |
+|---|---|
+| 全世界最热的卡比全局平均重几倍（木桶效应，谁拖住了 step 时间） | 自己算 `card_tokens_max / card_tokens_mean` |
+| 平均而言每个 EP 组内部有多少不均衡（路由层面，与 DP 数据分布差异无关） | `card_tokens_peak_mean_ratio` |
+
+两者的差就是 DP 维贡献的那部分不均衡。举例：`PP=2, EP=4, DP=2`，某层两个 EP 组分别收到
+`[1000,1000,1000,1000]` 和 `[4000,0,0,0]`，则 `max=4000`、`mean=1000`、`peak_mean_ratio=2.5`，
+手算 `max/mean=4.0`。**`peak_mean_ratio` 才是与 `moe_logging` 逐点可比的那一个。**
+
+口径与 PaddleFleet `moe_logging` 的 `local_tokens_per_card_layer_{N}_max_mean_ratio`
+（`moe_utils.py:_log_local_tokens_per_card`）一致：统计范围是**一个 EP 组内**，不含 DP 维。
+
+#### 微批的归约顺序是语义的一部分
+
+峰值先在**微批内**跨卡取，之后才对微批求平均 —— 即
+`mean_微批( max_卡 )`，与 `log_moe_balance` 相同。先把各微批的负载平均、再跨卡取 max
+会得到 `max_卡( mean_微批 )`，由 `max` 的凸性它**恒不大于**前者，只有"每个微批里最热的都是同一张卡"
+时才相等。12 层 EP=8 实测两者差到 8%。
+
+同理，`card_tokens_peak_mean_ratio` 是**逐微批比值的平均**而不是两条上报曲线的比值：
+只有当每微批的跨卡均值恒定（不丢 token 时成立）两者才重合。要木桶效应就自己拿
+`max / mean` 除，那是另一个口径（见上表），不是这条曲线的近似。
+
+取数点是 `moe_layer.dispatch` 上的一个 patch —— 计数是 dispatcher 的状态
+（`token_dispatcher.get_dispatched_routing()[2]`），不在任何模块的 forward 返回值里，
+而且只有 a2a 完成后才有效。热路径上只有一次 `sum` 和一次 append，没有 D2H、没有通信。
+
+EP 归约批到 `step()` 里做：把各层各微批的本地值 stack 成一个 `[层数, 微批数]` 矩阵，
+**整个栈一共两次 `all_reduce`**（MAX + SUM）—— 逐微批的峰值由一次逐元素 MAX 一并得到，
+不需要每个微批各来一次通信。payload 从 `L` 个 float 变成 `L×M` 个，仍在 1 KB 以内。
+
+对照之下 PaddleFleet 那份实现是每层**每微批**一次 `all_gather_object` 外加一次 D2H
+（`log_moe_balance` 里 `tokens_per_expert.cpu()`，它自己的注释就写了那是同步点），
+43 层 × 16 微批 = 688 次各一 —— 这也是它为什么只能突发采样
+（`trainer_utils.py:129-134` 的 `(step+1) % (interval*interval) < interval`）。
+
+> 该族依赖 `moe_layer.moe_group` 判定 EP 组。同一 EP 组的各 rank 持有相同的层、跑相同数量的
+> 微批，所以矩阵形状在组内一致，集合通信不会错配。某层触发次数不同时按最短的那次截断，
+> 而不是改矩阵形状。
+
 ---
 
 ## 二、QK Stats Monitor (qk_stats)
@@ -810,7 +874,7 @@ NeMo Trainer 对应字段为 `internal_medicine_hook_timing`。开启后 trainer
 | `massive_act` | `channel` 通道量级分布 / `outlier` 超大通道计数 / `module` 各模块输出量级 / `norm` 归一化后表示 / `overall` 整体激活量级 |
 | `ape_health` | `softmax` 位置 softmax 形状 / `coverage` 位置覆盖 / `scale` 量级与数值健康 |
 | `vha_health` | `mix` postmix 混合矩阵 / `gain` postmix 增益与扰动 / `head` 头间一致性 |
-| `moe_health` | `router` 路由打分质量 / `balance` 负载均衡 / `norm` 专家范数与 bias / `spectrum` gate 谱性质 / `act` 激活量级 / `shared` 共享 vs 路由 / `expert` 按专家分布 |
+| `moe_health` | `router` 路由打分质量 / `balance` 负载均衡 / `norm` 专家范数与 bias / `spectrum` gate 谱性质 / `act` 激活量级 / `shared` 共享 vs 路由 / `expert` 按专家分布 / `card` 按卡负载（EP 组内） |
 
 语义是**排除优先**：没声明的族默认全开，所以不配置这个参数时行为与以前逐字节一致；分类表若有遗漏，那条指标不属于任何排除集合，仍会被采集（fail-open）。反过来，族名写错会在启动时直接抛 `UnknownFamilyError`（fail-closed）——否则唯一的症状是「payload 没变小」，太难发现。
 

--- a/src/internal_medicine/backends/paddlefleet/moe_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/moe_monitor.py
@@ -388,6 +388,7 @@ class PaddleMoEMonitor(PaddleProbe):
         "assignment_load_max_min_ratio",
         "gate_mass_max_frac",
         "gate_mass_max_min_ratio",
+        "card_tokens_max",
     }
     MIN_AGGREGATED = {
         "score_sum_min",
@@ -418,9 +419,15 @@ class PaddleMoEMonitor(PaddleProbe):
         )
         self._patched_gates = []
         self._patched_moe_layers = []
+        self._patched_dispatch_layers = []
         self._expert_norm_layers = []
         self._shared_act_norm_cache: dict = {}  # layer_idx -> 0-dim GPU tensor
         self._routed_act_norm_cache: dict = {}  # layer_idx -> 0-dim GPU tensor
+        # Per-card dispatched token counts, one entry per microbatch, reduced
+        # over the EP group once per step (see _reduce_card_tokens_over_ep).
+        self._card_tokens_seq: dict = {}  # layer_idx -> [0-dim GPU tensor, per microbatch]
+        self._moe_group = None
+        self._ep_size = 1
 
     def register_hooks(self, model: nn.Layer):
         try:
@@ -436,6 +443,8 @@ class PaddleMoEMonitor(PaddleProbe):
             return
         if self.verbose:
             logger.info(f"[PaddleMoEMonitor] Found {len(moe_layers)} MoE layers.")
+
+        self._init_moe_group(moe_layers)
 
         # Declare metric schema
         for layer_idx, moe_layer in moe_layers:
@@ -503,6 +512,12 @@ class PaddleMoEMonitor(PaddleProbe):
                 ]
             for m in gate_metrics + expert_metrics + act_metrics:
                 self.declare_layer_metric(layer_idx, m)
+            # Dispatched tokens per card. Declared for every MoE layer whose
+            # dispatcher can report them; the values are filled at step() time
+            # after one EP-group reduction, not from the hook.
+            if self._dispatch_reports_tokens(moe_layer):
+                for m in ("card_tokens_max", "card_tokens_mean", "card_tokens_peak_mean_ratio"):
+                    self.declare_layer_metric(layer_idx, m)
             # Per-expert share curves: one metric element per routed expert.
             # num_experts must come from static config here — a hook-time
             # reduction would need a D2H sync to size the schema.
@@ -527,6 +542,8 @@ class PaddleMoEMonitor(PaddleProbe):
             # after routed experts, before adding shared output — no D2H).
             if hasattr(moe_layer, "_post_routed_output"):
                 self._patch_post_routed_output(moe_layer, layer_idx)
+            if self._dispatch_reports_tokens(moe_layer):
+                self._patch_dispatch(moe_layer, layer_idx)
             # Expert weight norms are NOT collected from a forward hook: under
             # offline FP8 quant the bf16 expert weights are cleared at step
             # begin. collect_expert_norms() reads them before quant instead.
@@ -663,6 +680,139 @@ class PaddleMoEMonitor(PaddleProbe):
         moe_layer._im_original_post_routed_output = original_fn
         moe_layer._post_routed_output = patched_post_routed_output
         self._patched_moe_layers.append(moe_layer)
+
+    @staticmethod
+    def _dispatch_reports_tokens(moe_layer) -> bool:
+        """True when this layer's dispatcher can report dispatched token counts."""
+        dispatcher = getattr(moe_layer, "token_dispatcher", None)
+        return hasattr(moe_layer, "dispatch") and hasattr(dispatcher, "get_dispatched_routing")
+
+    def _init_moe_group(self, moe_layers) -> None:
+        """Cache the EP group the per-card reduction runs on.
+
+        ``moe_layer.moe_group`` is the same group PaddleFleet's own
+        ``log_moe_balance`` all-gathers over, so the reported peak/mean ratio
+        keeps that metric's semantics: unbalance *within one EP group*, not
+        across data-parallel replicas.
+        """
+        for _layer_idx, moe_layer in moe_layers:
+            group = getattr(moe_layer, "moe_group", None)
+            if group is None:
+                continue
+            self._moe_group = group
+            try:
+                from paddlefleet.utils import get_pg_size
+
+                self._ep_size = int(get_pg_size(group))
+            except Exception:
+                self._ep_size = 1
+            return
+
+    def _patch_dispatch(self, moe_layer, layer_idx: int):
+        """Read ``tokens_per_expert`` right after dispatch returns.
+
+        A patch on ``dispatch`` rather than a hook: the count lives on the
+        dispatcher as state, not in any module's forward return, and it is only
+        populated once the a2a has completed.
+
+        Hot path cost is one ``sum`` plus one ``add_`` — no D2H, and no
+        collective. The EP reduction that turns this into a peak/mean ratio is
+        batched across all layers into two ``all_reduce`` calls at step() time.
+        """
+        original_fn = moe_layer.dispatch
+        monitor = self
+
+        def patched_dispatch(*args, **kwargs):
+            result = original_fn(*args, **kwargs)
+            if moe_layer.training and monitor._should_monitor():
+                try:
+                    tokens_per_expert = moe_layer.token_dispatcher.get_dispatched_routing()[2]
+                    if tokens_per_expert is not None:
+                        with paddle.no_grad():
+                            monitor._accumulate_card_tokens(layer_idx, tokens_per_expert)
+                except Exception as e:
+                    if monitor.verbose:
+                        logger.error(f"[PaddleMoEMonitor] dispatch patch error layer {layer_idx}: {e}")
+            return result
+
+        moe_layer._im_original_dispatch = original_fn
+        moe_layer.dispatch = patched_dispatch
+        self._patched_dispatch_layers.append(moe_layer)
+
+    def _accumulate_card_tokens(self, layer_idx: int, tokens_per_expert) -> None:
+        """Record this microbatch's local dispatched token total for one layer.
+
+        Kept per microbatch rather than summed: the reported peak is
+        ``mean_over_microbatches(max_over_cards(...))``, and averaging the loads
+        first would compute ``max(mean)``, which by convexity of ``max`` is a
+        different (always smaller) number — see _reduce_card_tokens_over_ep.
+        """
+        if not isinstance(tokens_per_expert, paddle.Tensor):
+            tokens_per_expert = paddle.to_tensor(tokens_per_expert, dtype="float32")
+        local = tokens_per_expert.detach().astype("float32").sum()
+        self._card_tokens_seq.setdefault(layer_idx, []).append(local)
+
+    def _reduce_card_tokens_over_ep(self) -> None:
+        """Turn per-card totals into EP-group max / mean / peak-mean ratio.
+
+        The reduction order matters and matches PaddleFleet's ``log_moe_balance``:
+        each microbatch's peak is taken across cards first, and only then are the
+        microbatches averaged. Averaging the loads first would report
+        ``max_cards(mean_microbatches(load))``, which is ``<=`` this by convexity
+        of ``max`` and equal only when the same card is hottest in every
+        microbatch — measured at up to 8% low on a 12-layer EP=8 run.
+
+        Still **two** ``all_reduce`` calls per step for the whole stack, not one
+        per microbatch: the locals are stacked into one ``[layers, microbatches]``
+        matrix, so per-microbatch peaks come out of a single elementwise MAX. The
+        payload grows from ``L`` to ``L*M`` floats and stays under a kilobyte.
+        The alternative shape — one collective per microbatch — would be 16x the
+        launches for the same numbers; ``log_moe_balance`` pays one
+        ``all_gather_object`` *plus* one D2H per layer per microbatch.
+
+        Every rank of an EP group holds the same layers and runs the same number
+        of microbatches, so the matrix has one shape across the group and the
+        collective cannot mismatch. A layer that fired a different number of
+        times is truncated to the shortest run rather than reshaping the matrix.
+        """
+        if not self._card_tokens_seq:
+            return
+        layer_ids = sorted(self._card_tokens_seq)
+        width = min(len(self._card_tokens_seq[i]) for i in layer_ids)
+        if width == 0:
+            self._card_tokens_seq = {}
+            return
+        local = paddle.stack(
+            [paddle.stack(self._card_tokens_seq[i][:width]) for i in layer_ids]
+        )  # [layers, microbatches]
+        peak_per_mb, mean_per_mb = local, local
+        if self._moe_group is not None and self._ep_size > 1:
+            import paddle.distributed as dist
+
+            peak_per_mb = local.clone()
+            dist.all_reduce(peak_per_mb, op=dist.ReduceOp.MAX, group=self._moe_group)
+            total = local.clone()
+            dist.all_reduce(total, op=dist.ReduceOp.SUM, group=self._moe_group)
+            mean_per_mb = total / float(self._ep_size)
+        peak, mean, ratio = self._card_token_stats(peak_per_mb, mean_per_mb)
+        for pos, layer_idx in enumerate(layer_ids):
+            self.record_layer_metric(layer_idx, "card_tokens_max", peak[pos])
+            self.record_layer_metric(layer_idx, "card_tokens_mean", mean[pos])
+            self.record_layer_metric(layer_idx, "card_tokens_peak_mean_ratio", ratio[pos])
+        self._card_tokens_seq = {}
+
+    @staticmethod
+    def _card_token_stats(peak_per_mb: paddle.Tensor, mean_per_mb: paddle.Tensor):
+        """``[layers, microbatches]`` EP-reduced pair → per-layer peak / mean / ratio.
+
+        Split out so the reduction order is testable without a process group: the
+        ratio is the *mean of per-microbatch ratios*, not the ratio of the means.
+        """
+        return (
+            peak_per_mb.mean(axis=-1),
+            mean_per_mb.mean(axis=-1),
+            (peak_per_mb / mean_per_mb.clip(min=1e-6)).mean(axis=-1),
+        )
 
     def _flush_act_ratio(self):
         """After both shared and routed hooks have run, record the norm ratio."""
@@ -1028,12 +1178,21 @@ class PaddleMoEMonitor(PaddleProbe):
                 if hasattr(moe_layer, attr):
                     delattr(moe_layer, attr)
         self._patched_moe_layers = []
+        for moe_layer in self._patched_dispatch_layers:
+            original_fn = getattr(moe_layer, "_im_original_dispatch", None)
+            if original_fn is not None:
+                moe_layer.dispatch = original_fn
+            if hasattr(moe_layer, "_im_original_dispatch"):
+                delattr(moe_layer, "_im_original_dispatch")
+        self._patched_dispatch_layers = []
+        self._card_tokens_seq = {}
         self._expert_norm_layers = []
         self._shared_act_norm_cache.clear()
         self._routed_act_norm_cache.clear()
 
     def step(self):
         self._flush_act_ratio()
+        self._reduce_card_tokens_over_ep()
         super().step()
 
 

--- a/src/internal_medicine/core/metric_families.py
+++ b/src/internal_medicine/core/metric_families.py
@@ -112,6 +112,7 @@ METRIC_TAXONOMY: dict[str, dict] = {
             ("act", "激活量级", r"_act_(abs_max|mean|norm)$|^routed_act|^shared_act"),
             ("shared", "共享 vs 路由", r"^shared_"),
             ("expert", "按专家分布", r"^expert_(token|weight)_share"),
+            ("card", "按卡负载（EP 组内）", r"^card_tokens_"),
         ),
     },
 }

--- a/tests/fixtures/metric_key_corpus.txt
+++ b/tests/fixtures/metric_key_corpus.txt
@@ -468,3 +468,9 @@ vha_health/mla_main_postmix_u_fro
 vha_health/mla_main_postmix_uv_eff_rank
 vha_health/mla_main_postmix_uv_sigma_max
 vha_health/mla_main_postmix_v_fro
+moe_health/card_tokens_max
+moe_health/global_card_tokens_max
+moe_health/card_tokens_mean
+moe_health/global_card_tokens_mean
+moe_health/card_tokens_peak_mean_ratio
+moe_health/global_card_tokens_peak_mean_ratio

--- a/tests/test_paddlefleet_monitors.py
+++ b/tests/test_paddlefleet_monitors.py
@@ -31,6 +31,7 @@ PaddleQKStatsMonitor = qk_monitor_module.PaddleQKStatsMonitor
 paddlefleet_backend = importlib.import_module("internal_medicine.backends.paddlefleet")
 layer_discovery = importlib.import_module("internal_medicine.backends.paddlefleet.layer_discovery")
 training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
+TrainingLogs = importlib.import_module("internal_medicine.core.training_logs").TrainingLogs
 
 
 class BrokenPaddleMoELayer:
@@ -3151,3 +3152,176 @@ class MetricFamilySelectionTest(unittest.TestCase):
             paddlefleet_backend.setup_monitors(
                 SimpleNamespace(), monitors=["moe_health"], exclude_families="moe:expert"
             )
+
+
+class _FakeDispatcher(nn.Layer):
+    """``token_dispatcher``: the count lives on it as state, not in a return."""
+
+    def __init__(self):
+        super().__init__()
+        self.tokens_per_expert = None
+
+    def get_dispatched_routing(self):
+        return (None, None, self.tokens_per_expert)
+
+
+class _MinimalGate(nn.Layer):
+    """Just enough for `_find_moe_layers` to recognise the module as MoE."""
+
+    def __init__(self, num_experts=4):
+        super().__init__()
+        self.num_experts = num_experts
+
+
+class _FakeMoELayerWithDispatch(nn.Layer):
+    """MoE layer exposing only what the per-card token path reads."""
+
+    def __init__(self, moe_group=None):
+        super().__init__()
+        self.gate = _MinimalGate()
+        self.token_dispatcher = _FakeDispatcher()
+        self.moe_group = moe_group
+        self.dispatch_calls = 0
+
+    def dispatch(self, tokens_per_expert):
+        # Stands in for the real a2a: the dispatcher's state is only valid once
+        # this has returned, which is why the monitor patches it.
+        self.token_dispatcher.tokens_per_expert = tokens_per_expert
+        self.dispatch_calls += 1
+        return tokens_per_expert
+
+
+def _dispatch_model(layers):
+    wrapped = []
+    for moe_layer in layers:
+        layer = nn.Layer()
+        layer.mlp = moe_layer
+        layer.layer_idx = len(wrapped)
+        wrapped.append(layer)
+    return SimpleNamespace(layers=wrapped)
+
+
+class PaddleMoECardTokensTest(unittest.TestCase):
+    """Dispatched tokens per card — EP-group peak / mean / peak-mean ratio."""
+
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    @staticmethod
+    def _counts(*values):
+        return paddle.to_tensor(list(values), dtype="int64")
+
+    def test_the_three_card_metrics_are_emitted(self):
+        moe_layer = _FakeMoELayerWithDispatch()
+        monitor = PaddleMoEMonitor()
+        monitor.register_hooks(_dispatch_model([moe_layer]))
+        moe_layer.dispatch(self._counts(10, 20, 30))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health/layer_0/card_tokens")
+        self.assertAlmostEqual(latest["moe_health/layer_0/card_tokens_max"], 60.0, places=5)
+        self.assertAlmostEqual(latest["moe_health/layer_0/card_tokens_mean"], 60.0, places=5)
+        # Single rank: this card *is* the peak and the mean.
+        self.assertAlmostEqual(latest["moe_health/layer_0/card_tokens_peak_mean_ratio"], 1.0, places=5)
+        monitor.remove_hooks()
+
+    def test_microbatches_are_averaged_not_summed(self):
+        # Otherwise a gradient-accumulation change would move the curve without
+        # any change in balance.
+        moe_layer = _FakeMoELayerWithDispatch()
+        monitor = PaddleMoEMonitor()
+        monitor.register_hooks(_dispatch_model([moe_layer]))
+        moe_layer.dispatch(self._counts(10, 10))
+        moe_layer.dispatch(self._counts(30, 30))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="moe_health/layer_0/card_tokens")
+        self.assertAlmostEqual(latest["moe_health/layer_0/card_tokens_mean"], 40.0, places=5)
+        monitor.remove_hooks()
+
+    def test_the_dispatch_patch_keeps_the_original_return_value(self):
+        moe_layer = _FakeMoELayerWithDispatch()
+        monitor = PaddleMoEMonitor()
+        monitor.register_hooks(_dispatch_model([moe_layer]))
+        counts = self._counts(1, 2)
+        self.assertIs(moe_layer.dispatch(counts), counts)
+        self.assertEqual(moe_layer.dispatch_calls, 1)
+        monitor.remove_hooks()
+
+    def test_remove_hooks_restores_dispatch(self):
+        moe_layer = _FakeMoELayerWithDispatch()
+        monitor = PaddleMoEMonitor()
+        monitor.register_hooks(_dispatch_model([moe_layer]))
+        monitor.remove_hooks()
+        self.assertFalse(hasattr(moe_layer, "_im_original_dispatch"))
+
+        moe_layer.dispatch(self._counts(5, 5))
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="moe_health/layer_0/card_tokens"), {})
+
+    def test_a_layer_without_a_dispatcher_declares_no_card_metrics(self):
+        plain = nn.Layer()
+        plain.gate = _MinimalGate()
+        monitor = PaddleMoEMonitor()
+        monitor.register_hooks(_dispatch_model([plain]))
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="moe_health/layer_0/card_tokens"), {})
+
+    def test_monitor_interval_gates_the_accumulation(self):
+        moe_layer = _FakeMoELayerWithDispatch()
+        monitor = PaddleMoEMonitor(monitor_interval=0)
+        monitor.register_hooks(_dispatch_model([moe_layer]))
+        moe_layer.dispatch(self._counts(10, 20))
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="moe_health/layer_0/card_tokens"), {})
+        monitor.remove_hooks()
+
+    def test_card_metric_naming_contract(self):
+        # training_logs picks the cross-rank reduction from the key name; it must
+        # agree with MAX_AGGREGATED or the EP peak gets averaged across ranks.
+        self.assertIn("card_tokens_max", PaddleMoEMonitor.MAX_AGGREGATED)
+        self.assertTrue(TrainingLogs._is_max_metric("moe_health/layer_0/card_tokens_max"))
+        for name in ("card_tokens_mean", "card_tokens_peak_mean_ratio"):
+            key = f"moe_health/layer_0/{name}"
+            self.assertFalse(TrainingLogs._is_max_metric(key), key)
+            self.assertFalse(TrainingLogs._is_min_metric(key), key)
+
+    def test_the_card_family_can_be_switched_off(self):
+        moe_layer = _FakeMoELayerWithDispatch()
+        monitor = PaddleMoEMonitor(exclude_families="card")
+        monitor.register_hooks(_dispatch_model([moe_layer]))
+        moe_layer.dispatch(self._counts(10, 20))
+        monitor.step()
+        self.assertEqual(training_logs.get_latest(prefix="moe_health/layer_0/card_tokens"), {})
+        monitor.remove_hooks()
+
+    def test_the_ratio_is_the_mean_of_per_microbatch_ratios(self):
+        """Reduction order, pinned without needing a process group.
+
+        `max` is convex, so `mean_mb(max_card)` and `max_card(mean_mb)` differ
+        whenever the hottest card changes between microbatches — and only the
+        first matches PaddleFleet's `log_moe_balance`. Two microbatches with the
+        peak on different cards: peaks 80 and 120, means 40 and 40.
+        """
+        peak_per_mb = paddle.to_tensor([[80.0, 120.0]], dtype="float32")
+        mean_per_mb = paddle.to_tensor([[40.0, 40.0]], dtype="float32")
+        peak, mean, ratio = PaddleMoEMonitor._card_token_stats(peak_per_mb, mean_per_mb)
+        self.assertAlmostEqual(float(peak[0]), 100.0, places=5)
+        self.assertAlmostEqual(float(mean[0]), 40.0, places=5)
+        # mean(80/40, 120/40) = mean(2, 3) = 2.5
+        self.assertAlmostEqual(float(ratio[0]), 2.5, places=5)
+
+    def test_the_ratio_is_not_the_ratio_of_the_reported_means(self):
+        """The two coincide only when the per-microbatch mean is constant.
+
+        Documented in the README because someone will otherwise divide the two
+        reported curves and expect the third.
+        """
+        peak_per_mb = paddle.to_tensor([[80.0, 120.0]], dtype="float32")
+        mean_per_mb = paddle.to_tensor([[40.0, 80.0]], dtype="float32")
+        peak, mean, ratio = PaddleMoEMonitor._card_token_stats(peak_per_mb, mean_per_mb)
+        self.assertAlmostEqual(float(ratio[0]), 1.75, places=5)  # mean(2.0, 1.5)
+        self.assertNotAlmostEqual(float(peak[0]) / float(mean[0]), float(ratio[0]), places=3)


### PR DESCRIPTION
## 背景

现有的负载指标全是**发送侧**视角 —— router 把本 rank 的 token 分给了哪些专家（`assignment_load_*`、`gate_mass_*`、`expert_token_share_*` 都来自 gate 的 post hook）。但决定 step 时间的是**接收侧**：a2a 之后收到 token 最多的那张卡，EP 组里其他卡都得等它。

PaddleFleet 已经在算这个数（`moe_utils.py:_log_local_tokens_per_card` → `local_tokens_per_card_layer_{N}_max_mean_ratio`），只是走 `moe_logging` 开关、写进 `global_training_logs`，不在内科指标体系里。本 PR 把它搬进来，**口径逐点一致**。

## 三个 key

`moe_health` 新增 `card` 族，每个 MoE 层三条：

| key | 含义 |
|---|---|
| `card_tokens_max` | 收到 token 最多的那张卡 |
| `card_tokens_mean` | 平均 |
| `card_tokens_peak_mean_ratio` | 峰均比。1.0 = 完全均衡 |

## 取数点

patch `moe_layer.dispatch`，读 `token_dispatcher.get_dispatched_routing()[2]`。计数是 dispatcher 的**状态**，不在任何模块的 forward 返回值里，而且只有 a2a 完成后才有效 —— 挂 forward hook 拿不到。热路径上只有一次 `sum` 加一次 list append：**无 D2H、无 collective**。

## 微批的归约顺序是语义的一部分

峰值先在**微批内**跨卡取，之后才对微批求平均，即 `mean_微批( max_卡 )`，与 `log_moe_balance` 相同。先把各微批负载平均、再跨卡取 max 会得到 `max_卡( mean_微批 )`，由 `max` 的凸性它恒不大于前者，只有"每个微批里最热的都是同一张卡"时才相等 —— 12 层 EP=8 实测两者差到 8%。

把顺序做对**仍然只要每步两次 `all_reduce`**，而不是每微批两次：本地值先 stack 成一个 `[层数, 微批数]` 矩阵，逐微批的峰值由一次逐元素 MAX 一并得到。payload 从 `L` 个 float 变成 `L×M` 个，仍在 1 KB 以内。

对照 `log_moe_balance`：每层**每微批**一次 `all_gather_object` 外加一次 D2H（`tokens_per_expert.cpu()`，它自己的注释就写了那是同步点），43 层 × 16 微批 = 688 次各一。这也是它只能突发采样的原因（`trainer_utils.py:129-134` 的 `(step+1) % (interval*interval) < interval`，`interval=100` 时一万步里只开一百步）。每步两次小通信意味着这一族可以每步都开。

## 两种口径，同一组 key

归约完后同一 EP 组内每张卡持有相同的三个值，之后跨 rank 归约按 key 名再来一层：

- `card_tokens_max` → `all_reduce(MAX)`：max of maxes = **全局最热的那张卡**
- `card_tokens_mean` → `all_reduce(SUM)/count`：G 个组各 `ep_size` 张卡都上报组均值 `m_g`，`(Σ_g ep_size·m_g)/(G·ep_size) = (Σ_g m_g)/G` = **全局所有卡的均值**（各组等大时）
- `card_tokens_peak_mean_ratio` → `all_reduce(SUM)/count` = **各 EP 组峰均比的平均**

于是：

| 想问的问题 | 看哪个 |
|---|---|
| 全世界最热的卡比全局平均重几倍（木桶效应） | 自己算 `card_tokens_max / card_tokens_mean` |
| 平均而言每个 EP 组内部有多少不均衡（路由层面，与 DP 数据分布差异无关） | `card_tokens_peak_mean_ratio` |

两者的差就是 DP 维贡献的那部分不均衡。例：`PP=2, EP=4, DP=2`，某层两个 EP 组分别收到 `[1000,1000,1000,1000]` 和 `[4000,0,0,0]` → `max=4000`、`mean=1000`、`peak_mean_ratio=2.5`，手算 `max/mean=4.0`。

注意**两条上报曲线相除不等于第三条**：ratio 是逐微批比值的平均，只有当每微批的跨卡均值恒定（不丢 token 时成立）两者才重合。

## 正确性前提

同一 EP 组的各 rank 持有相同的层、跑相同数量的微批，所以矩阵形状在组内一致，集合通信不会错配。某层触发次数不同时按最短的那次截断，而不是改矩阵形状。EP 组取自 `moe_layer.moe_group`，与 PaddleFleet 用的是同一个。

## 验证

**单机 EP=8 端到端，同时开 `moe_logging` 与内科指标**（`conf/online/ernielite_layer43_pretrain_mla_hca_single.yaml`，12 个 MoE 层含 MTP、GA=16、跑 12 步，`internal_medicine_monitor_interval: 1`）：

三个指标与 `local_tokens_per_card_layer_{N}_{max,mean,max_mean_ratio}_cur_dp` 在 **108/108（step × layer）个样本上完全相等，相对偏差 0.000e+00**。

step 1 逐层：

```
       layer  IM peak_mean       moe_log       相对偏差
     layer_1    1.14729404    1.14729404  0.00e+00
     layer_2    1.22944260    1.22944260  0.00e+00
     layer_3    1.37463093    1.37463093  0.00e+00
     layer_4    1.28789806    1.28789806  0.00e+00
     layer_5    1.37411690    1.37411690  0.00e+00
     layer_6    1.38572407    1.38572407  0.00e+00
     layer_7    1.19937992    1.19937992  0.00e+00
     layer_8    1.33115959    1.33115959  0.00e+00
     layer_9    1.43306541    1.43306541  0.00e+00
    layer_10    1.34156036    1.34156036  0.00e+00
    layer_11    1.26558781    1.26558781  0.00e+00
 mtp_layer_0    1.19156075    1.19156075  0.00e+00
```

**单测** 10 个：归约顺序（不需要进程组即可 pin）、两条曲线相除不等于 ratio、三指标产出、微批取平均、patch 保持 dispatch 返回值、`remove_hooks` 还原、dispatcher 无法上报时不声明、`monitor_interval` 门控、max/min 命名契约、`card` 族可关。全量 311 passed，ruff 干净。
