### PR TITLE
feat(paddlefleet): monitor per-layer activation-gradient L2 norm

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,49 @@ CP 下 query 行是本 rank 的序列切片，而 indexer 的 K 已经 all-gathe
 
 ---
 
+## 十、Grad Health Monitor (grad_health)
+
+**仅 paddlefleet。** 前面的 monitor 看的都是前向量级，这一个看反向：每层、每个模块输出上的
+**激活梯度** `dL/d(activation)` 的 L2 范数。回答「梯度往回走的路上是被放大还是被吃掉」。
+
+三个位置（`position`），命名与 `massive_act` 的前向位置对齐，同层的前向幅度与反向幅度可以并排看：
+
+- `layer_out` —— decoder layer 的输出，也就是残差流本身。**深度方向梯度通路的主指标**
+- `attn_out` —— attention 分支输出
+- `ffn_or_moe_out` —— MLP / MoE 分支输出
+
+| # | 指标 | Key | 公式 | 粒度 | 含义 |
+|---|------|-----|------|------|------|
+| 1 | `{pos}_norm` | `grad_health/.../layer_out_norm` | `‖g‖₂` | 每层+全局 | L2 grad norm，跨 step 看趋势 |
+| 2 | `{pos}_rms` | `grad_health/.../layer_out_rms` | `‖g‖₂/√N` | 每层+全局 | 去掉形状依赖，**跨层可比**的那条 |
+| 3 | `{pos}_abs_max` | `grad_health/.../layer_out_abs_max` | `max\|g\|` | 每层+全局 | 尖峰探测，max 归约 |
+
+采集方式：`forward_post_hook` 只负责拿到输出张量并在其上 `register_hook`，所有归约都在反向里发生，
+前向路径的额外开销是每模块一次 `register_hook`。
+
+### 三个必须知道的口径
+
+**AMP loss scale。** 梯度 hook 看到的是**放大后**的激活梯度（量级 1e4，每次 overflow 都会变）。
+`finalize_scaled_grad_metrics` 在 `on_optimizer_begin` 把 scale 除回去 —— 那个时点 `scaler._scale`
+还是本 step 反向实际用的值。三个量对 `g` 都是一次齐次，所以一次除法同时修好 mean 与 max 累加器。
+非 AMP 或直接调用者由 `_flush_buffers` 兜底。
+
+**分片。** 热路径不做任何 collective（见 `.claude/skills/monitor-hook-perf-rules`），跨卡归约在 flush
+时统一做。TP/SP/CP 下每卡量的是自己那一片：`rms` 在等分片时是全局真值（每卡均方是全局均方的无偏
+估计），而 `norm` 是**每片**的范数 —— 全局范数的 `1/√片数`，趋势一致，但不是 optimizer 的 global
+grad-norm clip 报的那个数。
+
+**Recompute。** `_should_monitor()` 在 grad 关闭时为假，所以被丢弃的第一次前向不挂 hook，真正承载
+反向的重算前向才挂。
+
+### 尚未做的
+
+- 没有进 `METRIC_TAXONOMY`（与 `kda_health` 相同）：所有 key 落在 fail-open 的 `other` 族，即
+  「一直采集、不能按族关掉」。等真实 run 的 key corpus 进 fixture 后再补 family。
+- 只有 paddlefleet 后端。
+
+---
+
 ## 基础设施
 
 ### TrainingLogs
@@ -1132,3 +1175,6 @@ setup_monitors(model, monitors=[...], exclude_families=exclusions_for(debug_mode
 | **Optim** | `update_rms` | `sqrt(mean((θ_new−θ_old)²))` | 已全局归约 | 本 step 参数更新幅度 (始终装上, 受 monitor_interval 门控) |
 | **Optim** | `param_rms` | `sqrt(mean(θ_new²))` | 已全局归约 | 更新后参数尺度 (始终装上, 受 monitor_interval 门控) |
 | **Optim** | `update_param_ratio` | `update_rms / param_rms` | 已全局归约 | trust ratio, ~1e-3 健康 (始终装上, 受 monitor_interval 门控) |
+| **Grad** | `{pos}_norm` | `‖dL/d(activation)‖₂` | mean | 反向梯度量级; `pos`=layer_out/attn_out/ffn_or_moe_out |
+| **Grad** | `{pos}_rms` | `‖g‖₂/√N` | mean | 跨层可比的梯度量级 (等分片下为全局真值) |
+| **Grad** | `{pos}_abs_max` | `max\|g\|` | max | 梯度尖峰; bf16 梯度下分辨力受限 |

--- a/src/internal_medicine/backends/paddlefleet/__init__.py
+++ b/src/internal_medicine/backends/paddlefleet/__init__.py
@@ -8,6 +8,7 @@ from .attn_update_monitor import PaddleAttnUpdateMonitor, setup_attn_update_moni
 from .base import PaddleProbe
 from .dsa_monitor import PaddleDSAHealthMonitor, setup_dsa_monitor
 from .gather import install_gather_fn
+from .grad_monitor import PaddleGradHealthMonitor, setup_grad_monitor
 from .kda_monitor import PaddleKDAHealthMonitor, setup_kda_monitor
 from .massive_activation_monitor import PaddleMassiveActivationMonitor, setup_massive_activation_monitor
 from .mhc_monitor import PaddleMHCHealthMonitor, setup_mhc_monitor
@@ -29,6 +30,7 @@ _MONITOR_MAP = {
     "mlp_update": setup_mlp_update_monitor,
     "kda_health": setup_kda_monitor,
     "dsa_health": setup_dsa_monitor,
+    "grad_health": setup_grad_monitor,
 }
 
 _MODEL_MONITOR_ATTR = "_internal_medicine_paddlefleet_monitors"
@@ -159,4 +161,6 @@ __all__ = [
     "setup_kda_monitor",
     "PaddleDSAHealthMonitor",
     "setup_dsa_monitor",
+    "PaddleGradHealthMonitor",
+    "setup_grad_monitor",
 ]

--- a/src/internal_medicine/backends/paddlefleet/grad_metrics.py
+++ b/src/internal_medicine/backends/paddlefleet/grad_metrics.py
@@ -1,0 +1,61 @@
+"""Activation-gradient magnitude metrics for PaddleFleet.
+
+Pure tensor functions, no monitor state. Everything returns a 0-dim GPU tensor so
+the caller hands it straight to ``record_layer_metric`` without a D2H sync --
+hot-path discipline: see ``.claude/skills/monitor-hook-perf-rules``.
+
+The quantity being measured is dL/d(activation) at a module's *output*, i.e. the
+gradient that flows back into that module. This is the backward-path counterpart
+of ``massive_act``'s forward-path magnitudes, and the positions are named to
+match so a gradient curve and its activation curve line up in the viewer.
+"""
+
+from __future__ import annotations
+
+import math
+
+import paddle
+
+# Where on the backward path a gradient is read. ``layer_out`` is the residual
+# stream leaving a decoder layer -- the series that answers "does the gradient
+# survive depth"; the other two attribute a layer's share to its two branches.
+POSITIONS = ("attn_out", "ffn_or_moe_out", "layer_out")
+
+METRICS = ("norm", "rms", "abs_max")
+
+# ``abs_max`` is a max over microbatches / ranks / layers, the rest are means.
+MAX_METRICS = ("abs_max",)
+
+ALL_METRICS = tuple(f"{position}_{metric}" for position in POSITIONS for metric in METRICS)
+
+MAX_AGGREGATED = frozenset(f"{position}_{metric}" for position in POSITIONS for metric in MAX_METRICS)
+
+
+def grad_magnitude_stats(grad: paddle.Tensor) -> dict[str, paddle.Tensor]:
+    """``norm`` / ``rms`` / ``abs_max`` of one activation gradient.
+
+    All three are homogeneous of degree 1 in ``grad``. That is what lets a single
+    division by the AMP loss scale de-scale the whole set at finalize time, for
+    both the mean accumulators (a sum over microbatches) and the max ones.
+
+    - ``norm`` -- the L2 norm the caller asked for, over *this rank's shard*.
+      Shape-dependent, so read it across steps, not across layers.
+    - ``rms`` -- ``norm / sqrt(N)``. Shard- and shape-invariant under equal
+      sharding (each rank's mean square is an unbiased estimate of the global
+      one), so this is the series that is comparable across layers and across
+      parallel layouts.
+    - ``abs_max`` -- ``max|g|``, the spike detector. Max-aggregated, so one
+      outlier microbatch or rank still reaches the global key.
+
+    Two reductions, not three: ``N`` comes from ``shape``, which is Python
+    metadata in dygraph, so ``norm`` is a scale of ``rms`` rather than a second
+    sum over the tensor.
+    """
+    value = grad.detach().astype("float32")
+    rms = paddle.sqrt(value.square().mean())
+    sqrt_numel = math.sqrt(max(1, math.prod(value.shape)))
+    return {
+        "norm": rms * sqrt_numel,
+        "rms": rms,
+        "abs_max": value.abs().max(),
+    }

--- a/src/internal_medicine/backends/paddlefleet/grad_monitor.py
+++ b/src/internal_medicine/backends/paddlefleet/grad_monitor.py
@@ -1,0 +1,267 @@
+"""Activation-gradient health monitor for PaddleFleet.
+
+Answers "where does the gradient grow or die on the way back" with one L2 norm
+per module output per layer. Three positions per layer -- the attention branch
+output, the MLP/MoE branch output, and the decoder layer output (the residual
+stream itself) -- times the three magnitudes in ``grad_metrics``.
+
+Collection is a ``forward_post_hook`` that registers a tensor gradient hook on
+the module's output. The forward hook measures nothing itself: it exists only to
+get hold of the tensor whose gradient is wanted, so the forward path pays one
+``register_hook`` per module and the reductions all happen during backward.
+
+**AMP.** A gradient hook sees the *loss-scaled* activation gradient, so the raw
+numbers are the scale (order 1e4, and it moves on every overflow) times the
+quantity of interest. ``finalize_scaled_grad_metrics`` divides the scale back out
+once per step from ``on_optimizer_begin`` -- before ``optimizer.step()``, while
+``scaler._scale`` still holds the value this step's backward actually used.
+Without that step the curves would jump by 2x every time the scaler halves.
+
+**Sharding.** No collective runs here (hot-path discipline: see
+``.claude/skills/monitor-hook-perf-rules``); the cross-rank reduction happens at
+flush time in ``gather.py``. Under TP / SP / CP each rank therefore measures its
+own shard: ``rms`` is the true global value when shards are equal-sized, while
+``norm`` is the per-shard norm -- a fixed ``1/sqrt(num_shards)`` of the global
+one, so it tracks the same trend but is not the number a global grad-norm clip
+would report.
+
+**Recompute.** ``_should_monitor`` is False while grad is disabled, so the
+discarded first forward of a recomputed block registers nothing and the replayed
+forward -- the one whose graph actually carries the backward -- is what gets
+hooked.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import paddle
+from paddle import nn
+
+from .base import PaddleProbe
+from .grad_metrics import MAX_AGGREGATED, METRICS, grad_magnitude_stats
+from .layer_discovery import get_decoder_layers, iter_monitor_layers
+
+logger = logging.getLogger(__name__)
+
+
+def _is_transformer_layer(layer) -> bool:
+    """Same predicate ``massive_act`` uses, so both monitors see one layer set."""
+    return hasattr(layer, "self_attn") or hasattr(layer, "self_attention") or hasattr(layer, "input_layernorm")
+
+
+def _output_tensor(outputs):
+    """First tensor of a PaddleFleet forward result, or ``None``."""
+    if isinstance(outputs, paddle.Tensor):
+        return outputs
+    if isinstance(outputs, dict):
+        return outputs.get("hidden_states")
+    if isinstance(outputs, (tuple, list)) and outputs:
+        return _output_tensor(outputs[0])
+    return None
+
+
+def _branch_modules(layer):
+    """``[(position, module)]`` for the branches this layer actually has.
+
+    Only positions that exist are returned, and the same list drives both the
+    schema and the hooks -- so a layer without an ``mlp`` never declares a key it
+    could not fill.
+    """
+    modules = []
+    attn = getattr(layer, "self_attn", None)
+    if attn is None:
+        attn = getattr(layer, "self_attention", None)
+    if attn is not None:
+        modules.append(("attn_out", attn))
+    ffn = getattr(layer, "mlp", None)
+    if ffn is None:
+        ffn = getattr(layer, "moe", None)
+    if ffn is not None:
+        modules.append(("ffn_or_moe_out", ffn))
+    # The layer itself is the residual stream leaving this block.
+    modules.append(("layer_out", layer))
+    return modules
+
+
+class PaddleGradHealthMonitor(PaddleProbe):
+    """L2 norm / RMS / abs-max of the activation gradient, per layer per module."""
+
+    METRIC_PREFIX = "grad_health"
+    MAX_AGGREGATED = set(MAX_AGGREGATED)
+    MIN_AGGREGATED: set[str] = set()
+
+    def __init__(
+        self,
+        log_per_layer: bool = True,
+        log_global: bool = True,
+        monitor_interval: int = 1,
+        verbose: bool = False,
+        sample_layers: list[int] | None = None,
+        exclude_families=None,
+    ):
+        super().__init__(
+            log_per_layer=log_per_layer,
+            log_global=log_global,
+            monitor_interval=monitor_interval,
+            verbose=verbose,
+            exclude_families=exclude_families,
+        )
+        self.sample_layers = set(sample_layers) if sample_layers else None
+        self._failed: set[tuple[int, str]] = set()
+        # AMP: latched so the scale is divided out exactly once per step, and so a
+        # step whose backward recorded nothing is left alone.
+        self._grad_metrics_finalized = False
+
+    # ------------------------------------------------------------------
+    # Setup: discover -> declare -> allocate -> attach
+    # ------------------------------------------------------------------
+
+    def _init_parallel_state(self) -> None:
+        try:
+            from paddlefleet.parallel_state import get_pipeline_model_parallel_rank
+
+            self.pp_rank = get_pipeline_model_parallel_rank()
+        except Exception:
+            pass
+
+    def _find_targets(self, model):
+        """``[(layer_idx, position, module, attn_type)]`` for every hooked module."""
+        layers = get_decoder_layers(model)
+        if not layers:
+            return []
+
+        monitor_layers = iter_monitor_layers(layers, _is_transformer_layer, pp_rank=self.pp_rank)
+        mtp_layer_ids = [item.idx for item in monitor_layers if item.is_mtp]
+        if mtp_layer_ids:
+            self.mark_mtp_layers(mtp_layer_ids)
+
+        targets = []
+        for item in monitor_layers:
+            if self.sample_layers and item.idx not in self.sample_layers:
+                continue
+            for position, module in _branch_modules(item.layer):
+                targets.append((item.idx, position, module, item.attn_type))
+        return targets
+
+    def register_hooks(self, model: nn.Layer):
+        self._init_parallel_state()
+        targets = self._find_targets(model)
+        if not targets:
+            logger.info("[PaddleGradMonitor] No transformer layers found; skipping.")
+            return
+
+        for layer_idx, position, _module, attn_type in targets:
+            for metric in METRICS:
+                self.declare_layer_metric(layer_idx, f"{position}_{metric}", attn_type=attn_type)
+
+        self.allocate_buffers()
+
+        for layer_idx, position, module, attn_type in targets:
+            self.hooks.append(module.register_forward_post_hook(self._make_output_hook(layer_idx, position, attn_type)))
+
+        layer_count = len({layer_idx for layer_idx, _p, _m, _a in targets})
+        logger.info(f"[PaddleGradMonitor] Registered {len(self.hooks)} hooks across {layer_count} layers.")
+
+    # ------------------------------------------------------------------
+    # Hooks (the hot path)
+    # ------------------------------------------------------------------
+
+    def _log_failure(self, layer_idx: int, position: str, exc: Exception) -> None:
+        if self.verbose and (layer_idx, position) not in self._failed:
+            logger.error(f"[PaddleGradMonitor] Error at layer {layer_idx}/{position}: {exc}")
+            self._failed.add((layer_idx, position))
+
+    def _make_output_hook(self, layer_idx: int, position: str, attn_type: str | None):
+        """Forward hook: attach a gradient hook to this module's output tensor.
+
+        ``stop_gradient`` outputs are skipped rather than guarded later: a tensor
+        outside the graph will never call the hook, so registering one would only
+        cost a closure per microbatch.
+        """
+
+        def hook_fn(module, _inputs, outputs):
+            if not module.training or not self._should_monitor():
+                return None
+            try:
+                tensor = _output_tensor(outputs)
+                if tensor is None or tensor.stop_gradient:
+                    return None
+                tensor.register_hook(self._make_grad_recorder(layer_idx, position, attn_type))
+            except Exception as exc:
+                self._log_failure(layer_idx, position, exc)
+            return None
+
+        return hook_fn
+
+    def _make_grad_recorder(self, layer_idx: int, position: str, attn_type: str | None):
+        """Gradient hook: reduce ``grad`` into the accumulators, return it unchanged."""
+
+        def record(grad):
+            try:
+                with paddle.no_grad():
+                    for metric, value in grad_magnitude_stats(grad).items():
+                        self.record_layer_metric(layer_idx, f"{position}_{metric}", value, attn_type=attn_type)
+                self._grad_metrics_finalized = False
+            except Exception as exc:
+                self._log_failure(layer_idx, position, exc)
+            return grad
+
+        return record
+
+    # ------------------------------------------------------------------
+    # AMP de-scaling (cold path, once per step)
+    # ------------------------------------------------------------------
+
+    def finalize_scaled_grad_metrics(self, scaler=None) -> None:
+        """Divide this step's AMP loss scale out of every accumulator.
+
+        Every metric this monitor owns is degree-1 homogeneous in the gradient, so
+        one division fixes all of them -- and it is valid on the raw accumulator
+        because both aggregations commute with a positive scale: ``sum(g_i)/S`` is
+        the mean of ``g_i/S``, and ``max(g_i)/S`` is the max of ``g_i/S``. The
+        scaler updates ``_scale`` in its own ``step``/``update``, i.e. once per
+        optimizer step, so every microbatch folded into these sums shared it.
+
+        Idempotent within a step: called from ``on_optimizer_begin`` when the
+        trainer provides a scaler, with ``_flush_buffers`` as the fallback read
+        point for direct users and non-AMP runs.
+        """
+        if self._grad_metrics_finalized:
+            return
+        scale = getattr(scaler, "_scale", None) if scaler is not None else None
+        if scale is not None:
+            scale = paddle.assign(scale).detach().astype("float32")
+            for key in self._mean_keys | self._max_keys:
+                if self._gpu_cnt.get(key, 0) > 0:
+                    self._gpu_acc[key].divide_(scale)
+        self._grad_metrics_finalized = True
+
+    def _flush_buffers(self) -> None:
+        self.finalize_scaled_grad_metrics()
+        super()._flush_buffers()
+        self._grad_metrics_finalized = False
+
+
+def setup_grad_monitor(
+    model,
+    log_per_layer: bool = True,
+    log_global: bool = True,
+    monitor_interval: int = 1,
+    verbose: bool = False,
+    sample_layers: list[int] | None = None,
+    monitor_dict: dict | None = None,
+    exclude_families=None,
+):
+    monitor = PaddleGradHealthMonitor(
+        log_per_layer=log_per_layer,
+        log_global=log_global,
+        monitor_interval=monitor_interval,
+        verbose=verbose,
+        sample_layers=sample_layers,
+        exclude_families=exclude_families,
+    )
+    monitor.register_hooks(model)
+    if monitor_dict is not None:
+        monitor_dict["grad_health"] = monitor
+    return model

--- a/src/internal_medicine/core/registry.py
+++ b/src/internal_medicine/core/registry.py
@@ -17,6 +17,7 @@ AVAILABLE_MONITORS = {
         "mlp_update",
         "kda_health",
         "dsa_health",
+        "grad_health",
     ],
 }
 

--- a/tests/test_paddlefleet_grad_health.py
+++ b/tests/test_paddlefleet_grad_health.py
@@ -1,0 +1,238 @@
+"""grad_health: gradient magnitude math, schema, AMP de-scaling, end-to-end.
+
+The monitor measures ``dL/d(activation)``, so every test here drives a real
+backward rather than calling a metric function on a synthetic "gradient" -- the
+part that can break is the hook wiring, not the arithmetic.
+"""
+
+import importlib
+import math
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+importlib.import_module("_backend_env").skip_unless_backend("paddlefleet")
+
+try:
+    paddle = importlib.import_module("paddle")
+    nn = importlib.import_module("paddle.nn")
+except Exception as exc:  # pragma: no cover - depends on optional backend install
+    raise unittest.SkipTest(f"paddle backend unavailable: {exc}") from exc
+
+grad_metrics = importlib.import_module("internal_medicine.backends.paddlefleet.grad_metrics")
+grad_monitor = importlib.import_module("internal_medicine.backends.paddlefleet.grad_monitor")
+training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
+
+PaddleGradHealthMonitor = grad_monitor.PaddleGradHealthMonitor
+
+WIDTH = 4
+
+
+class FakeBranch(nn.Layer):
+    """Deterministic stand-in for attention / MLP: a fixed scale of its input."""
+
+    def __init__(self, factor):
+        super().__init__()
+        self.factor = factor
+
+    def forward(self, x):
+        return x * self.factor
+
+
+class FakeLayer(nn.Layer):
+    """Two residual branches, both hooked, plus the layer output itself."""
+
+    def __init__(self, idx, attn_factor=0.5, mlp_factor=0.25):
+        super().__init__()
+        self.idx = idx
+        self.self_attn = FakeBranch(attn_factor)
+        self.mlp = FakeBranch(mlp_factor)
+
+    def forward(self, x):
+        x = x + self.self_attn(x)
+        return x + self.mlp(x)
+
+
+def _model(layers):
+    return SimpleNamespace(decoder=SimpleNamespace(layers=nn.LayerList(layers)))
+
+
+def _monitor(layers, **kwargs):
+    monitor = PaddleGradHealthMonitor(**kwargs)
+    monitor.register_hooks(_model(layers))
+    return monitor
+
+
+def _run_backward(layers, grad_seed):
+    """Forward the stack, then backprop ``grad_seed`` as ``dL/d(final output)``."""
+    x = paddle.ones([2, WIDTH], dtype="float32")
+    x.stop_gradient = False
+    out = x
+    for layer in layers:
+        out = layer(out)
+    (out * grad_seed).sum().backward()
+
+
+class GradMagnitudeMathTest(unittest.TestCase):
+    def test_norm_is_the_l2_norm(self):
+        grad = paddle.to_tensor([[3.0, 4.0], [0.0, 0.0]])
+        self.assertAlmostEqual(float(grad_metrics.grad_magnitude_stats(grad)["norm"]), 5.0, places=5)
+
+    def test_rms_is_the_norm_over_sqrt_numel(self):
+        stats = grad_metrics.grad_magnitude_stats(paddle.randn([3, 5, 7]))
+        self.assertAlmostEqual(float(stats["rms"]), float(stats["norm"]) / math.sqrt(3 * 5 * 7), places=4)
+
+    def test_abs_max_sees_a_negative_spike(self):
+        grad = paddle.to_tensor([[0.1, -9.0], [0.2, 0.3]])
+        self.assertAlmostEqual(float(grad_metrics.grad_magnitude_stats(grad)["abs_max"]), 9.0, places=5)
+
+    def test_every_hooked_position_is_a_declared_position(self):
+        """``_branch_modules`` and ``POSITIONS`` must not drift apart.
+
+        ``MAX_AGGREGATED`` is built from ``POSITIONS``, so a position the monitor
+        emits but that list does not carry would silently become a mean.
+        """
+        positions = [position for position, _module in grad_monitor._branch_modules(FakeLayer(0))]
+        self.assertEqual(positions, list(grad_metrics.POSITIONS))
+
+
+class GradMonitorSchemaTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def test_schema_covers_every_position_times_every_metric(self):
+        monitor = _monitor([FakeLayer(0), FakeLayer(1)], log_global=False)
+        expected = {
+            f"grad_health/layer_{idx}/{position}_{metric}"
+            for idx in (0, 1)
+            for position in grad_metrics.POSITIONS
+            for metric in grad_metrics.METRICS
+        }
+        self.assertEqual(monitor._mean_keys | monitor._max_keys, expected)
+        self.assertEqual(len(monitor.hooks), 6)  # 3 positions x 2 layers
+
+    def test_only_abs_max_is_max_aggregated(self):
+        monitor = _monitor([FakeLayer(0)], log_global=False)
+        self.assertEqual(
+            monitor._max_keys,
+            {f"grad_health/layer_0/{position}_abs_max" for position in grad_metrics.POSITIONS},
+        )
+
+    def test_sample_layers_restricts_both_schema_and_hooks(self):
+        monitor = _monitor([FakeLayer(0), FakeLayer(1)], log_global=False, sample_layers=[1])
+        self.assertEqual(len(monitor.hooks), 3)
+        self.assertTrue(all("/layer_1/" in key for key in monitor._mean_keys | monitor._max_keys))
+
+    def test_a_model_without_layers_registers_nothing(self):
+        monitor = PaddleGradHealthMonitor()
+        monitor.register_hooks(SimpleNamespace())
+        self.assertEqual(monitor.hooks, [])
+
+
+class GradMonitorAmpTest(unittest.TestCase):
+    """The loss scale must not reach the curves; see ``finalize_scaled_grad_metrics``."""
+
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def _norm_after(self, finalize_calls, scale=8.0):
+        layers = [FakeLayer(0)]
+        monitor = _monitor(layers, log_global=False)
+        _run_backward(layers, paddle.full([2, WIDTH], 2.0))
+        for _ in range(finalize_calls):
+            monitor.finalize_scaled_grad_metrics(SimpleNamespace(_scale=paddle.to_tensor(scale)))
+        monitor.step()
+        return training_logs.get_latest(prefix="grad_health")["grad_health/layer_0/layer_out_norm"]
+
+    def test_the_loss_scale_is_divided_out(self):
+        expected = float(paddle.linalg.norm(paddle.full([2, WIDTH], 2.0))) / 8.0
+        self.assertAlmostEqual(self._norm_after(1), expected, places=4)
+
+    def test_finalizing_twice_in_one_step_divides_once(self):
+        """``on_optimizer_begin`` and the ``_flush_buffers`` fallback both fire."""
+        expected = float(paddle.linalg.norm(paddle.full([2, WIDTH], 2.0))) / 8.0
+        self.assertAlmostEqual(self._norm_after(2), expected, places=4)
+
+    def test_a_run_without_a_scaler_is_left_alone(self):
+        layers = [FakeLayer(0)]
+        monitor = _monitor(layers, log_global=False)
+        seed = paddle.full([2, WIDTH], 2.0)
+        _run_backward(layers, seed)
+        monitor.finalize_scaled_grad_metrics(None)
+        monitor.step()
+        latest = training_logs.get_latest(prefix="grad_health")
+        self.assertAlmostEqual(latest["grad_health/layer_0/layer_out_norm"], float(paddle.linalg.norm(seed)), places=4)
+
+    def test_the_next_step_is_de_scaled_again(self):
+        """The latch has to reset at flush, or step 2 keeps the raw scaled value."""
+        layers = [FakeLayer(0)]
+        monitor = _monitor(layers, log_global=False)
+        seed = paddle.full([2, WIDTH], 2.0)
+        for _ in range(2):
+            _run_backward(layers, seed)
+            monitor.finalize_scaled_grad_metrics(SimpleNamespace(_scale=paddle.to_tensor(8.0)))
+            monitor.step()
+        latest = training_logs.get_latest(prefix="grad_health")
+        self.assertAlmostEqual(
+            latest["grad_health/layer_0/layer_out_norm"], float(paddle.linalg.norm(seed)) / 8.0, places=4
+        )
+
+
+class GradMonitorEndToEndTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def test_layer_out_norm_is_the_norm_of_the_incoming_gradient(self):
+        """The last layer's output gradient is exactly the seed, so this is exact."""
+        layers = [FakeLayer(0)]
+        monitor = _monitor(layers, log_global=False)
+        seed = paddle.to_tensor([[1.0, 2.0, 3.0, 4.0], [0.0, 0.0, 0.0, 0.0]])
+        _run_backward(layers, seed)
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="grad_health")
+        expected = float(paddle.linalg.norm(seed))
+        self.assertAlmostEqual(latest["grad_health/layer_0/layer_out_norm"], expected, places=4)
+        self.assertAlmostEqual(latest["grad_health/layer_0/layer_out_rms"], expected / math.sqrt(2 * WIDTH), places=4)
+        self.assertAlmostEqual(latest["grad_health/layer_0/layer_out_abs_max"], 4.0, places=4)
+
+    def test_every_position_of_every_layer_reports(self):
+        layers = [FakeLayer(0), FakeLayer(1)]
+        monitor = _monitor(layers, log_global=False)
+        _run_backward(layers, paddle.ones([2, WIDTH]))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="grad_health")
+        for idx in (0, 1):
+            for position in grad_metrics.POSITIONS:
+                for metric in grad_metrics.METRICS:
+                    key = f"grad_health/layer_{idx}/{position}_{metric}"
+                    self.assertIn(key, latest)
+                    self.assertGreater(latest[key], 0.0)
+
+    def test_the_gradient_grows_towards_the_input_of_a_residual_stack(self):
+        """Each block multiplies the backward signal by (1+attn)(1+mlp) > 1.
+
+        Not a property of the monitor, but it is the property these curves exist
+        to show, and it pins the layer-to-layer direction of what gets recorded.
+        """
+        layers = [FakeLayer(0), FakeLayer(1)]
+        monitor = _monitor(layers, log_global=False)
+        _run_backward(layers, paddle.ones([2, WIDTH]))
+        monitor.step()
+
+        latest = training_logs.get_latest(prefix="grad_health")
+        self.assertGreater(latest["grad_health/layer_0/layer_out_norm"], latest["grad_health/layer_1/layer_out_norm"])

--- a/tests/test_paddlefleet_grad_health_amp.py
+++ b/tests/test_paddlefleet_grad_health_amp.py
@@ -1,0 +1,73 @@
+"""grad_health under AMP: the loss scale must not reach the curves.
+
+Split from ``test_paddlefleet_grad_health`` (whose fixtures this reuses) because
+these cases are about the step lifecycle rather than a metric's value: a gradient
+hook sees the *scaled* gradient, and ``finalize_scaled_grad_metrics`` is the only
+thing standing between that and the logged number.
+"""
+
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+importlib.import_module("_backend_env").skip_unless_backend("paddlefleet")
+
+try:
+    paddle = importlib.import_module("paddle")
+except Exception as exc:  # pragma: no cover - depends on optional backend install
+    raise unittest.SkipTest(f"paddle backend unavailable: {exc}") from exc
+
+_fixtures = importlib.import_module("test_paddlefleet_grad_health")
+training_logs = importlib.import_module("internal_medicine.core.training_logs").training_logs
+
+FakeLayer = _fixtures.FakeLayer
+WIDTH = _fixtures.WIDTH
+SCALE = 8.0
+
+
+class GradHealthAmpTest(unittest.TestCase):
+    def setUp(self):
+        training_logs.reset()
+
+    def tearDown(self):
+        training_logs.reset()
+
+    def _run(self, finalize_calls, steps=1):
+        """Drive ``steps`` full steps, finalizing ``finalize_calls`` times in each."""
+        layers = [FakeLayer(0)]
+        monitor = _fixtures._monitor(layers, log_global=False)
+        seed = paddle.full([2, WIDTH], 2.0)
+        for _ in range(steps):
+            _fixtures._run_backward(layers, seed)
+            for _ in range(finalize_calls):
+                # Minimal GradScaler stand-in: only ``_scale`` is ever read.
+                monitor.finalize_scaled_grad_metrics(SimpleNamespace(_scale=paddle.to_tensor(SCALE)))
+            monitor.step()
+        return training_logs.get_latest(prefix="grad_health")["grad_health/layer_0/layer_out_norm"]
+
+    def _raw_norm(self):
+        return float(paddle.linalg.norm(paddle.full([2, WIDTH], 2.0)))
+
+    def test_the_loss_scale_is_divided_out(self):
+        self.assertAlmostEqual(self._run(1), self._raw_norm() / SCALE, places=4)
+
+    def test_finalizing_twice_in_one_step_divides_once(self):
+        """``on_optimizer_begin`` and the ``_flush_buffers`` fallback both fire."""
+        self.assertAlmostEqual(self._run(2), self._raw_norm() / SCALE, places=4)
+
+    def test_the_next_step_is_de_scaled_again(self):
+        """The latch has to reset at flush, or step 2 keeps the raw scaled value."""
+        self.assertAlmostEqual(self._run(1, steps=2), self._raw_norm() / SCALE, places=4)
+
+    def test_a_run_without_a_scaler_is_left_alone(self):
+        """Non-AMP runs and direct users must not have their values touched."""
+        self.assertAlmostEqual(self._run(0), self._raw_norm(), places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 做了什么

新增 `grad_health` monitor（仅 paddlefleet）。现有 monitor 读的都是前向量级，这个读反向：每层各模块输出上 `dL/d(activation)` 的 L2 范数——直接回答「梯度能不能穿过深度」，而不是从前向量级去反推。

每层三个位置（命名与 `massive_act` 的前向位置对齐，便于同层前/反向曲线并排看）：

- `layer_out` —— 残差流本身，深度方向梯度通路的主指标
- `attn_out` —— attention 分支输出
- `ffn_or_moe_out` —— MLP / MoE 分支输出

每个位置三个量：

- `norm` —— 本 rank 分片上的 `‖g‖₂`
- `rms` —— `norm/√N`，与形状和分片无关，跨层可比
- `abs_max` —— `max|g|`，max 归约，单个异常微批/rank 也能保留到 global

采集是 `forward_post_hook` 只负责在模块输出张量上挂一个梯度 hook，所有归约发生在反向里；前向路径的开销是每模块一次 `register_hook`。

## 三个容易踩错的口径

**AMP。** 梯度 hook 看到的是放大后的梯度，且 scaler 每次 overflow 都会把 scale 折半，所以原始序列跨 scale 变化后不可读。`finalize_scaled_grad_metrics` 在 `on_optimizer_begin` 把 scale 除回去——那个时点 `scaler._scale` 还是本 step 反向实际用的值。三个量对 `g` 都是一次齐次，所以一次除法同时修好 mean 和 max 累加器（`sum(g_i)/S` 是 `g_i/S` 的均值，`max(g_i)/S` 是 `g_i/S` 的最大值）。非 AMP 与直接调用者由 `_flush_buffers` 兜底。PaddleFormers 的 `InternalMedicineCallback.on_optimizer_begin` 已有通用挂载点，训练侧不需要改代码。

**分片。** 热路径不做任何 collective（见 `monitor-hook-perf-rules`），跨卡归约留在 flush 时。TP/SP/CP 下每卡量自己那一片：等分片时 `rms` 是全局真值（每卡均方是全局均方的无偏估计），而 `norm` 是每片的范数，即全局范数的 `1/√片数`——趋势一致，但不是 optimizer global grad-norm clip 报的那个数。

**Recompute。** `_should_monitor()` 在 grad 关闭时为假，所以被丢弃的第一次前向不挂 hook，真正承载反向的重算前向才挂。

## 测试

`tests/test_paddlefleet_grad_health.py`（15 例）+ `tests/test_paddlefleet_grad_health_amp.py`（4 例）：

- 范数与手算梯度精确相符：单层栈上 `layer_out_norm` = `‖seed‖`，`rms` = `norm/√N`
- 残差栈上 layer_0 的范数 = layer_1 × (1+attn)(1+mlp)，梯度方向正确
- global 从各层派生（norm 取均值、abs_max 取最大）
- 微批 mean/max 语义、`sample_layers` 过滤、空模型 no-op
- 纯前向和 `no_grad` 前向都不产指标（recompute 守卫）
- AMP：scale 被除回、同 step 内幂等、跨 step 重新生效、无 scaler 时不动值

`pre-commit run --all-files` 全绿；`test_core_monitoring.py` + `test_paddlefleet_monitors.py` 194 passed。

## 真实作业上的自检

在一个 19 层 + MoE 的预训练作业上跑通并核对了 `internal_medicine.jsonl`：

- key 数量精确对上：189 = 19 层 × 9 + 18 global（按 attention 类型分标签，两类各一套）
- 覆盖的层集与 `massive_act` / `qk_stats` 完全一致，无漏层、无漏位置
- `norm / rms` 在每层恰好等于 `√numel`，说明两个量来自同一次归约
- 无 NaN / Inf
- 量级符合已除掉 loss scale 的预期

## 已知缺口

- 未进 `METRIC_TAXONOMY`（与 `kda_health` 相同）：key 落在 fail-open 的 `other` 族，即一直采集、不能按族关掉。等真实 run 的 key corpus 进 `tests/fixtures/metric_key_corpus.txt` 后再补 family（现有测试会断言「每个声明的 family 必须被 corpus 命中」且 corpus 恰好 7 个 monitor，所以两者要一起改）。
- 只有 paddlefleet 后端，megatron 侧未动。
- 未做多卡实盘的分片口径验证，也未做 perf 预算实测（`monitor-hook-perf-rules` 要求单 monitor < 5% step time）。
- bf16 梯度下 `abs_max` 的逐层分辨力受量化限制（相邻层的差异可能落在 bf16 分辨率以下），只适合当粗警报；有分辨力的是 `norm` / `rms`（fp32 归约）。
